### PR TITLE
Distinguish known empty user profiles in consent filtering

### DIFF
--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -518,9 +518,17 @@ func buildConsentedElementSet(consents []*consent.Consent) map[string]bool {
 }
 
 // buildUserAttributeSet builds a set of attribute names present in the user's profile.
-// When availableAttributes is nil, the returned set is empty — meaning no profile filtering is applied.
+// A nil result means the profile is unavailable or opaque, so no profile filtering is applied.
+// A non-nil result, including an empty one, means the profile is known and only the attributes
+// it contains may be prompted for.
 func buildUserAttributeSet(available *providers.AttributesResponse) map[string]bool {
-	if available == nil || len(available.Attributes) == 0 {
+	if available == nil {
+		return nil
+	}
+
+	// An opaque JWT/JWE response carries the token under a single pseudo-claim rather than
+	// individual attribute names, so the attributes the user holds are not known here.
+	if _, ok := available.Attributes[providers.RawJWTAttributeKey]; ok {
 		return nil
 	}
 
@@ -586,7 +594,7 @@ func buildAttributePurposePrompt(purpose consent.ConsentPurpose,
 		}
 
 		// Skip elements not present in the user profile
-		if len(userAttributeSet) > 0 && !userAttributeSet[elem.Name] {
+		if userAttributeSet != nil && !userAttributeSet[elem.Name] {
 			continue
 		}
 

--- a/backend/internal/authn/consent/service_test.go
+++ b/backend/internal/authn/consent/service_test.go
@@ -1110,6 +1110,23 @@ func (s *ConsentEnforcerServiceTestSuite) TestBuildUserAttributeSet_Empty() {
 	}
 
 	result := buildUserAttributeSet(available)
+
+	// A known empty profile is distinct from an unavailable one, so the set is empty but not nil.
+	s.NotNil(result)
+	s.Empty(result)
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestBuildUserAttributeSet_OpaqueJWT() {
+	available := &providers.AttributesResponse{
+		Attributes: map[string]*providers.AttributeResponse{
+			providers.RawJWTAttributeKey: {Value: "header.payload.signature"},
+		},
+	}
+
+	result := buildUserAttributeSet(available)
+
+	// The attribute names inside the token are not visible here, so the profile is treated
+	// as unavailable rather than as a profile holding a single "_jwt" attribute.
 	s.Nil(result)
 }
 
@@ -1821,6 +1838,84 @@ func (s *ConsentEnforcerServiceTestSuite) TestBuildPermissionPurposePrompt_Empty
 	consented := map[string]bool{purposeElementKey(purpose.Name, "p1"): true}
 	_, ok := buildPermissionPurposePrompt(purpose, consented, []string{"p1"})
 	s.False(ok)
+}
+
+func (s *ConsentEnforcerServiceTestSuite) attributePurpose() consent.ConsentPurpose {
+	return consent.ConsentPurpose{
+		ID:   "attr-1",
+		Name: consent.AttributePurposeName("app1"),
+		Elements: []consent.PurposeElement{
+			{Name: "email"},
+			{Name: "phone"},
+		},
+	}
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestBuildAttributePurposePrompt_KnownEmptyProfileProducesNoPrompt() {
+	userAttributeSet := buildUserAttributeSet(&providers.AttributesResponse{
+		Attributes: map[string]*providers.AttributeResponse{},
+	})
+
+	_, ok := buildAttributePurposePrompt(s.attributePurpose(), []string{"email"}, []string{"phone"},
+		map[string]bool{}, userAttributeSet)
+
+	s.False(ok)
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestBuildAttributePurposePrompt_PopulatedProfileFiltersToPresentAttributes() {
+	userAttributeSet := buildUserAttributeSet(&providers.AttributesResponse{
+		Attributes: map[string]*providers.AttributeResponse{"email": {}},
+	})
+
+	prompt, ok := buildAttributePurposePrompt(s.attributePurpose(), []string{"email"}, []string{"phone"},
+		map[string]bool{}, userAttributeSet)
+
+	s.True(ok)
+	s.Len(prompt.Essential, 1)
+	s.Equal("email", prompt.Essential[0].Name)
+	s.Empty(prompt.Optional)
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestBuildAttributePurposePrompt_OnlyInjectedKeysFiltersEverything() {
+	// The consent executor augments every non-nil profile with presence-only keys such as
+	// "groups" and "roles", so an empty profile reaches this function carrying just those.
+	userAttributeSet := buildUserAttributeSet(&providers.AttributesResponse{
+		Attributes: map[string]*providers.AttributeResponse{
+			"groups": {},
+			"roles":  {},
+		},
+	})
+
+	_, ok := buildAttributePurposePrompt(s.attributePurpose(), []string{"email"}, []string{"phone"},
+		map[string]bool{}, userAttributeSet)
+
+	s.False(ok)
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestBuildAttributePurposePrompt_UnavailableProfileDoesNotFilter() {
+	userAttributeSet := buildUserAttributeSet(nil)
+
+	prompt, ok := buildAttributePurposePrompt(s.attributePurpose(), []string{"email"}, []string{"phone"},
+		map[string]bool{}, userAttributeSet)
+
+	s.True(ok)
+	s.Len(prompt.Essential, 1)
+	s.Len(prompt.Optional, 1)
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestBuildAttributePurposePrompt_OpaqueProfileDoesNotFilter() {
+	userAttributeSet := buildUserAttributeSet(&providers.AttributesResponse{
+		Attributes: map[string]*providers.AttributeResponse{
+			providers.RawJWTAttributeKey: {Value: "header.payload.signature"},
+		},
+	})
+
+	prompt, ok := buildAttributePurposePrompt(s.attributePurpose(), []string{"email"}, []string{"phone"},
+		map[string]bool{}, userAttributeSet)
+
+	s.True(ok)
+	s.Len(prompt.Essential, 1)
+	s.Len(prompt.Optional, 1)
 }
 
 func (s *ConsentEnforcerServiceTestSuite) TestBuildPromptedPurposeSet_AndElementSet() {

--- a/docs/content/guides/consent.mdx
+++ b/docs/content/guides/consent.mdx
@@ -23,6 +23,7 @@ As of now, <ProductName /> only supports **attribute consent**.
 When users authenticate with an application that requires specific profile attributes, <ProductName /> can prompt them to consent to sharing specific attributes with the application.
 
 Attribute consent requirements are driven by the requested attributes during application configuration. If an application requires specific user attributes (e.g., username, email), the user will be asked to grant consent before the login process completes.
+Only attributes the user actually holds are included in the prompt. Requested attributes that are not present in the user's profile are omitted, and if the profile holds no attributes at all, no attribute consent is prompted. Where the attribute set cannot be determined for example when the provider returns a signed or encrypted token rather than individual claims no filtering is applied and all requested attributes are prompted for.
 
 ## Configuring Consent in Flows
 


### PR DESCRIPTION
### Purpose
An empty profile map ({}) was previously treated the same as a missing profile (nil). This disabled attribute filtering entirely which causing users to be prompted for attributes they didn't have.
The internal _jwt pseudo claim was treated as a regular attribute name which causing all requested attributes to be filtered out and skipping consent collection completely.

### Approach
Updated buildUserAttributeSet and buildAttributePurposePrompt to distinguish between an unknown profile and a known empty profile
The buildUserAttributeSet now returns nil only when the profile is missing or opaque (providers.RawJWTAttributeKey). For a known profile (even if empty) it returns a non-nil set.
The buildAttributePurposePrompt now checks userAttributeSet != nil instead of len(userAttributeSet) > 0 that ensuring empty profiles are properly filtered.
The buildUserAttributeSet has a single production caller and its result is consumed in one place and both within service.go. So the contract change does not propagate beyond that file.

### Related Issues
Fixes #5098

### Related PRs
N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consent prompts now show only attributes available in a user’s profile.
  * Empty profiles no longer display profile-specific consent elements.
  * Profile filtering is skipped when profile details are unavailable or provided only as an opaque token.

* **Documentation**
  * Added guidance on attribute filtering and consent prompt behavior.

* **Tests**
  * Added coverage for empty, populated, unavailable, and opaque profile scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->