### PR TITLE
Document agent onboarding as a configurable flow

### DIFF
--- a/docs/content/guides/agents/manage-agents.mdx
+++ b/docs/content/guides/agents/manage-agents.mdx
@@ -53,6 +53,14 @@ An agent needs an OAuth profile before it can request tokens. The Console create
 That profile is configured on the **Credentials**, **Flows**, **Tokens**, and **Advanced** tabs, which appear only for an agent that has one, and are summarized under [Manage an agent](#manage-an-agent) below.
 :::
 
+### Customize the onboarding sequence
+
+The Console steps above are the default **agent onboarding flow**, a system-wide flow that runs whenever an agent is created, from the Console or the API. It checks the caller's permission, resolves the agent type, organization unit, and owner, collects the schema attributes, creates the agent, and presents its credential once.
+
+Edit that flow to change what onboarding asks for: collect an extra attribute, require an approval before the credential is issued, or branch on the agent type. Validation, credential generation, and the OAuth profile stay with the agent service, so a customized flow cannot register an agent the API would reject. If a step after creation fails, the agent is removed rather than left behind with a live credential.
+
+See [Build a Flow](../../flows/build-a-flow) to build an agent onboarding flow and make it active.
+
 ## Manage an agent
 
 In the Console, open the agent from the list. The name and description are editable inline in the header, and changes across tabs are saved together from the unsaved-changes bar.

--- a/docs/content/guides/flows/build-a-flow.mdx
+++ b/docs/content/guides/flows/build-a-flow.mdx
@@ -216,6 +216,36 @@ A flow has no effect until it is assigned to an application.
 </details>
 
 <details>
+  <summary>Build and configure an agent onboarding flow</summary>
+
+  An agent onboarding flow controls how administrators create agents. Like the user onboarding flow, it is configured **system-wide** rather than per application, and it runs whenever an agent is created through the <ProductName /> Console or the API.
+
+  The default built-in flow walks the admin through the following steps:
+
+  1. **Permission check**: validates that the caller holds the required `system` scope.
+  2. **Agent type selection**: resolves the agent type the new agent is created as.
+  3. **Organization unit (OU) selection**: prompts the admin to choose the target OU from the OU tree.
+  4. **Owner resolution**: sets the user accountable for the agent, defaulting to the creator.
+  5. **Attribute collection**: prompts for the attributes the agent schema defines.
+  6. **Provisioning**: creates the agent along with its OAuth profile.
+  7. **Credential presentation**: shows the client ID and the client secret, which is displayed only once.
+
+  Add, remove, reorder, or branch these steps to match how your organization admits agents. The agent service still owns validation, credential generation, and the inbound client configuration, so a customized flow changes what onboarding asks for without changing what a valid agent has to satisfy. If a step after provisioning fails, the agent the flow created is removed, so a failed onboarding leaves no live credential behind.
+
+  To customize the flow, edit the default directly in the Console's Flow Builder, or create a new one via the `/flows` API. See [API Reference](../../../apis).
+
+  To set the flow as the active system-wide agent onboarding flow, call the Server Configuration API:
+
+  ```bash
+  curl -kL -X PUT https://localhost:8090/server-config/flow \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{ "agentOnboardingFlow": { "defaultHandle": "<your-flow-handle>" } }'
+  ```
+
+</details>
+
+<details>
   <summary>Build and configure a sign-out flow</summary>
 
   A sign-out flow terminates the [Single Sign-On session](../../../key-concepts/authentication/sessions) an authentication flow established, so a user is fully signed out rather than silently signed in again on their next visit. The default flow ends the session without prompting, and a custom flow can confirm the sign-out with the user first. Every application already resolves to a flow, the one it pins, its organization unit's default, or the server-level default, so you only build a sign-out flow when you want to change that behavior. To create one:

--- a/docs/content/guides/flows/what-are-flows.mdx
+++ b/docs/content/guides/flows/what-are-flows.mdx
@@ -10,14 +10,16 @@ description: Learn how flows define the step-by-step journeys users take when si
 
 A **flow** defines the step-by-step journey a user takes during a specific interaction with your application, signing in, creating an account, or resetting a password. <ProductName /> executes the assigned flow whenever a user initiates that action.
 
-<ProductName /> supports four flow types:
+<ProductName /> supports six flow types:
 
 | Type | Purpose | Assigned To |
 |------|---------|-------------|
 | **Authentication** | Controls how users sign in, including Multi-Factor Authentication (MFA) and social login | Application → Authentication Flow |
 | **Registration** | Controls how new users create accounts and provide profile data | Application → Registration Flow (toggle must be enabled) |
 | **Recovery** | Controls how users regain access to their account, such as resetting a forgotten password | Application → Recovery Flow (toggle must be enabled) |
+| **Sign Out** | Controls how a user's Single Sign-On session is terminated, silently or after a confirmation step | Application → Sign Out Flow, or the organization unit or server default |
 | **User Onboarding** | Controls how admins create and onboard new users, directly or via an invite link | System-level |
+| **Agent Onboarding** | Controls how admins create agents, including what is collected and approved before a credential is issued | System-level |
 
 Each flow is a **named, versioned definition**. One flow can be assigned to multiple applications. Every time you save a flow, <ProductName /> creates a new version. The version number appears in the Version column on the Flows list page; previous versions are preserved and can be restored via API. See [Flow Versioning API Reference](../../../apis#tag/flow-versioning).
 

--- a/docs/content/use-cases/ai-agents/overview.mdx
+++ b/docs/content/use-cases/ai-agents/overview.mdx
@@ -2,7 +2,7 @@
 title: Understand It
 docType: use-case
 sidebar_position: 1
-description: Why AI agents need identities of their own, and how AgentID management lets you control, authorize, and trace every action an agent takes.
+description: Why AI agents need identities of their own, and how AgentID management lets you create, control, authorize, and trace every action an agent takes.
 ---
 
 # Understand It
@@ -36,6 +36,12 @@ That works until the agent becomes a real participant in your system.
 A shared or borrowed credential can tell you that *something* trusted made a request, but it does not give you
 a reliable identity model for the individual agent. As your agents become more capable, you start facing
 questions such as:
+
+- **How does an agent come into existence in the first place?**
+  Every agent starts as a decision someone made. What has to be true before it holds a live credential, such
+  as who owns it, which part of the company it belongs to, and whether anyone signs off, is answered
+  differently by every organization, and rarely the same way for a prototype as for an agent that touches
+  customer data.
 
 - **Which agent actually made this call?**
   If several agents share the same application or service credential, your APIs and audit trails cannot
@@ -78,6 +84,20 @@ authorize, and trace.
 Instead of treating an agent as an extension of another application or user, the identity layer registers the
 agent as its own principal. The agent gets credentials of its own, and its access can be controlled through the
 roles and permissions associated with that identity.
+
+Registration itself is part of what you control. Creating an agent is the last point before a working
+credential exists: after it the agent can already act, and whatever onboarding did not ask for was never
+recorded. What that step collects, and what it refuses to proceed without, is a policy question rather than a
+product one.
+
+So onboarding runs as a flow you define, an ordered set of steps <ProductName /> executes when an agent is
+created, rather than a fixed screen. Collect the attribute your inventory depends on, hold the credential
+behind an approval, branch on the kind of agent being registered, and change any of it as your rules change.
+Requirements that would otherwise live in a spreadsheet or a review ticket outside the system are applied where
+the agent is created, and the rules governing what a valid agent looks like stay enforced underneath, so a
+customized sequence can add requirements but never relax them. See
+[Customize the onboarding sequence](../../../guides/agents/manage-agents#customize-the-onboarding-sequence) for
+the default steps and how to change them.
 
 When the agent calls a protected API, it presents a token issued for that identity. Your services can then make
 authorization decisions based on what the token represents rather than trusting information supplied by the


### PR DESCRIPTION
### Purpose

Agent onboarding is moving from a hardcoded Console wizard to a flow definition resolved at runtime, the same model user onboarding already follows. Organizations can then change what onboarding collects, reorder its steps, add approval or governance steps, and branch by agent type, without waiting for a product release. Nothing in the docs covered that, so this adds the use case story and the configuration reference.

Docs only. No breaking changes, so the breaking-changes block is omitted.

| File | Change |
| --- | --- |
| `use-cases/ai-agents/overview.mdx` | New problem bullet ("How does an agent come into existence in the first place?") and two paragraphs in How It Works on why the sequence is yours to define |
| `guides/agents/manage-agents.mdx` | New `Customize the onboarding sequence` section under Create an agent |
| `guides/flows/build-a-flow.mdx` | New details block: the default onboarding steps, what customizing does and does not change, and the Server Configuration API call |
| `guides/flows/what-are-flows.mdx` | New Agent Onboarding row in the flow types table |

### Approach

**The use case section carries the problem, the guides carry the configuration.** The use case funnel exists to answer "is this my problem", so the onboarding content there names no executors, flows, or API calls. It states that the moment an agent is created is the last point before a working credential exists, that what has to be true at that point differs by organization, and that the sequence is therefore something you define. The configuration detail sits in the guides, linked once from the use case page.

**Placed at the front of the funnel, in the existing structure.** The problem bullet goes first in `The Problem`, since it precedes every other question there chronologically. The explanation goes into `How It Works` at the seam between registration and the runtime token story, picking up the existing sentence about registering the agent as its own principal. No new page and no new row in the six-problem table on `solve-index.mdx`: those six are runtime authority problems tied to the `sub` and `act` postures, every row needs a page that solves it, and the count is stated in the page body and its frontmatter description.

**The guide mirrors the user onboarding precedent.** The details block on `build-a-flow.mdx` sits directly after the user onboarding one and follows the same shape (system-wide scope, numbered default steps, customization note, the `server-config/flow` call), so the two read as one family. The agent guide gets the short version plus the anchor the use case links to.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4021

### Related PRs
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for customizing agent onboarding sequences.
  * Documented the default seven-step onboarding flow and configuration options.
  * Added Agent Onboarding and Sign Out to the list of supported flow types.
  * Expanded AI agent identity guidance to cover agent creation, approvals, attributes, and credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->