### PR TITLE
Add new attribute to credential auth executor

### DIFF
--- a/backend/internal/flow/core/ExecutorBackedNodeInterface_mock_test.go
+++ b/backend/internal/flow/core/ExecutorBackedNodeInterface_mock_test.go
@@ -408,6 +408,52 @@ func (_c *ExecutorBackedNodeInterfaceMock_GetID_Call) RunAndReturn(run func() st
 	return _c
 }
 
+// GetIdentifierInputs provides a mock function for the type ExecutorBackedNodeInterfaceMock
+func (_mock *ExecutorBackedNodeInterfaceMock) GetIdentifierInputs() []providers.Input {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentifierInputs")
+	}
+
+	var r0 []providers.Input
+	if returnFunc, ok := ret.Get(0).(func() []providers.Input); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]providers.Input)
+		}
+	}
+	return r0
+}
+
+// ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentifierInputs'
+type ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call struct {
+	*mock.Call
+}
+
+// GetIdentifierInputs is a helper method to define mock.On call
+func (_e *ExecutorBackedNodeInterfaceMock_Expecter) GetIdentifierInputs() *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call {
+	return &ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call{Call: _e.mock.On("GetIdentifierInputs")}
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call) Run(run func()) *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call) Return(inputs []providers.Input) *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call {
+	_c.Call.Return(inputs)
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call) RunAndReturn(run func() []providers.Input) *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetInputs provides a mock function for the type ExecutorBackedNodeInterfaceMock
 func (_mock *ExecutorBackedNodeInterfaceMock) GetInputs() []providers.Input {
 	ret := _mock.Called()
@@ -1162,6 +1208,46 @@ func (_c *ExecutorBackedNodeInterfaceMock_SetExecutorName_Call) Return() *Execut
 }
 
 func (_c *ExecutorBackedNodeInterfaceMock_SetExecutorName_Call) RunAndReturn(run func(name string)) *ExecutorBackedNodeInterfaceMock_SetExecutorName_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetIdentifierInputs provides a mock function for the type ExecutorBackedNodeInterfaceMock
+func (_mock *ExecutorBackedNodeInterfaceMock) SetIdentifierInputs(inputs []providers.Input) {
+	_mock.Called(inputs)
+	return
+}
+
+// ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetIdentifierInputs'
+type ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call struct {
+	*mock.Call
+}
+
+// SetIdentifierInputs is a helper method to define mock.On call
+//   - inputs []providers.Input
+func (_e *ExecutorBackedNodeInterfaceMock_Expecter) SetIdentifierInputs(inputs interface{}) *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call {
+	return &ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call{Call: _e.mock.On("SetIdentifierInputs", inputs)}
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call) Run(run func(inputs []providers.Input)) *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []providers.Input
+		if args[0] != nil {
+			arg0 = args[0].([]providers.Input)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call) Return() *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call) RunAndReturn(run func(inputs []providers.Input)) *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/internal/flow/core/factory.go
+++ b/backend/internal/flow/core/factory.go
@@ -151,6 +151,8 @@ func (f *flowFactory) CloneNode(source NodeInterface) (NodeInterface, error) {
 		if executableCopy, ok := nodeCopy.(ExecutorBackedNodeInterface); ok {
 			executableCopy.SetExecutorName(executableSource.GetExecutorName())
 			executableCopy.SetInputs(append([]providers.Input{}, executableSource.GetInputs()...))
+			executableCopy.SetIdentifierInputs(
+				append([]providers.Input{}, executableSource.GetIdentifierInputs()...))
 			executableCopy.SetOnSuccess(executableSource.GetOnSuccess())
 			executableCopy.SetOnFailure(executableSource.GetOnFailure())
 			executableCopy.SetOnIncomplete(executableSource.GetOnIncomplete())

--- a/backend/internal/flow/core/factory_test.go
+++ b/backend/internal/flow/core/factory_test.go
@@ -483,6 +483,12 @@ func (f *fakeExecutorBackedNode) GetInputs() []providers.Input {
 
 func (f *fakeExecutorBackedNode) SetInputs(inputs []providers.Input) {}
 
+func (f *fakeExecutorBackedNode) GetIdentifierInputs() []providers.Input {
+	return nil
+}
+
+func (f *fakeExecutorBackedNode) SetIdentifierInputs(inputs []providers.Input) {}
+
 func (f *fakeExecutorBackedNode) GetCondition() *NodeCondition {
 	return nil
 }

--- a/backend/internal/flow/core/graph.go
+++ b/backend/internal/flow/core/graph.go
@@ -269,6 +269,7 @@ func (g *graph) ToJSON() (string, error) {
 		NextNodeIDList     []string       `json:"nextNodeIds"`
 		PreviousNodeIDList []string       `json:"previousNodeIds"`
 		Inputs             []JSONInputs   `json:"inputs,omitempty"`
+		IdentifierInputs   []JSONInputs   `json:"identifierInputs,omitempty"`
 		Executor           string         `json:"executor,omitempty"`
 		Condition          *JSONCondition `json:"condition,omitempty"`
 	}
@@ -278,6 +279,24 @@ func (g *graph) ToJSON() (string, error) {
 		Nodes       map[string]JSONNode `json:"nodes"`
 		Edges       map[string][]string `json:"edges"`
 		StartNodeID string              `json:"startNodeId"`
+	}
+
+	toJSONInputs := func(inputs []providers.Input) []JSONInputs {
+		if len(inputs) == 0 {
+			return nil
+		}
+		converted := make([]JSONInputs, len(inputs))
+		for i, input := range inputs {
+			converted[i] = JSONInputs{
+				Ref:        input.Ref,
+				Identifier: input.Identifier,
+				Type:       input.Type,
+				Required:   input.Required,
+				OneTimeUse: input.OneTimeUse,
+				Options:    input.Options,
+			}
+		}
+		return converted
 	}
 
 	jsonGraph := JSONGraph{
@@ -305,20 +324,8 @@ func (g *graph) ToJSON() (string, error) {
 				jsonNode.Executor = executorName
 			}
 
-			inputs := executableNode.GetInputs()
-			if len(inputs) > 0 {
-				jsonNode.Inputs = make([]JSONInputs, len(inputs))
-				for i, input := range inputs {
-					jsonNode.Inputs[i] = JSONInputs{
-						Ref:        input.Ref,
-						Identifier: input.Identifier,
-						Type:       input.Type,
-						Required:   input.Required,
-						OneTimeUse: input.OneTimeUse,
-						Options:    input.Options,
-					}
-				}
-			}
+			jsonNode.Inputs = toJSONInputs(executableNode.GetInputs())
+			jsonNode.IdentifierInputs = toJSONInputs(executableNode.GetIdentifierInputs())
 		}
 
 		// Set condition if present

--- a/backend/internal/flow/core/task_execution_node.go
+++ b/backend/internal/flow/core/task_execution_node.go
@@ -24,6 +24,8 @@ type ExecutorBackedNodeInterface interface {
 	SetExecutor(executor providers.Executor)
 	GetInputs() []providers.Input
 	SetInputs(inputs []providers.Input)
+	GetIdentifierInputs() []providers.Input
+	SetIdentifierInputs(inputs []providers.Input)
 	GetOnSuccess() string
 	SetOnSuccess(nodeID string)
 	GetOnFailure() string
@@ -37,14 +39,15 @@ type ExecutorBackedNodeInterface interface {
 // taskExecutionNode represents a node that executes a task via an executor
 type taskExecutionNode struct {
 	*node
-	executorName string
-	executor     providers.Executor
-	mode         string
-	inputs       []providers.Input
-	onSuccess    string
-	onFailure    string
-	onIncomplete string
-	logger       *log.Logger
+	executorName     string
+	executor         providers.Executor
+	mode             string
+	inputs           []providers.Input
+	identifierInputs []providers.Input
+	onSuccess        string
+	onFailure        string
+	onIncomplete     string
+	logger           *log.Logger
 }
 
 // Ensure taskExecutionNode implements ExecutorBackedNodeInterface
@@ -88,8 +91,9 @@ func (n *taskExecutionNode) Execute(ctx *providers.NodeContext) (*common.NodeRes
 		ctx.NodeProperties = make(map[string]interface{})
 	}
 
-	// Set executor mode in context
+	// Set executor mode and identifier inputs in context
 	ctx.ExecutorMode = n.mode
+	ctx.NodeIdentifierInputs = n.identifierInputs
 
 	n.enrichRuntimeData(ctx)
 
@@ -117,10 +121,7 @@ func (n *taskExecutionNode) Execute(ctx *providers.NodeContext) (*common.NodeRes
 			}
 		}
 
-		// Clear user inputs consumed by this executor
-		for _, input := range n.inputs {
-			delete(ctx.UserInputs, input.Identifier)
-		}
+		n.clearConsumedInputs(ctx)
 	} else if nodeResp.Status == common.NodeStatusIncomplete && n.onIncomplete != "" {
 		// Executor requires user input - forward to dedicated prompt node
 		// Change status to Forward so engine forwards execution to onIncomplete node
@@ -136,10 +137,7 @@ func (n *taskExecutionNode) Execute(ctx *providers.NodeContext) (*common.NodeRes
 				nodeResp.RuntimeData["failureReasonJSON"] = string(jsonBytes)
 			}
 
-			// Clear user inputs consumed by this executor
-			for _, input := range n.inputs {
-				delete(ctx.UserInputs, input.Identifier)
-			}
+			n.clearConsumedInputs(ctx)
 		}
 	} else if nodeResp.Status == common.NodeStatusIncomplete && nodeResp.Type == common.NodeResponseTypeView &&
 		len(nodeResp.Inputs) == 0 {
@@ -150,6 +148,17 @@ func (n *taskExecutionNode) Execute(ctx *providers.NodeContext) (*common.NodeRes
 	}
 
 	return nodeResp, nil
+}
+
+// clearConsumedInputs removes the user inputs this node declared, so the prompt it forwards to
+// re-asks for them. Identifier inputs are cleared alongside the regular ones: leaving one behind
+// would let a second identifier accumulate on a later attempt, which the executor cannot resolve.
+func (n *taskExecutionNode) clearConsumedInputs(ctx *providers.NodeContext) {
+	for _, inputs := range [][]providers.Input{n.inputs, n.identifierInputs} {
+		for _, input := range inputs {
+			delete(ctx.UserInputs, input.Identifier)
+		}
+	}
 }
 
 // enrichRuntimeData initializes the runtime data map and attaches identifiers like application, IDP,
@@ -322,4 +331,14 @@ func (n *taskExecutionNode) GetInputs() []providers.Input {
 // SetInputs sets the inputs required for the task execution node
 func (n *taskExecutionNode) SetInputs(inputs []providers.Input) {
 	n.inputs = inputs
+}
+
+// GetIdentifierInputs returns the node's mutually exclusive identifier inputs
+func (n *taskExecutionNode) GetIdentifierInputs() []providers.Input {
+	return n.identifierInputs
+}
+
+// SetIdentifierInputs sets the node's mutually exclusive identifier inputs
+func (n *taskExecutionNode) SetIdentifierInputs(inputs []providers.Input) {
+	n.identifierInputs = inputs
 }

--- a/backend/internal/flow/core/task_execution_node_test.go
+++ b/backend/internal/flow/core/task_execution_node_test.go
@@ -58,6 +58,57 @@ func (s *TaskExecutionNodeTestSuite) TestExecutorMethods() {
 	s.Equal("mock-executor", execNode.GetExecutorName())
 }
 
+func (s *TaskExecutionNodeTestSuite) TestExecuteClearsIdentifierInputsOnIncomplete() {
+	node := newTaskExecutionNode("task-1", nil, false, false)
+	execNode, ok := node.(ExecutorBackedNodeInterface)
+	s.True(ok)
+	execNode.SetInputs([]providers.Input{{Identifier: "password", Type: providers.InputTypePassword}})
+	execNode.SetIdentifierInputs([]providers.Input{{Identifier: "uin", Type: providers.InputTypeText}})
+	execNode.SetOnIncomplete("prompt-1")
+
+	s.mockExecutor.On("GetName").Return("test-executor").Once()
+	s.mockExecutor.On("Execute", mock.Anything).Return(
+		&providers.ExecutorResponse{
+			Status: providers.ExecUserInputRequired,
+			Error:  &tidcommon.ServiceError{Code: "ERR-1"},
+		}, nil).Once()
+	execNode.SetExecutor(s.mockExecutor)
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-1",
+		UserInputs:  map[string]string{"uin": "4358192047", "password": "secret"},
+	}
+	_, svcErr := node.Execute(ctx)
+	s.Nil(svcErr)
+
+	// Both lists are cleared: a surviving identifier would collide with the next attempt's.
+	s.Empty(ctx.UserInputs)
+}
+
+func (s *TaskExecutionNodeTestSuite) TestExecuteExposesIdentifierInputs() {
+	identifierInputs := []providers.Input{
+		{Identifier: "uin", Type: providers.InputTypeText},
+		{Identifier: "phone", Type: providers.InputTypeText},
+	}
+
+	node := newTaskExecutionNode("task-1", nil, false, false)
+	execNode, ok := node.(ExecutorBackedNodeInterface)
+	s.True(ok)
+	execNode.SetIdentifierInputs(identifierInputs)
+
+	s.mockExecutor.On("GetName").Return("test-executor").Once()
+	s.mockExecutor.On("Execute", mock.Anything).Return(
+		&providers.ExecutorResponse{Status: providers.ExecComplete}, nil).Once().
+		Run(func(args mock.Arguments) {
+			s.Equal(identifierInputs, args.Get(0).(*providers.NodeContext).NodeIdentifierInputs)
+		})
+	execNode.SetExecutor(s.mockExecutor)
+
+	_, svcErr := node.Execute(&providers.NodeContext{ExecutionID: "flow-1"})
+	s.Nil(svcErr)
+	s.mockExecutor.AssertExpectations(s.T())
+}
+
 func (s *TaskExecutionNodeTestSuite) TestExecuteNoExecutor() {
 	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
 	ctx := &providers.NodeContext{ExecutionID: "test-flow"}

--- a/backend/internal/flow/executor/credentials_auth_executor.go
+++ b/backend/internal/flow/executor/credentials_auth_executor.go
@@ -76,9 +76,11 @@ func (b *credentialsAuthExecutor) Execute(ctx *providers.NodeContext) (*provider
 		AuthUser:       ctx.AuthUser,
 	}
 
-	// When a userID is pre-resolved (e.g., by an IdentifyingExecutor in resolve mode),
-	// only credential inputs are required — skip the identifier input check.
+	// When a userID is pre-resolved, only credential inputs are required -
+	// identifier resolution and its ambiguity validation are skipped entirely.
 	hasPreResolvedUser := ctx.RuntimeData[userAttributeUserID] != ""
+
+	var identifierInput *providers.Input
 	if hasPreResolvedUser {
 		credentialInputs := b.getCredentialInputs(ctx)
 		hasMissingCredentials := false
@@ -93,16 +95,33 @@ func (b *credentialsAuthExecutor) Execute(ctx *providers.NodeContext) (*provider
 			execResp.Inputs = credentialInputs
 			return execResp, nil
 		}
-	} else if !b.HasRequiredInputs(ctx, execResp) {
-		logger.Debug(ctx.Context, "Required inputs for credentials authentication executor is not provided")
-		execResp.Status = providers.ExecUserInputRequired
-		return execResp, nil
+	} else {
+		// A node may declare mutually exclusive identifier inputs; exactly one must be supplied.
+		resolvedInput, identifierMatches := resolveIdentifierInput(ctx)
+		if identifierMatches > 1 {
+			logger.Debug(ctx.Context, "More than one identifier input provided")
+			execResp.Status = providers.ExecFailure
+			execResp.Error = &ErrAmbiguousIdentifier
+			return execResp, nil
+		}
+		identifierInput = resolvedInput
+
+		missingInputs := !b.HasRequiredInputs(ctx, execResp)
+		missingIdentifier := len(ctx.NodeIdentifierInputs) > 0 && identifierMatches == 0
+		if missingIdentifier {
+			execResp.Inputs = append(execResp.Inputs, ctx.NodeIdentifierInputs...)
+		}
+		if missingInputs || missingIdentifier {
+			logger.Debug(ctx.Context, "Required inputs for credentials authentication executor is not provided")
+			execResp.Status = providers.ExecUserInputRequired
+			return execResp, nil
+		}
 	}
 
 	// TODO: Should handle client errors here. Service should return a ServiceError and
 	//  client errors should be appended as a failure.
 	//  For the moment handling returned error as a authentication failure.
-	err := b.authenticateUser(ctx, execResp)
+	err := b.authenticateUser(ctx, execResp, identifierInput)
 	if err != nil {
 		execResp.Status = providers.ExecFailure
 		execResp.Error = &ErrUserAuthFailed
@@ -142,10 +161,24 @@ func (b *credentialsAuthExecutor) getCredentialInputs(ctx *providers.NodeContext
 	return credentials
 }
 
+// resolveIdentifierInput returns the single supplied identifier input along with the number of
+// the node's identifier inputs that were supplied. Returns (nil, 0) when the node declares none.
+func resolveIdentifierInput(ctx *providers.NodeContext) (*providers.Input, int) {
+	var resolved *providers.Input
+	matches := 0
+	for i, input := range ctx.NodeIdentifierInputs {
+		if ctx.UserInputs[input.Identifier] != "" {
+			resolved = &ctx.NodeIdentifierInputs[i]
+			matches++
+		}
+	}
+	return resolved, matches
+}
+
 // authenticateUser perform authentication based on the provided identifying and
 // credential attributes and returns the authenticated user details.
 func (b *credentialsAuthExecutor) authenticateUser(ctx *providers.NodeContext,
-	execResp *providers.ExecutorResponse) error {
+	execResp *providers.ExecutorResponse, identifierInput *providers.Input) error {
 	logger := b.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	userIdentifiers := map[string]interface{}{}
@@ -154,6 +187,12 @@ func (b *credentialsAuthExecutor) authenticateUser(ctx *providers.NodeContext,
 	// When a userID is pre-resolved, use it as the identifier for authentication.
 	if preResolvedUserID, ok := ctx.RuntimeData[userAttributeUserID]; ok {
 		userIdentifiers[userAttributeUserID] = preResolvedUserID
+	}
+
+	// The resolved identifier is passed under its own name, so the authn provider can tell
+	// which kind of identifier the user supplied.
+	if identifierInput != nil {
+		userIdentifiers[identifierInput.Identifier] = ctx.UserInputs[identifierInput.Identifier]
 	}
 
 	for _, inputData := range b.GetRequiredInputs(ctx) {

--- a/backend/internal/flow/executor/credentials_auth_executor_test.go
+++ b/backend/internal/flow/executor/credentials_auth_executor_test.go
@@ -447,7 +447,7 @@ func (suite *CredentialsAuthExecutorTestSuite) TestAuthenticateUser_SuccessfulAu
 	}, mock.Anything, mock.Anything, mock.Anything).
 		Return(authenticatedAuthUser, providers.AuthenticatedClaims{}, nil)
 
-	err := suite.executor.authenticateUser(ctx, execResp)
+	err := suite.executor.authenticateUser(ctx, execResp, nil)
 
 	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), execResp.AuthUser.IsAuthenticated())
@@ -480,7 +480,7 @@ func (suite *CredentialsAuthExecutorTestSuite) TestAuthenticateUser_Success_With
 		userAttributePassword: "password123",
 	}, mock.Anything, mock.Anything, mock.Anything).Return(authenticatedAuthUser, runtimeAttrs, nil)
 
-	err := suite.executor.authenticateUser(ctx, execResp)
+	err := suite.executor.authenticateUser(ctx, execResp, nil)
 
 	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), execResp.AuthUser.IsAuthenticated())
@@ -511,7 +511,7 @@ func (suite *CredentialsAuthExecutorTestSuite) TestAuthenticateUser_Authenticati
 	}, mock.Anything, mock.Anything, mock.Anything).
 		Return(authenticatedAuthUser, providers.AuthenticatedClaims{}, nil)
 
-	err := suite.executor.authenticateUser(ctx, execResp)
+	err := suite.executor.authenticateUser(ctx, execResp, nil)
 
 	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), execResp.AuthUser.IsAuthenticated())
@@ -536,7 +536,7 @@ func (suite *CredentialsAuthExecutorTestSuite) TestAuthenticateUser_Registration
 		userAttributeUsername: "newuser",
 	}).Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
 
-	err := suite.executor.authenticateUser(ctx, execResp)
+	err := suite.executor.authenticateUser(ctx, execResp, nil)
 
 	assert.NoError(suite.T(), err)
 	assert.False(suite.T(), execResp.AuthUser.IsAuthenticated())
@@ -632,7 +632,7 @@ func (suite *CredentialsAuthExecutorTestSuite) TestGetAuthenticatedUser_ClientEr
 			ErrorDescription: tidcommon.I18nMessage{Key: "error.test.wrong_password", DefaultValue: "wrong password"},
 		})
 
-	err := suite.executor.authenticateUser(ctx, execResp)
+	err := suite.executor.authenticateUser(ctx, execResp, nil)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), providers.ExecUserInputRequired, execResp.Status,
@@ -687,4 +687,129 @@ func (suite *CredentialsAuthExecutorTestSuite) TestExecute_PreResolvedUser_WithP
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
 	assert.True(suite.T(), resp.AuthUser.IsAuthenticated())
+}
+
+// identifierInputsFixture returns the mutually exclusive identifier inputs used by the
+// identifier-input tests, mirroring a node reachable from several identifier prompts.
+func identifierInputsFixture() []providers.Input {
+	return []providers.Input{
+		{Identifier: "uin", Type: providers.InputTypeText, Required: true},
+		{Identifier: "phone", Type: providers.InputTypeText, Required: true},
+		{Identifier: "email", Type: providers.InputTypeText, Required: true},
+	}
+}
+
+// newIdentifierInputsContext builds a context for a node declaring identifier inputs, with
+// only the given identifiers supplied alongside the password.
+func newIdentifierInputsContext(supplied map[string]string) *providers.NodeContext {
+	userInputs := map[string]string{userAttributePassword: "password123"}
+	for k, v := range supplied {
+		userInputs[k] = v
+	}
+	return &providers.NodeContext{
+		ExecutionID:          "flow-123",
+		FlowType:             providers.FlowTypeAuthentication,
+		UserInputs:           userInputs,
+		RuntimeData:          make(map[string]string),
+		NodeIdentifierInputs: identifierInputsFixture(),
+	}
+}
+
+func (suite *CredentialsAuthExecutorTestSuite) TestExecute_IdentifierInputs_PassesSuppliedIdentifier() {
+	ctx := newIdentifierInputsContext(map[string]string{"phone": "+919876543210@phone"})
+	suite.executor.Executor = createMockExecutorWithCustomInputs(suite.T(), ExecutorNameCredentialsAuth,
+		[]providers.Input{{Identifier: userAttributePassword, Type: providers.InputTypePassword, Required: true}})
+
+	authenticatedAuthUser := newCredentialsAuthAuthenticatedUser()
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything,
+		map[string]interface{}{"phone": "+919876543210@phone"},
+		map[string]interface{}{userAttributePassword: "password123"},
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authenticatedAuthUser, providers.AuthenticatedClaims{}, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
+func (suite *CredentialsAuthExecutorTestSuite) TestExecute_IdentifierInputs_MissingIdentifierPrompts() {
+	ctx := newIdentifierInputsContext(nil)
+	suite.executor.Executor = createMockExecutorWithCustomInputs(suite.T(), ExecutorNameCredentialsAuth,
+		[]providers.Input{{Identifier: userAttributePassword, Type: providers.InputTypePassword, Required: true}})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecUserInputRequired, resp.Status)
+	assert.Subset(suite.T(), resp.Inputs, identifierInputsFixture())
+}
+
+func (suite *CredentialsAuthExecutorTestSuite) TestExecute_IdentifierInputs_AmbiguousIdentifierFails() {
+	ctx := newIdentifierInputsContext(map[string]string{"uin": "4358192047", "phone": "+919876543210@phone"})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), ErrAmbiguousIdentifier.Code, resp.Error.Code)
+}
+
+func (suite *CredentialsAuthExecutorTestSuite) TestExecute_WithoutIdentifierInputs_UsesDeclaredInputs() {
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		UserInputs: map[string]string{
+			userAttributeUsername: "testuser",
+			userAttributePassword: "password123",
+		},
+		RuntimeData: make(map[string]string),
+	}
+
+	authenticatedAuthUser := newCredentialsAuthAuthenticatedUser()
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything,
+		map[string]interface{}{userAttributeUsername: "testuser"},
+		map[string]interface{}{userAttributePassword: "password123"},
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authenticatedAuthUser, providers.AuthenticatedClaims{}, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
+// TestExecute_PreResolvedUser_SkipsIdentifierInputs verifies that when a userID is
+// pre-resolved, identifier resolution and its ambiguity validation are skipped even
+// though the node declares identifier inputs and multiple are supplied. Authentication
+// must proceed using only the pre-resolved userID rather than failing as ambiguous.
+func (suite *CredentialsAuthExecutorTestSuite) TestExecute_PreResolvedUser_SkipsIdentifierInputs() {
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		UserInputs: map[string]string{
+			userAttributePassword: "password123",
+			"uin":                 "4358192047",
+			"phone":               "+919876543210@phone",
+		},
+		RuntimeData: map[string]string{
+			userAttributeUserID: "pre-resolved-user-123",
+		},
+		NodeIdentifierInputs: identifierInputsFixture(),
+	}
+
+	authenticatedAuthUser := newCredentialsAuthAuthenticatedUser()
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything,
+		map[string]interface{}{userAttributeUserID: "pre-resolved-user-123"},
+		map[string]interface{}{userAttributePassword: "password123"},
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authenticatedAuthUser, providers.AuthenticatedClaims{}, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }

--- a/backend/internal/flow/executor/error_constants.go
+++ b/backend/internal/flow/executor/error_constants.go
@@ -1208,6 +1208,21 @@ var (
 			DefaultValue: "The user could not be deleted",
 		},
 	}
+
+	// ErrAmbiguousIdentifier is returned when more than one of a node's mutually exclusive
+	// identifier inputs is supplied, leaving the identifier to authenticate with undetermined.
+	ErrAmbiguousIdentifier = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "FET-1086",
+		Error: tidcommon.I18nMessage{
+			Key:          "flows.executor.errors.ambiguous_identifier",
+			DefaultValue: "Ambiguous identifier",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key:          "flows.executor.errors.ambiguous_identifier_desc",
+			DefaultValue: "More than one identifier was provided for this step",
+		},
+	}
 )
 
 // errAttributeNotUniqueFor returns a ServiceError for a specific attribute that is not unique.

--- a/backend/internal/flow/graphbuilder/graph_builder.go
+++ b/backend/internal/flow/graphbuilder/graph_builder.go
@@ -187,7 +187,9 @@ func (b *graphBuilder) processNode(
 		return err
 	}
 
-	b.configureNodeInputs(ctx, nodeDef, node)
+	if err := b.configureNodeInputs(ctx, nodeDef, node); err != nil {
+		return err
+	}
 	b.configureNodeMeta(nodeDef, node)
 	b.configureNodeVariant(nodeDef, node)
 	b.configureNodeCondition(nodeDef, node)
@@ -324,40 +326,63 @@ func (b *graphBuilder) configureCallNodeReference(nodeDef *providers.NodeDefinit
 	}
 }
 
-// configureNodeInputs configures the inputs for executor-backed nodes.
-// Validation rules on executor inputs are intentionally not propagated:
-// executor inputs are read from runtime context (already validated at the
-// preceding PROMPT node), so per-rule re-validation here would be redundant.
+// configureNodeInputs configures the inputs for executor-backed nodes, carrying
+// any validation rules declared on the executor's inputs and identifier inputs
+// instead of silently discarding them. Rule conversion errors (e.g. an invalid
+// regex) are propagated rather than swallowed.
 func (b *graphBuilder) configureNodeInputs(
 	ctx context.Context,
 	nodeDef *providers.NodeDefinition,
 	node core.NodeInterface,
-) {
+) error {
 	logger := b.logger.With(log.String("nodeID", nodeDef.ID))
 
 	executorNode, ok := node.(core.ExecutorBackedNodeInterface)
 	if !ok {
 		logger.Debug(ctx, "Node is not executor-backed; skipping input configuration")
-		return
+		return nil
 	}
 
-	if nodeDef.Executor == nil || len(nodeDef.Executor.Inputs) == 0 {
-		logger.Debug(ctx, "No inputs defined for executor; setting empty input list")
+	if nodeDef.Executor == nil {
+		logger.Debug(ctx, "No executor defined; setting empty input lists")
 		executorNode.SetInputs([]providers.Input{})
-		return
+		executorNode.SetIdentifierInputs([]providers.Input{})
+		return nil
 	}
 
-	inputs := make([]providers.Input, len(nodeDef.Executor.Inputs))
-	for i, input := range nodeDef.Executor.Inputs {
+	inputs, err := toExecutorInputs(nodeDef.Executor.Inputs)
+	if err != nil {
+		return fmt.Errorf("node %s inputs: %w", nodeDef.ID, err)
+	}
+	identifierInputs, err := toExecutorInputs(nodeDef.Executor.IdentifierInputs)
+	if err != nil {
+		return fmt.Errorf("node %s identifier inputs: %w", nodeDef.ID, err)
+	}
+
+	executorNode.SetInputs(inputs)
+	executorNode.SetIdentifierInputs(identifierInputs)
+	return nil
+}
+
+// toExecutorInputs converts executor input definitions to their runtime form,
+// carrying each definition's validation rules. Always returns a non-nil slice.
+func toExecutorInputs(defs []providers.InputDefinition) ([]providers.Input, error) {
+	inputs := make([]providers.Input, len(defs))
+	for i, def := range defs {
+		validation, err := toValidationRules(def.Validation)
+		if err != nil {
+			return nil, fmt.Errorf("input %s: %w", def.Identifier, err)
+		}
 		inputs[i] = providers.Input{
-			Ref:        input.Ref,
-			Identifier: input.Identifier,
-			Type:       input.Type,
-			Required:   input.Required,
-			OneTimeUse: input.OneTimeUse,
+			Ref:        def.Ref,
+			Identifier: def.Identifier,
+			Type:       def.Type,
+			Required:   def.Required,
+			OneTimeUse: def.OneTimeUse,
+			Validation: validation,
 		}
 	}
-	executorNode.SetInputs(inputs)
+	return inputs, nil
 }
 
 // toValidationRules converts mgt rule definitions to runtime ValidationRule

--- a/backend/internal/flow/graphbuilder/graph_builder_subset_registry_test.go
+++ b/backend/internal/flow/graphbuilder/graph_builder_subset_registry_test.go
@@ -93,6 +93,7 @@ func (s *GraphBuilderSubsetRegistryTestSuite) TestBuildGraph_SubsetRegistryRejec
 	mockFlowFactory.EXPECT().CreateNode(
 		"task", "TASK_EXECUTION", map[string]interface{}(nil), false, true).Return(mockTaskNode, nil)
 	mockTaskNode.EXPECT().SetInputs([]providers.Input{})
+	mockTaskNode.EXPECT().SetIdentifierInputs([]providers.Input{})
 
 	graph, err := builder.buildGraph(context.Background(), flow)
 

--- a/backend/internal/flow/graphbuilder/graph_builder_test.go
+++ b/backend/internal/flow/graphbuilder/graph_builder_test.go
@@ -278,6 +278,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithExecutor() {
 	s.mockExecutorRegistry.EXPECT().IsRegistered("test-executor").Return(true)
 	mockTaskNode.EXPECT().SetExecutorName("test-executor")
 	mockTaskNode.EXPECT().SetInputs([]providers.Input{})
+	mockTaskNode.EXPECT().SetIdentifierInputs([]providers.Input{})
 
 	mockGraph.EXPECT().AddNode(mockStartNode).Return(nil)
 	mockGraph.EXPECT().AddNode(mockTaskNode).Return(nil)
@@ -322,6 +323,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_ExecutorNotRegistered() {
 		"task", "TASK_EXECUTION", map[string]interface{}(nil), false, true).Return(
 		mockTaskNode, nil)
 	mockTaskNode.EXPECT().SetInputs([]providers.Input{})
+	mockTaskNode.EXPECT().SetIdentifierInputs([]providers.Input{})
 
 	s.mockExecutorRegistry.EXPECT().IsRegistered("unknown-executor").Return(false)
 
@@ -378,6 +380,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithOnFailure() {
 	mockTaskNode.EXPECT().SetOnSuccess("end")
 	mockTaskNode.EXPECT().SetOnFailure("error-prompt")
 	mockTaskNode.EXPECT().SetInputs([]providers.Input{})
+	mockTaskNode.EXPECT().SetIdentifierInputs([]providers.Input{})
 
 	s.mockExecutorRegistry.EXPECT().IsRegistered("test-executor").Return(true)
 	mockTaskNode.EXPECT().SetExecutorName("test-executor")
@@ -517,6 +520,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithInputs() {
 		{Ref: "username", Type: "string", Identifier: "user", Required: true},
 		{Ref: "password", Type: "string", Identifier: "pass", Required: true},
 	})
+	mockTaskNode.EXPECT().SetIdentifierInputs([]providers.Input{})
 
 	mockGraph.EXPECT().AddNode(mockStartNode).Return(nil)
 	mockGraph.EXPECT().AddNode(mockTaskNode).Return(nil)
@@ -594,7 +598,9 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithActions() {
 		return true
 	}))
 	mockTask1Node.EXPECT().SetInputs([]providers.Input{})
+	mockTask1Node.EXPECT().SetIdentifierInputs([]providers.Input{})
 	mockTask2Node.EXPECT().SetInputs([]providers.Input{})
+	mockTask2Node.EXPECT().SetIdentifierInputs([]providers.Input{})
 
 	mockGraph.EXPECT().AddNode(mockStartNode).Return(nil)
 	mockGraph.EXPECT().AddNode(mockPromptNode).Return(nil)
@@ -762,6 +768,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithCondition() {
 
 	mockStartNode.EXPECT().SetOnSuccess("task")
 	mockTaskNode.EXPECT().SetInputs([]providers.Input{})
+	mockTaskNode.EXPECT().SetIdentifierInputs([]providers.Input{})
 	mockTaskNode.EXPECT().SetCondition(&core.NodeCondition{
 		Key:    "userType",
 		Value:  "premium",
@@ -1039,6 +1046,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithExecutorMode() {
 	mockTaskNode.EXPECT().SetExecutorName("OTPExecutor")
 	mockTaskNode.EXPECT().SetMode("generate")
 	mockTaskNode.EXPECT().SetInputs([]providers.Input{})
+	mockTaskNode.EXPECT().SetIdentifierInputs([]providers.Input{})
 
 	mockGraph.EXPECT().AddNode(mockStartNode).Return(nil)
 	mockGraph.EXPECT().AddNode(mockTaskNode).Return(nil)
@@ -1653,6 +1661,58 @@ func (s *GraphBuilderTestSuite) TestConfigureNodePrompts_ValidationRulesCompiled
 
 	err := s.builder.configureNodePrompts(context.Background(), nodeDef, mockPromptNode, map[string][]string{})
 	s.Nil(err)
+}
+
+func (s *GraphBuilderTestSuite) TestConfigureNodeInputs_IdentifierInputsValidationCompiled() {
+	nodeDef := &providers.NodeDefinition{
+		ID:   "task-1",
+		Type: "TASK_EXECUTION",
+		Executor: &providers.ExecutorDefinition{
+			IdentifierInputs: []providers.InputDefinition{
+				{
+					Identifier: "phone",
+					Validation: []providers.ValidationRuleDefinition{
+						{Type: "regex", Value: `^\+[0-9]+@phone$`, Message: "invalid.phone"},
+					},
+				},
+			},
+		},
+	}
+
+	mockTaskNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
+	mockTaskNode.EXPECT().SetInputs([]providers.Input{})
+	mockTaskNode.EXPECT().SetIdentifierInputs(mock.MatchedBy(func(inputs []providers.Input) bool {
+		if len(inputs) != 1 || inputs[0].Identifier != "phone" || len(inputs[0].Validation) != 1 {
+			return false
+		}
+		rule := inputs[0].Validation[0]
+		return rule.Type == providers.ValidationTypeRegex && rule.CompiledRegex != nil
+	}))
+
+	err := s.builder.configureNodeInputs(context.Background(), nodeDef, mockTaskNode)
+	s.Nil(err)
+}
+
+func (s *GraphBuilderTestSuite) TestConfigureNodeInputs_InvalidValidationRegexReturnsError() {
+	nodeDef := &providers.NodeDefinition{
+		ID:   "task-1",
+		Type: "TASK_EXECUTION",
+		Executor: &providers.ExecutorDefinition{
+			IdentifierInputs: []providers.InputDefinition{
+				{
+					Identifier: "phone",
+					Validation: []providers.ValidationRuleDefinition{
+						{Type: "regex", Value: "[unclosed", Message: "bad"},
+					},
+				},
+			},
+		},
+	}
+
+	mockTaskNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
+
+	err := s.builder.configureNodeInputs(context.Background(), nodeDef, mockTaskNode)
+	s.Error(err)
 }
 
 // CALL node tests

--- a/backend/pkg/thunderidengine/providers/model.go
+++ b/backend/pkg/thunderidengine/providers/model.go
@@ -346,9 +346,10 @@ type PromptDefinition struct {
 
 // ExecutorDefinition represents the executor configuration for a node.
 type ExecutorDefinition struct {
-	Name   string            `json:"name"             yaml:"name"             jsonschema:"Name of the executor (e.g., 'UsernamePasswordAuthenticator')."`
-	Mode   string            `json:"mode,omitempty"   yaml:"mode,omitempty"   jsonschema:"Execution mode or configuration."`
-	Inputs []InputDefinition `json:"inputs,omitempty" yaml:"inputs,omitempty" jsonschema:"Static inputs or configuration parameters for the executor."`
+	Name             string            `json:"name"             yaml:"name"             jsonschema:"Name of the executor (e.g., 'UsernamePasswordAuthenticator')."`
+	Mode             string            `json:"mode,omitempty"   yaml:"mode,omitempty"   jsonschema:"Execution mode or configuration."`
+	Inputs           []InputDefinition `json:"inputs,omitempty" yaml:"inputs,omitempty" jsonschema:"Static inputs or configuration parameters for the executor."`
+	IdentifierInputs []InputDefinition `json:"identifierInputs,omitempty" yaml:"identifierInputs,omitempty" jsonschema:"Mutually exclusive identifier inputs. Exactly one must be supplied."`
 }
 
 // ConditionDefinition represents a condition for node execution.
@@ -1092,8 +1093,11 @@ type NodeContext struct {
 
 	NodeProperties map[string]interface{}
 	NodeInputs     []Input
-	UserInputs     map[string]string
-	RuntimeData    map[string]string
+	// NodeIdentifierInputs holds the node's mutually exclusive identifier inputs, exactly one of
+	// which is expected to be supplied. Empty when the node declares none.
+	NodeIdentifierInputs []Input
+	UserInputs           map[string]string
+	RuntimeData          map[string]string
 	// SharedRuntimeData contains trusted data shared by every frame in the execution.
 	SharedRuntimeData map[string]string
 	ForwardedData     map[string]interface{}

--- a/backend/tests/mocks/flow/coremock/ExecutorBackedNodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/ExecutorBackedNodeInterface_mock.go
@@ -409,6 +409,52 @@ func (_c *ExecutorBackedNodeInterfaceMock_GetID_Call) RunAndReturn(run func() st
 	return _c
 }
 
+// GetIdentifierInputs provides a mock function for the type ExecutorBackedNodeInterfaceMock
+func (_mock *ExecutorBackedNodeInterfaceMock) GetIdentifierInputs() []providers.Input {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentifierInputs")
+	}
+
+	var r0 []providers.Input
+	if returnFunc, ok := ret.Get(0).(func() []providers.Input); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]providers.Input)
+		}
+	}
+	return r0
+}
+
+// ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentifierInputs'
+type ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call struct {
+	*mock.Call
+}
+
+// GetIdentifierInputs is a helper method to define mock.On call
+func (_e *ExecutorBackedNodeInterfaceMock_Expecter) GetIdentifierInputs() *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call {
+	return &ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call{Call: _e.mock.On("GetIdentifierInputs")}
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call) Run(run func()) *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call) Return(inputs []providers.Input) *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call {
+	_c.Call.Return(inputs)
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call) RunAndReturn(run func() []providers.Input) *ExecutorBackedNodeInterfaceMock_GetIdentifierInputs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetInputs provides a mock function for the type ExecutorBackedNodeInterfaceMock
 func (_mock *ExecutorBackedNodeInterfaceMock) GetInputs() []providers.Input {
 	ret := _mock.Called()
@@ -1163,6 +1209,46 @@ func (_c *ExecutorBackedNodeInterfaceMock_SetExecutorName_Call) Return() *Execut
 }
 
 func (_c *ExecutorBackedNodeInterfaceMock_SetExecutorName_Call) RunAndReturn(run func(name string)) *ExecutorBackedNodeInterfaceMock_SetExecutorName_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetIdentifierInputs provides a mock function for the type ExecutorBackedNodeInterfaceMock
+func (_mock *ExecutorBackedNodeInterfaceMock) SetIdentifierInputs(inputs []providers.Input) {
+	_mock.Called(inputs)
+	return
+}
+
+// ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetIdentifierInputs'
+type ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call struct {
+	*mock.Call
+}
+
+// SetIdentifierInputs is a helper method to define mock.On call
+//   - inputs []providers.Input
+func (_e *ExecutorBackedNodeInterfaceMock_Expecter) SetIdentifierInputs(inputs interface{}) *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call {
+	return &ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call{Call: _e.mock.On("SetIdentifierInputs", inputs)}
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call) Run(run func(inputs []providers.Input)) *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []providers.Input
+		if args[0] != nil {
+			arg0 = args[0].([]providers.Input)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call) Return() *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call) RunAndReturn(run func(inputs []providers.Input)) *ExecutorBackedNodeInterfaceMock_SetIdentifierInputs_Call {
 	_c.Run(run)
 	return _c
 }

--- a/docs/content/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/flows/advanced-configurations.mdx
@@ -224,7 +224,8 @@ A **TASK EXECUTION** node runs a named executor, a discrete unit of server-side 
 |---|---|---|
 | `executor` | Yes | Name of the executor to run. |
 | `mode` | No | Operational mode passed to the executor. Use when an executor supports multiple steps or variants (e.g. `send`, `verify`). |
-| `inputs` | No | Override the executor's default inputs for this node. When omitted, the executor's own default inputs are used. |
+| `inputs` | No | Override the executor's default inputs for this node. When omitted, the executor's own default inputs are used. All declared inputs must be supplied. |
+| `identifierInputs` | No | Mutually exclusive identifier inputs, exactly one of which must be supplied. Use when a node is reachable from several prompts that each collect a different kind of identifier. Supplements `inputs`, which the node should still declare for its remaining fields. |
 | `onSuccess` | No | ID of the node to advance to when the executor completes successfully. |
 | `onFailure` | No | ID of the node to forward to when the executor reports a failure. The failure reason is stored in runtime data so the target node (typically a PROMPT) can display it. |
 | `onIncomplete` | No | ID of the PROMPT node to forward to when the executor needs additional user input. |
@@ -504,9 +505,30 @@ Verifies a provided identifier and a password against stored values. This is the
 }
 ```
 
+**Accepting more than one kind of identifier:** when a node is reachable from several prompts that each collect a different identifier (for example a national ID, a phone number, or an email address), declare them under `identifierInputs` instead of `inputs`. Exactly one must be supplied; the executor passes it to the authentication provider under its own name, so the provider can tell which kind of identifier the user used.
+
+```json
+{
+  "id": "credentials_auth",
+  "type": "TASK_EXECUTION",
+  "executor": {
+    "name": "CredentialsAuthExecutor",
+    "identifierInputs": [
+      { "identifier": "uin", "type": "TEXT_INPUT" },
+      { "identifier": "phone", "type": "PHONE_INPUT" },
+      { "identifier": "email", "type": "EMAIL_INPUT" }
+    ],
+    "inputs": [
+      { "identifier": "password", "type": "PASSWORD", "required": true }
+    ]
+  }
+}
+```
+
 **Failure conditions:**
 - Invalid credentials
 - User not found
+- More than one `identifierInputs` entry supplied
 - Authentication service error
 
 </details>


### PR DESCRIPTION
### Purpose
Adds a new `identifierInputs` list attribute to executor-backed (TASK_EXECUTION) nodes, letting a node accept **one of several mutually exclusive identifier inputs** rather than a fixed set. This enables a single shared authentication node to be reached from multiple prompts that each collect a different kind of identifier, and to pass whichever one was supplied to the authentication provider **under its own name** — so the provider can tell which kind of identifier the user used.

The attribute is optional and additive: nodes that do not declare `identifierInputs` behave exactly as before.

### Approach
- **Model** (`providers/model.go`): add `ExecutorDefinition.IdentifierInputs []InputDefinition`
  and `NodeContext.NodeIdentifierInputs []Input`.
- **Graph build** (`graphbuilder/graph_builder.go`): a shared `toExecutorInputs` helper builds
  both `inputs` and `identifierInputs` onto the node; both always resolve to a non-nil slice.
- **Node** (`core/task_execution_node.go`): `Get/SetIdentifierInputs` added to
  `ExecutorBackedNodeInterface`; the list is copied into `ctx.NodeIdentifierInputs` before the
  executor runs. A new `clearConsumedInputs` clears identifier inputs alongside regular inputs
  on failure/incomplete, so a stale identifier cannot accumulate across attempts.
- **Clone/export** (`core/factory.go`, `core/graph.go`): `CloneNode` carries the identifier
  inputs; `ToJSON` exports them as `identifierInputs`.
- **Executor** (`executor/credentials_auth_executor.go`): resolves the supplied identifier —
  **exactly one** required. Zero prompts for input; **more than one fails** explicitly with the
  new `ErrAmbiguousIdentifier` (`FET-1086`, `error_constants.go`) rather than guessing. The
  resolved identifier is passed to the provider under its own key.
- **Semantics:** `inputs` → all required (unchanged); `identifierInputs` → exactly one required.
- **Docs:** `identifierInputs` documented on the TASK_EXECUTION node and the Identifier +
  Password executor in `advanced-configurations.mdx`.
- **Tests:** cover one-identifier pass-through under its own key, none-prompts, two-fails-with-
  `ErrAmbiguousIdentifier`, and the absent-attribute (backward-compatible) path; graph builder
  sets both input lists; the declared identifier inputs reach the executor context. Mocks
  regenerated for the two new interface methods.

**Backward compatibility:** when `identifierInputs` is absent — the case for every existing
flow — the executor and node behave identically to today. `inputs` semantics are unchanged.

### Related Issues
- [2123] (https://github.com/mosip/esignet/issues/2123)

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple, mutually exclusive identifier inputs on task execution nodes.
  * Credential authentication now accepts different identifier types and prompts for missing identifiers.
  * Added validation rules for identifier inputs.

* **Bug Fixes**
  * Added a clear error when multiple identifiers are supplied.
  * Identifier inputs are preserved when cloning and serializing flows.
  * Failed or incomplete executions correctly clear consumed identifier inputs.

* **Documentation**
  * Documented configuring identifier inputs and related authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->