### PR TITLE
Add backend outbound authentication module

### DIFF
--- a/backend/internal/system/outboundauthn/authenticator.go
+++ b/backend/internal/system/outboundauthn/authenticator.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package outboundauthn provides authentication strategies for outbound HTTP requests.
+package outboundauthn
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	// SchemeNone sends no authentication headers.
+	SchemeNone = "NONE"
+	// SchemeBearer sends an OAuth bearer token in the Authorization header.
+	SchemeBearer = "BEARER"
+	// SchemeAPIKey sends an API key in a configured header.
+	SchemeAPIKey = "API_KEY"
+)
+
+// Config configures authentication for an outbound HTTP connection.
+type Config struct {
+	Scheme       string
+	BearerToken  string
+	APIKeyHeader string
+	APIKeyValue  string
+}
+
+// RequestAuthenticator applies configured authentication to an HTTP request.
+type RequestAuthenticator interface {
+	Apply(*http.Request)
+}
+
+type requestAuthenticator struct {
+	scheme       string
+	bearerToken  string
+	apiKeyHeader string
+	apiKeyValue  string
+}
+
+// New creates an outbound HTTP request authenticator.
+func New(config Config) (RequestAuthenticator, error) {
+	scheme := normalizeScheme(config.Scheme, config.BearerToken, config.APIKeyHeader, config.APIKeyValue)
+	if scheme != SchemeNone && scheme != SchemeBearer && scheme != SchemeAPIKey {
+		return nil, fmt.Errorf("unsupported outbound authentication scheme %q", config.Scheme)
+	}
+	if scheme == SchemeAPIKey && strings.TrimSpace(config.APIKeyHeader) == "" {
+		return nil, fmt.Errorf("API key header is required")
+	}
+
+	return &requestAuthenticator{
+		scheme:       scheme,
+		bearerToken:  config.BearerToken,
+		apiKeyHeader: strings.TrimSpace(config.APIKeyHeader),
+		apiKeyValue:  config.APIKeyValue,
+	}, nil
+}
+
+// Apply adds the configured authentication headers to req.
+func (a *requestAuthenticator) Apply(req *http.Request) {
+	if req == nil {
+		return
+	}
+
+	switch a.scheme {
+	case SchemeBearer:
+		if a.bearerToken != "" {
+			req.Header.Set("Authorization", "Bearer "+a.bearerToken)
+		}
+	case SchemeAPIKey:
+		if a.apiKeyValue != "" {
+			req.Header.Set(a.apiKeyHeader, a.apiKeyValue)
+		}
+	}
+}
+
+func normalizeScheme(value, bearerToken, apiKeyHeader, apiKeyValue string) string {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case SchemeNone, SchemeBearer, SchemeAPIKey:
+		return strings.ToUpper(strings.TrimSpace(value))
+	default:
+		if strings.TrimSpace(bearerToken) != "" {
+			return SchemeBearer
+		}
+		if strings.TrimSpace(apiKeyHeader) != "" && strings.TrimSpace(apiKeyValue) != "" {
+			return SchemeAPIKey
+		}
+		return SchemeNone
+	}
+}

--- a/backend/internal/system/outboundauthn/authenticator_test.go
+++ b/backend/internal/system/outboundauthn/authenticator_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package outboundauthn
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAppliesNoAuthentication(t *testing.T) {
+	authenticator, err := New(Config{Scheme: SchemeNone})
+	require.NoError(t, err)
+
+	req := httptestRequest(t)
+	authenticator.Apply(req)
+
+	require.Empty(t, req.Header)
+}
+
+func TestNewAppliesBearerAuthentication(t *testing.T) {
+	authenticator, err := New(Config{Scheme: SchemeBearer, BearerToken: "token"})
+	require.NoError(t, err)
+
+	req := httptestRequest(t)
+	authenticator.Apply(req)
+
+	require.Equal(t, "Bearer token", req.Header.Get("Authorization"))
+}
+
+func TestNewAppliesAPIKeyAuthentication(t *testing.T) {
+	authenticator, err := New(Config{
+		Scheme:       SchemeAPIKey,
+		APIKeyHeader: "X-API-Key",
+		APIKeyValue:  "secret",
+	})
+	require.NoError(t, err)
+
+	req := httptestRequest(t)
+	authenticator.Apply(req)
+
+	require.Equal(t, "secret", req.Header.Get("X-API-Key"))
+	require.Empty(t, req.Header.Get("Authorization"))
+}
+
+func TestNewRejectsAPIKeyWithoutHeader(t *testing.T) {
+	_, err := New(Config{Scheme: SchemeAPIKey, APIKeyValue: "secret"})
+	require.EqualError(t, err, "API key header is required")
+}
+
+func TestNewInfersAuthenticationScheme(t *testing.T) {
+	authenticator, err := New(Config{BearerToken: "token"})
+	require.NoError(t, err)
+
+	req := httptestRequest(t)
+	authenticator.Apply(req)
+
+	require.Equal(t, "Bearer token", req.Header.Get("Authorization"))
+}
+
+func httptestRequest(t *testing.T) *http.Request {
+	t.Helper()
+	return httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+}


### PR DESCRIPTION
### Purpose
Add a backend reusable outbound authentication module for HTTP requests made by ThunderID services.

The module supports:

- No authentication.
- Bearer token authentication.
- API key authentication using a configurable header.

This module is used by external service integrations such as external AuthZEN PDP connections.
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
- Added a reusable `outboundauthn` package under `backend/internal/system`.
- Added a common `RequestAuthenticator` interface.
- Added configuration validation for supported authentication schemes.
- Added support for applying authentication headers to outbound HTTP requests.
- Added unit tests covering supported schemes, header application, normalization, and invalid configuration.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/5220

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
