### PR TITLE
Fix broken inline code pill rendering when wrapping across lines

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -281,6 +281,10 @@ h5 {
   padding: 0.1em 0.4em;
   font-size: 0.875em;
   color: var(--ifm-color-primary-light, var(--ifm-color-primary));
+  /* When a pill wraps across lines, give each fragment a complete box
+     instead of slicing the border and padding at the break */
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 /* ------------------------------ Code blocks ----------------------------- */


### PR DESCRIPTION
### Purpose

Inline code pills in the docs (the `.markdown code` styling in `docs/src/css/custom.css`) get a border, background, and padding. With the CSS default `box-decoration-break: slice`, a pill that wraps at the end of a line is cut apart: the border and padding are sliced at the break, leaving a stray half-box at the end of one line and an open-edged fragment with misaligned content at the start of the next, as shown in the issue screenshot.

### Approach

Add `box-decoration-break: clone` (plus the `-webkit-` prefix for Safari) to the existing inline code rule, so each line fragment renders as a complete pill with its own border, radius, and padding on all sides.

Verified by reproducing the wrap locally with the same rule: with `slice` (current behavior) the pill fragments into broken half-boxes at the line break; with `clone` each fragment is a clean, fully enclosed pill. This also keeps long inline code able to wrap, so it cannot cause horizontal overflow of the page.

This was implemented with AI assistance (Claude Code), and reviewed by me.

### Related Issues

- Fixes #5235

### Related PRs

- N/A

### Checklist

- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks

- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved inline code formatting so wrapped code pills retain consistent borders and padding across lines and browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->