### PR TITLE
Add use case docs for agents as resource providers

### DIFF
--- a/docs/content/use-cases/ai-agents/entity-resource-ownership.mdx
+++ b/docs/content/use-cases/ai-agents/entity-resource-ownership.mdx
@@ -1,0 +1,67 @@
+---
+title: Agents as Resource Providers
+docType: use-case
+description: The problem of disconnected agent identities and the resource servers they expose, and why a first-class binding is needed.
+sidebar_position: 9
+---
+
+# Agents as Resource Providers
+
+An agent that exposes resources, whether API endpoints, MCP tools, or data, needs two identities in the platform: a client identity (who the agent *is*) and a resource server (what the agent *exposes*). Today these are separate, unrelated objects. Nothing in the platform records that a resource server belongs to a specific agent. This disconnect creates problems across three areas: exposing resources, discovering them across agents, and managing their lifecycle.
+
+## The Client-Resource Disconnect
+
+### The Challenge
+
+Making an agent's resources available to callers requires manual, disconnected setup. An administrator registers the agent, then separately creates a resource server, manually sets its identifier to match the agent's endpoint, and mentally tracks that the two belong together. The platform has no record of the relationship.
+
+This breaks in practice. An agent running an MCP server declares its resource identity in a Protected Resource Metadata (PRM) document. But the identity platform does not know that the resource server in the PRM belongs to this agent. If the agent is removed, the resource server lingers. If credentials are rotated, the resource server is unaware. The two sides of the agent's identity, client and resource, can drift independently.
+
+The same gap affects token validation. When an agent receives an incoming request, it must check the `aud` claim to confirm the token targets its resources. Without a binding, the agent's resource server identifier is a separate configuration value, managed outside the platform, that can fall out of sync.
+
+### Scenario: MCP Server Without a Bound Identity
+
+A team deploys a "Document Extraction" agent with an MCP endpoint exposing text extraction and invoice parsing. The administrator creates the agent's identity, then separately creates a resource server and manually matches its identifier to the PRM. Six months later the agent's capabilities have expanded, but the resource server still carries the original scopes. Nobody remembers who set it up or that it belongs to this agent.
+
+## Cross-Agent Resource Discovery
+
+### The Challenge
+
+When one agent needs to invoke another agent's resources, it must know the target's resource server identifier. The platform cannot answer "what resources does this agent expose?" because it has no record of which resource server belongs to which agent. The caller must obtain the identifier out of band, from documentation, a config file, or a colleague.
+
+In multi-agent systems this becomes fragile. An orchestrator coordinating worker agents carries a static mapping of agent names to resource server identifiers. When a team rotates an identifier, the mapping breaks at runtime with an opaque error. The platform authenticates callers and issues tokens, but it cannot resolve "I want to call Agent B" to "here is Agent B's resource server."
+
+### Scenario: Multi-Agent Orchestration
+
+An enterprise runs a "Customer Data" agent, a "Fraud Detection" agent, and an orchestrator. The orchestrator's deployment manifest maps each agent to its resource server identifier, configured manually by an engineer. When the Fraud Detection team migrates to a new identifier during a security rotation, the orchestrator's manifest goes stale. Token requests fail at runtime as "invalid target" because the platform has no concept of which resource server belongs to which agent.
+
+## Resource Lifecycle
+
+### The Challenge
+
+An agent's lifecycle does not extend to the resources it exposes. Creating an agent does not create its resource server. Deleting an agent leaves the resource server behind as an orphan, still issuing tokens for resources that no longer exist. There is no native correlation between an agent and its resources for audit or analytics.
+
+Agents can register their client identity dynamically (DCR), but there is no equivalent for the resource side. An agent starting up can tell the platform "I exist" but not "I serve these resources."
+
+### Scenario: Orphaned Resources After Decommissioning
+
+An enterprise retires its "Legacy Pricing" agent. The administrator deletes the agent, but the resource server `legacy-pricing-api` remains. For three months the platform continues issuing tokens with that audience. The tokens are valid but point to resources no longer backed by a running service, a security gap nobody notices because no binding existed to flag the orphan.
+
+## Key Principles
+
+**An agent's resource identity is part of its identity.** The client side and the resource side should not be two disconnected objects in the platform.
+
+**Ownership should be queryable.** An agent should be able to look up its own resource server, and a resource server's owning agent should be visible to administrators and callers.
+
+**Standalone resource servers remain valid.** Not every resource server belongs to an agent. Ownership is additive, not mandatory.
+
+**Lifecycle events should propagate.** Deleting or disabling an agent should have a defined effect on its resources, not leave orphaned configuration behind.
+
+**Discovery should replace configuration.** Callers accessing an agent's resources should resolve the target through the platform, not maintain out-of-band identifier mappings.
+
+## Related Use Cases
+
+- [Invoking the Agent and Authenticating Users](../invoking-the-agent): governs who may call an agent and how authentication is enforced for the resources the agent exposes.
+- [Managed Identity](../managed-agent-identity): the registration, lifecycle, and revocation governance that resource ownership extends to the resource side.
+- [Multi-Agent Interactions](../multi-agent): delegation and downscoping between agents, where cross-agent resource discovery determines the target audience for each hop.
+- [Accessing Internal Business Services](../internal-services): the dual-identity problem when accessing resources, which resource ownership makes resolvable through the platform.

--- a/docs/content/use-cases/ai-agents/overview.mdx
+++ b/docs/content/use-cases/ai-agents/overview.mdx
@@ -51,6 +51,7 @@ These patterns govern who may call an agent and how the agent proves its own ide
 
 - **[Invoking the Agent and Authenticating Users](../invoking-the-agent)**: authenticate the users, applications, and agents that call an agent; enforce step-up for sensitive actions; and manage the structured, time-bound consent that lets an agent act for a user.
 - **[Agent as Subject](../agent-as-subject)**: let an agent prove its own identity to the systems it accesses with its own credentials (`client_credentials`, `private_key_jwt`, OIDC), distinct from human users and service accounts.
+- **[Agents as Resource Providers](../entity-resource-ownership)**: the problem of disconnected agent and resource server identities, and why agents that expose resources need a first-class binding between their client identity and the resources they serve.
 
 ## Reaching Out (Outbound)
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -244,6 +244,7 @@ const sidebars: SidebarsConfig = {
                 {type: 'doc', id: 'use-cases/ai-agents/internal-services', label: 'Internal Business Services'},
                 {type: 'doc', id: 'use-cases/ai-agents/external-integration', label: 'External Integration'},
                 {type: 'doc', id: 'use-cases/ai-agents/multi-agent', label: 'Multi-Agent Interactions'},
+                {type: 'doc', id: 'use-cases/ai-agents/entity-resource-ownership', label: 'Agents as Resource Providers'},
                 {
                   type: 'category',
                   label: 'Try It Out',


### PR DESCRIPTION
## Summary

- Adds a new use case page **Agents as Resource Providers** under the AI Agents use case section, documenting the problem space for entity-resource server ownership (the disconnect between an agent's client identity and the resource server it exposes).
- Consolidates seven use cases from the [design discussion](https://github.com/thunder-id/thunderid/discussions/5128#discussioncomment-18188104) into three focused problem areas: the client-resource disconnect, cross-agent resource discovery, and resource lifecycle coherence.
- This is problem-focused documentation only, no solution or implementation details are included.

Refs #2456

## Test plan

- [ ] Verify the new page renders correctly in the docs site (`make run_docs`, navigate to Use Cases > AI Agents > Agents as Resource Providers)
- [ ] Verify sidebar entry appears after Multi-Agent Interactions
- [ ] Verify the overview page reference links to the new page correctly
- [ ] Run `make build_docs` to confirm no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an “Agents as Resource Providers” use case covering separated agent identities and resource servers.
  - Documented challenges involving resource exposure, cross-agent discovery, and lifecycle management.
  - Added scenarios and design principles for binding agent identities to served resources.
  - Linked the new use case from the AI agents overview and documentation sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->