### PR TITLE
fix(session): resolve zero-value session timeouts in merged config response

### DIFF
--- a/backend/internal/flow/session/config.go
+++ b/backend/internal/flow/session/config.go
@@ -22,6 +22,16 @@ type Config struct {
 	ActivityRefreshIntervalSeconds int64 `json:"activityRefreshIntervalSeconds" yaml:"activityRefreshIntervalSeconds"`
 }
 
+// Resolved returns a copy of Config with all unset fields replaced by their effective default values.
+func (c Config) Resolved() Config {
+	t := NewTimeouts(c.IdleTimeoutSeconds, c.AbsoluteTimeoutSeconds, c.ActivityRefreshIntervalSeconds)
+	return Config{
+		IdleTimeoutSeconds:             int64(t.Idle.Seconds()),
+		AbsoluteTimeoutSeconds:         int64(t.Absolute.Seconds()),
+		ActivityRefreshIntervalSeconds: int64(t.ActivityRefresh.Seconds()),
+	}
+}
+
 // Validate ensures the configured session timeouts are coherent. Unset (zero) values are allowed and
 // fall back to defaults; the activity-refresh/idle invariant is checked against the resolved
 // durations so a defaulted side cannot silently violate it.
@@ -95,5 +105,5 @@ func (ConfigHandler) Merge(readOnly, writable any) any {
 	if wr.ActivityRefreshIntervalSeconds > 0 {
 		merged.ActivityRefreshIntervalSeconds = wr.ActivityRefreshIntervalSeconds
 	}
-	return merged
+	return merged.Resolved()
 }

--- a/backend/internal/flow/session/config_test.go
+++ b/backend/internal/flow/session/config_test.go
@@ -86,6 +86,23 @@ func (s *ConfigTestSuite) TestHandler_ValidateRejectsIncoherent() {
 	s.Require().Error(ConfigHandler{}.Validate(Config{IdleTimeoutSeconds: -5}, nil, nil))
 }
 
+// TestHandler_MergeResolvesUnsetToDefaults verifies that Merge resolves unset fields to their effective defaults.
+func (s *ConfigTestSuite) TestHandler_MergeResolvesUnsetToDefaults() {
+	merged := ConfigHandler{}.Merge(Config{}, Config{}).(Config)
+	s.Equal(int64(DefaultIdleTimeout.Seconds()), merged.IdleTimeoutSeconds)
+	s.Equal(int64(DefaultAbsoluteTimeout.Seconds()), merged.AbsoluteTimeoutSeconds)
+	s.Equal(int64(defaultActivityRefreshInterval.Seconds()), merged.ActivityRefreshIntervalSeconds)
+}
+
+// TestHandler_MergePartiallyUnsetResolvesRemainingFields verifies that explicit values are preserved while unset fields resolve to defaults.
+func (s *ConfigTestSuite) TestHandler_MergePartiallyUnsetResolvesRemainingFields() {
+	readOnly := Config{IdleTimeoutSeconds: 900}
+	merged := ConfigHandler{}.Merge(readOnly, Config{}).(Config)
+	s.Equal(int64(900), merged.IdleTimeoutSeconds, "explicitly configured field must be preserved")
+	s.Equal(int64(DefaultAbsoluteTimeout.Seconds()), merged.AbsoluteTimeoutSeconds)
+	s.Equal(int64(defaultActivityRefreshInterval.Seconds()), merged.ActivityRefreshIntervalSeconds)
+}
+
 func (s *ConfigTestSuite) TestHandler_MergeWritableWins() {
 	readOnly := Config{IdleTimeoutSeconds: 1800, AbsoluteTimeoutSeconds: 28800, ActivityRefreshIntervalSeconds: 60}
 	writable := Config{IdleTimeoutSeconds: 600, ActivityRefreshIntervalSeconds: 30}


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
`GET /server-config/session` was returning `0` for `idleTimeoutSeconds`, `absoluteTimeoutSeconds`, and `activityRefreshIntervalSeconds` in the merged response when nothing was explicitly configured. even though the server was actually using its real default values (30 min / 8 hr / 60 sec) behind the scenes. This made the API give a wrong/misleading answer about the actual session timeouts in effect.

This PR fixes that by resolving the zero (unset) values to their real defaults before returning the `merged` config, so the API always shows what's actually being enforced.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
Added a `Resolved()` method on the session `Config` struct that reuses the existing `NewTimeouts()` logic (the same logic already used when creating real sessions) to convert any `0` field into its real default value. Then called `.Resolved()` at the end of `Merge()`, so only the merged layer gets the resolved values .`readOnly` and `writable` still show the raw config as before, since those represent what's actually declared/stored, not the effective value.

### Related Issues
- Fixes #5213 

### Related PRs
- N/A

### Checklist
- [X] Followed the contribution guidelines.
- [X] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [X] Tests provided. (Add links if there are any)
    - [X] Unit Tests
    - [X] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [X] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merged session configurations now automatically apply default timeout and activity refresh values when settings are left unspecified.
  * Explicitly configured values are preserved while only missing settings receive defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->