### PR TITLE
Document mobile SDK development and testing

### DIFF
--- a/docs/community/contributing/contributing-code/sdk-development/android/overview.mdx
+++ b/docs/community/contributing/contributing-code/sdk-development/android/overview.mdx
@@ -1,0 +1,64 @@
+---
+title: Android SDK Development
+docType: community
+description: "Repository layout, build commands, and code style for contributing to the {{ProductName}} Android SDK."
+sidebar_position: 1
+hide_table_of_contents: false
+---
+
+# Android SDK Development
+
+The Android SDK lives in [android-sdks](https://github.com/thunder-id/android-sdks), a Kotlin library split into a platform layer and a Compose component library.
+
+```text
+src/main/kotlin/dev/thunderid/
+  android/              Core SDK
+    auth/               PKCE and flow execution
+    http/               HTTP client
+    token/              Token store, validator, refresher, JWKS cache
+  compose/              Jetpack Compose component library
+    components/
+      actions/          SignInButton, SignOutButton, SignUpButton
+      guards/           SignedIn, SignedOut, Loading
+      presentation/     SignIn, SignUp, user and organization components
+    i18n/               Localization
+src/test/kotlin/        Unit tests
+samples/quickstart/     Demo app, not part of the SDK
+tests/e2e/              End-to-end suite
+```
+
+The layering runs core → Compose → sample. The sample depends on the SDK through `includeBuild`, so a change to the SDK is picked up when you rebuild the sample.
+
+Every Compose component ships in two variants: a **styled** one with opinionated Material 3 defaults, such as `SignInButton`, and a **base** slot-based one for full customization, such as `BaseSignInButton`.
+
+## Commands
+
+```bash
+./gradlew build
+./gradlew test
+./gradlew lint ktlintCheck
+```
+
+Build and install the sample onto a running emulator with `./gradlew installDebug` from `samples/quickstart`. That directory is its own Gradle build, so `ktlintCheck` does not exist there; run lint from the repository root.
+
+## Code Style
+
+- Kotlin targeting JVM 17. `minSdk` 26 for the SDK, 24 for the sample.
+- Jetpack Compose via BOM `2024.02.00`.
+- No dependency injection framework. State reaches components through `CompositionLocal` (`LocalThunderID`).
+- Coroutines (`suspend` and `Flow`) rather than callbacks.
+- No third-party networking. `HttpClient` wraps `HttpURLConnection`.
+- Token storage uses `EncryptedSharedPreferences` behind the `StorageAdapter` interface.
+- Errors use the typed `IAMErrorCode` enum and `IAMException`.
+
+`ktlintCheck` gates CI and every violation fails the build. The rules worth remembering are a 120-character line limit, alphabetically sorted imports with no wildcards, trailing commas on multi-line declarations but not at call sites, and `} else {` on one line.
+
+## Vendor Naming
+
+The SDK is white-labelable through `ThunderIDConfig.vendor`. Do not hardcode `thunderid` in a runtime name that override should control, such as an `EncryptedSharedPreferences` key or a log tag. Resolve it from `config.vendor` instead.
+
+An entry point whose purpose is to represent the SDK itself, such as `ThunderIDClient`, is a fixed identity and keeps the name.
+
+## Next Steps
+
+- [Testing](../testing)

--- a/docs/community/contributing/contributing-code/sdk-development/android/testing.mdx
+++ b/docs/community/contributing/contributing-code/sdk-development/android/testing.mdx
@@ -1,0 +1,151 @@
+---
+title: Android SDK Testing
+docType: community
+description: "How to run and write the unit tests and the Maestro end-to-end suite for the {{ProductName}} Android SDK."
+sidebar_position: 2
+hide_table_of_contents: false
+---
+
+# Testing
+
+## Unit Tests
+
+```bash
+./gradlew test
+```
+
+Unit tests live in `src/test/kotlin`. Run a single variant with `./gradlew testDebugUnitTest` when you want a faster loop.
+
+## End-to-end Testing
+
+Unit tests cover the SDK with the server stubbed out. They cannot catch the failures that matter most to someone integrating it: a flow step the SDK renders but cannot submit, a field the server renames, or an application whose configuration the SDK rejects at runtime.
+
+The end-to-end suite closes that gap with [Maestro](https://maestro.mobile.dev), which drives the Quickstart sample the way a person would, against a server that is actually running. It signs a user in, signs them out, registers a new account, and signs in as that account.
+
+Maestro is used rather than Espresso because the sign-in and sign-up forms are not static native views. The server returns a flow definition and the SDK renders it, and the iOS and Flutter SDKs tag the resulting fields identically, so one set of selectors works across all three platforms.
+
+```text
+tests/e2e/
+  flows/                       Maestro flows, the tests themselves
+    config.yaml                limits test entry points to the top level
+    signin.yaml
+    signup.yaml
+    subflows/                  shared building blocks, not run on their own
+  run-e2e.sh                   the whole run: server, provisioning, build, Maestro
+  run-e2e.ps1                  the same, for contributors on Windows
+  thunderid-config.yaml        the test application, declaratively
+```
+
+### Configure and Run
+
+You need [Maestro](https://maestro.mobile.dev/getting-started/installing-maestro) installed and an emulator running.
+
+One script does the whole run: it downloads and starts a server, provisions the test
+application and user, configures and installs the sample, then drives it with Maestro.
+
+```bash
+cd tests/e2e
+./run-e2e.sh
+```
+
+Every stage is idempotent, so re-running is the normal way to iterate. A server already serving
+on `:8090` is reused rather than restarted, which matters because all three mobile suites bind
+that port. Skip the stages you do not need, and pass a flow path to run just one:
+
+```bash
+./run-e2e.sh --skip-server --skip-build
+./run-e2e.sh flows/signin.yaml
+```
+
+On Windows, use the PowerShell twin, which takes the same stages:
+
+```powershell
+.\run-e2e.ps1
+.\run-e2e.ps1 -SkipServer -SkipBuild
+```
+
+Provisioning creates one application and one user:
+
+| Resource | Value |
+|----------|-------|
+| Application | `019e5b10-1001-7a2b-9c3d-4e5f60718293` |
+| User | `e2e_mobile_user` / `TestPassword@123` |
+
+Set `THUNDERID_VERSION` to pin a specific server release instead of taking the latest:
+
+```bash
+THUNDERID_VERSION=1.0.1 ./run-e2e.sh
+```
+
+Rebuild and reinstall the sample after changing SDK source. Maestro drives the installed binary, so an edited SDK that has not been reinstalled still tests the old code. This also applies after restarting an emulator that loads a snapshot, which can restore an older build of the application.
+
+### Writing Tests
+
+A flow is a YAML file: a header naming the application under test, then a list of commands after the `---` separator.
+
+```yaml
+appId: dev.thunderid.Quickstart
+name: Sign in and sign out
+tags:
+  - auth
+env:
+  E2E_USERNAME: e2e_mobile_user
+  E2E_PASSWORD: TestPassword@123
+---
+- launchApp:
+    clearState: true
+- tapOn: "Sign in"
+```
+
+Override any `env` value from the command line with `-e E2E_USERNAME=someone`.
+
+#### Targeting Fields and Buttons
+
+The SDK tags every flow-driven field and action with `Modifier.testTag`. Target those identifiers rather than on-screen labels, which change with locale and theme:
+
+- Fields use the server's field identifier: `thunderid-field-username`
+- Actions use the action's ref: `thunderid-action-action_001`
+
+```yaml
+- tapOn:
+    id: "thunderid-field-username"
+- inputText: ${E2E_USERNAME}
+```
+
+:::warning
+Compose keeps `testTag` inside its own semantics tree, where only the Compose test framework can read it. Maestro drives the platform accessibility tree, so a tag is invisible to it unless an ancestor opts the subtree in with `testTagsAsResourceId`. The SDK applies that at the root of the components that render flow steps. A tagged component added outside one of those subtrees looks correct in source but cannot be targeted.
+:::
+
+Action refs differ per flow type. Authentication submits with `action_001`, while registration submits its credentials step with `action_credentials` and its attributes step with `action_schema_attrs`. Read the identifiers off a running application rather than guessing:
+
+```bash
+maestro --platform android hierarchy | grep -o 'thunderid-[a-z]*-[A-Za-z0-9_]*' | sort -u
+```
+
+#### Starting From a Known State
+
+Never assume a clean device. Tokens live in `EncryptedSharedPreferences`, which `clearState: true` does clear, but a flow that fails part way through can still leave the application mid-session. Every flow starts by calling a shared subflow that signs out when a session is present:
+
+```yaml
+- launchApp:
+    clearState: true
+- runFlow: subflows/ensure-signed-out.yaml
+```
+
+Put anything used by more than one flow in `subflows/`. The `config.yaml` entry limits test discovery to the top level, so subflows are building blocks rather than tests that run on their own.
+
+#### Keeping Flows Independent
+
+Each flow leaves the application as it found it, signed out on the landing screen, so flows run in any order. Where a flow needs a unique value, generate one:
+
+```yaml
+- evalScript: ${output.username = 'e2e_signup_' + Date.now()}
+```
+
+Registering a user leaves that account behind on the target server. That is fine against a disposable CI instance; against a long-lived development server, expect the accounts to accumulate.
+
+Note that registration completes without establishing a session, so a sign-up flow ends on the landing screen. Signing in afterward with the credentials just registered is what proves the account works.
+
+## Continuous Integration
+
+`nightly.yml` runs the suite against the latest published server release at 02:30 UTC, and the `e2e` job in `pr-builder.yml` runs it on every pull request. Both call the same `run-e2e-suite.yml` reusable workflow, on a Linux runner with KVM enabled so the emulator can start. On failure it uploads Maestro's screenshots and recorded hierarchy alongside the server log, which is how you tell a real regression from a flake after the run is gone.

--- a/docs/community/contributing/contributing-code/sdk-development/flutter/overview.mdx
+++ b/docs/community/contributing/contributing-code/sdk-development/flutter/overview.mdx
@@ -1,0 +1,67 @@
+---
+title: Flutter SDK Development
+docType: community
+description: "Repository layout, build commands, and code style for contributing to the {{ProductName}} Flutter SDK."
+sidebar_position: 1
+hide_table_of_contents: false
+---
+
+# Flutter SDK Development
+
+The Flutter SDK lives in [flutter-sdks](https://github.com/thunder-id/flutter-sdks), a plugin that bridges to the native iOS and Android SDKs rather than reimplementing authentication in Dart.
+
+```text
+lib/
+  thunderid_flutter.dart        Public API barrel export
+  src/
+    thunderid_client.dart       Core client
+    channel/                    MethodChannel bridge (dev.thunderid/sdk)
+    models/                     Config, errors, user, tokens, flow models
+    widgets/                    Buttons, guards, forms, user components
+    i18n/                       Locale resolution
+android/                        Kotlin method channel handler
+ios/                            Swift method channel handler (SPM package + CocoaPods podspec)
+test/                           Unit tests
+samples/quickstart/             Demo app, not part of the package
+tests/e2e/                      End-to-end suite
+```
+
+The layering runs client → channel → widgets → sample. The Dart client performs no networking of its own: it delegates across a `MethodChannel` to the native SDK, which means a change in behaviour may originate in the native SDK rather than here.
+
+Every widget ships in two variants: a **styled** one with Material 3 defaults, such as `SignInButton`, and a **base** slot-based one for full customization, such as `BaseSignInButton`.
+
+## Commands
+
+```bash
+flutter pub get
+flutter analyze
+flutter test
+```
+
+Build the sample from `samples/quickstart`, for example `flutter build apk --debug` or `flutter build ios --debug --simulator`.
+
+## Code Style
+
+- Dart 3.3 or later and Flutter 3.19 or later, with full null safety. `Semantics.identifier`, which the SDK uses to expose flow fields, requires 3.19.
+- No external state management framework. State reaches widgets through `InheritedWidget` (`ThunderIDProvider.of(context)`).
+- All async methods return a `Future`. No `Stream`s in the public API.
+- Errors use the typed `ThunderIDErrorCode` enum and `IAMException`.
+- `ThunderIDConfig.allowInsecureConnections` lets a debug build reach a development server over
+  its self-signed certificate. It is forwarded to the native Android SDK, which relaxes
+  validation for loopback hosts only (`localhost`, `127.0.0.1`, `::1`, `10.0.2.2`) and rejects
+  the configuration outright for anything else. iOS achieves the same through an
+  `NSAppTransportSecurity` exemption at the app level, so the flag is a no-op there.
+- Minimum tap targets of 44 by 44 logical pixels, and a `Semantics` label on every widget.
+- Native code: Swift 5.9 with `@MainActor` for UI-thread safety on iOS, Kotlin on JVM 17 with coroutines on Android.
+
+`flutter analyze` gates CI and must report zero issues. The rules that catch people most often are trailing commas on multi-line argument lists, `const` constructors wherever possible, single-quoted strings, explicit return types, and imports sorted `dart:` then `package:` then relative.
+
+## Vendor Naming
+
+The SDK is white-labelable through `ThunderIDConfig.vendor`. Do not hardcode `thunderid` in a runtime name that override should control, such as a platform-channel storage key or a log tag. Because this package delegates to the native SDKs, a vendor-scoped value may need bridging across the method channel rather than resolving in Dart.
+
+Entry point names such as `thunderid_client.dart` and `ThunderIDClient` are a fixed identity and keep the name.
+
+## Next Steps
+
+- [Testing](../testing)

--- a/docs/community/contributing/contributing-code/sdk-development/flutter/testing.mdx
+++ b/docs/community/contributing/contributing-code/sdk-development/flutter/testing.mdx
@@ -1,0 +1,172 @@
+---
+title: Flutter SDK Testing
+docType: community
+description: "How to run and write the unit tests and the Maestro end-to-end suite for the {{ProductName}} Flutter SDK."
+sidebar_position: 2
+hide_table_of_contents: false
+---
+
+# Testing
+
+## Unit Tests
+
+```bash
+flutter test
+```
+
+Unit tests live in `test/` and use `flutter_test` with `mockito`. Because the Dart layer delegates to the native SDKs over a `MethodChannel`, these tests mock the channel: they cover the Dart client, models, and widgets, not the native implementations.
+
+## End-to-end Testing
+
+Unit tests mock the channel, so they cannot catch the failures that matter most to someone integrating the SDK: a flow step the SDK renders but cannot submit, a field the server renames, or a bridge that drops an argument on the way to the native SDK.
+
+The end-to-end suite closes that gap with [Maestro](https://maestro.mobile.dev), which drives the Quickstart sample the way a person would, against a server that is actually running. It signs a user in, signs them out, registers a new account, and signs in as that account. Because it exercises the real bridge, it is the only layer that tests the Dart and native halves together.
+
+Maestro is used rather than `integration_test` because the sign-in and sign-up forms are not static widgets. The server returns a flow definition and the SDK renders it, and the iOS and Android SDKs tag the resulting fields identically, so one set of selectors works across all three platforms.
+
+```text
+tests/e2e/
+  flows/                       Maestro flows, the tests themselves
+    config.yaml                limits test entry points to the top level
+    signin.yaml
+    signup.yaml
+    subflows/                  shared building blocks, not run on their own
+  run-e2e.sh                   the whole run on iOS: server, provisioning, build, Maestro
+  run-e2e.ps1                  the same on Android, for contributors on Windows
+  thunderid-config.yaml        the test application, declaratively
+```
+
+### Configure and Run
+
+Install [Maestro](https://maestro.mobile.dev/getting-started/installing-maestro). `run-e2e.sh` boots an iOS Simulator itself if none is running; `run-e2e.ps1` needs a running Android emulator, since it does not boot one for you.
+
+:::note[Choosing a platform]
+`run-e2e.sh` drives an **iOS Simulator** and needs a Mac. `run-e2e.ps1` drives an **Android
+emulator** and is the path for contributors on Windows.
+
+Both reach the local server over its self-signed certificate, by different routes: the iOS target
+carries an `NSAllowsArbitraryLoads` exemption, while Android relies on
+`ThunderIDConfig.allowInsecureConnections`, which the sample enables for debug builds only and
+the native SDK honours for loopback hosts only. `NSAllowsArbitraryLoads` disables ATS globally
+rather than trusting only the E2E certificate; it is a testing-only convenience for this sample
+and must not be carried into a production target.
+:::
+
+One script does the whole run: it downloads and starts a server, provisions the test
+application and user, configures and installs the sample, then drives it with Maestro.
+
+```bash
+cd tests/e2e
+./run-e2e.sh
+```
+
+Every stage is idempotent, so re-running is the normal way to iterate. A server already serving
+on `:8090` is reused rather than restarted, which matters because all three mobile suites bind
+that port. Skip the stages you do not need, and pass a flow path to run just one:
+
+```bash
+./run-e2e.sh --skip-server --skip-build
+./run-e2e.sh flows/signin.yaml
+```
+
+Provisioning creates one application and one user:
+
+| Resource | Value |
+|----------|-------|
+| Application | `019e5b10-1001-7a2b-9c3d-4e5f60718293` |
+| User | `e2e_mobile_user` / `TestPassword@123` |
+
+Set `THUNDERID_VERSION` to pin a specific server release instead of taking the latest:
+
+```bash
+THUNDERID_VERSION=1.0.1 ./run-e2e.sh
+```
+
+Rebuild and reinstall the sample after changing SDK source. Maestro drives the installed binary, so an edited SDK that has not been reinstalled still tests the old code.
+
+### Writing Tests
+
+A flow is a YAML file: a header naming the application under test, then a list of commands after the `---` separator.
+
+```yaml
+appId: dev.thunderid.Quickstart
+name: Sign in and sign out
+tags:
+  - auth
+env:
+  E2E_USERNAME: e2e_mobile_user
+  E2E_PASSWORD: TestPassword@123
+---
+- launchApp:
+    clearState: true
+- tapOn: "Sign in"
+```
+
+Override any `env` value from the command line with `-e E2E_USERNAME=someone`.
+
+#### Targeting Fields and Buttons
+
+The SDK tags every flow-driven field and action. Target those identifiers rather than on-screen labels, which change with locale and theme:
+
+- Fields use the server's field identifier: `thunderid-field-username`
+- Actions use the action's ref: `thunderid-action-action_001`
+
+```yaml
+- tapOn:
+    id: "thunderid-field-username"
+- inputText: ${E2E_USERNAME}
+```
+
+:::warning
+A widget `Key` is internal to the Flutter tree and never reaches the platform accessibility tree, so Maestro cannot see it. `Semantics.identifier` is what maps to `resource-id` on Android and `accessibilityIdentifier` on iOS. Flow fields carry both: the key for widget tests, the identifier for external drivers. A widget given only a `Key` looks correct in source but cannot be targeted.
+
+The identifier resolves the field's server-side `identifier`, not its `ref`, which is what keeps selectors the same across all three SDKs. The `ref` remains the key used for form state and submission.
+:::
+
+Action refs differ per flow type. Authentication submits with `action_001`, while registration submits its credentials step with `action_credentials` and its attributes step with `action_schema_attrs`. Read the identifiers off a running application rather than guessing:
+
+```bash
+maestro hierarchy | grep -o 'thunderid-[a-z]*-[A-Za-z0-9_]*' | sort -u
+```
+
+#### Starting From a Known State
+
+Never assume a clean device. On iOS the native SDK stores tokens in the Keychain, which sits outside the application container and survives both `clearState: true` and reinstalling the application, so a previous run can leave the application signed in. Every flow starts by calling a shared subflow that signs out when a session is present:
+
+```yaml
+- launchApp:
+    clearState: true
+- runFlow: subflows/ensure-signed-out.yaml
+```
+
+Put anything used by more than one flow in `subflows/`. The `config.yaml` entry limits test discovery to the top level, so subflows are building blocks rather than tests that run on their own.
+
+#### Handling Interruptions
+
+Guard anything that appears only sometimes with a conditional subflow instead of an unconditional wait. iOS offers to save credentials after a password field is submitted, and whether it prompts depends on prior AutoFill state:
+
+```yaml
+- runFlow:
+    when:
+      visible: "Save Password?"
+    commands:
+      - tapOn: "Not Now"
+```
+
+An unconditional wait here passes on the machine where the dialog appears and fails everywhere else.
+
+#### Keeping Flows Independent
+
+Each flow leaves the application as it found it, signed out on the landing screen, so flows run in any order. Where a flow needs a unique value, generate one:
+
+```yaml
+- evalScript: ${output.username = 'e2e_signup_' + Date.now()}
+```
+
+Registering a user leaves that account behind on the target server. That is fine against a disposable CI instance; against a long-lived development server, expect the accounts to accumulate.
+
+Note that registration completes without establishing a session, so a sign-up flow ends on the landing screen. Signing in afterward with the credentials just registered is what proves the account works.
+
+## Continuous Integration
+
+`nightly.yml` runs the suite against the latest published server release at 02:30 UTC, and the `e2e` job in `pr-builder.yml` runs it on every pull request. Both call the same `run-e2e-suite.yml` reusable workflow, on a macOS runner so it can boot a Simulator. On failure it uploads Maestro's screenshots and recorded hierarchy alongside the server log, which is how you tell a real regression from a flake after the run is gone.

--- a/docs/community/contributing/contributing-code/sdk-development/ios/overview.mdx
+++ b/docs/community/contributing/contributing-code/sdk-development/ios/overview.mdx
@@ -1,0 +1,53 @@
+---
+title: iOS SDK Development
+docType: community
+description: "Repository layout, build commands, and code style for contributing to the {{ProductName}} iOS SDK."
+sidebar_position: 1
+hide_table_of_contents: false
+---
+
+# iOS SDK Development
+
+The iOS SDK lives in [ios-sdks](https://github.com/thunder-id/ios-sdks), a Swift package publishing two products.
+
+| Product | Purpose |
+|---------|---------|
+| `ThunderID` | Core SDK: HTTP, token management, auth flows, PKCE, storage |
+| `ThunderIDSwiftUI` | SwiftUI component library built on the core |
+
+```text
+Sources/ThunderID/          Core SDK (auth, token, http layers)
+Sources/ThunderIDSwiftUI/   SwiftUI component library
+Samples/Quickstart/         Demo app, not part of the SDK
+Tests/                      Unit tests
+Tests/e2e/                  End-to-end suite
+```
+
+## Commands
+
+```bash
+swift build
+swift test
+swiftlint lint --strict
+```
+
+Open `Samples/Quickstart/Package.swift` in Xcode to run the sample on a simulator or device.
+
+## Code Style
+
+- Swift 5.9 or later, targeting iOS 16 and macOS 13 as a minimum.
+- No third-party dependencies in `Sources/`. Only `Foundation`, `CryptoKit`, and `SwiftUI`.
+- Prefer `async`/`throws` over completion handlers.
+- Mark internal helpers `private` and expose only intentional API as `public`.
+
+`swiftlint lint --strict` gates CI, and every violation fails the build. The rules that catch people most often are a 120-character line limit, alphabetically sorted imports, `} else {` on one line, trailing closure syntax, and identifiers of at least three characters. Run it locally before opening a pull request.
+
+## Vendor Naming
+
+The SDK is white-labelable: a consuming app overrides the brand namespace through `ThunderIDConfig.vendor`. Do not hardcode `thunderid` in a runtime name that override should control, such as a Keychain service name or a log tag. Resolve it from `config.vendor` instead.
+
+An entry point whose purpose is to represent the SDK itself, such as `ThunderIDClient`, is a fixed identity and keeps the name.
+
+## Next Steps
+
+- [Testing](../testing)

--- a/docs/community/contributing/contributing-code/sdk-development/ios/testing.mdx
+++ b/docs/community/contributing/contributing-code/sdk-development/ios/testing.mdx
@@ -1,0 +1,168 @@
+---
+title: iOS SDK Testing
+docType: community
+description: "How to run and write the unit tests and the Maestro end-to-end suite for the {{ProductName}} iOS SDK."
+sidebar_position: 2
+hide_table_of_contents: false
+---
+
+# Testing
+
+## Unit Tests
+
+```bash
+swift test
+```
+
+Unit tests live in `Tests/ThunderIDTests` and `Tests/ThunderIDSwiftUITests`, split to match the two products. SwiftLint excludes `Tests`, so lint rules do not apply there.
+
+## End-to-end Testing
+
+Unit tests cover the SDK with the server stubbed out. They cannot catch the failures that matter most to someone integrating it: a flow step the SDK renders but cannot submit, a field the server renames, or an application whose configuration the SDK rejects at runtime.
+
+The end-to-end suite closes that gap with [Maestro](https://maestro.mobile.dev), which drives the Quickstart sample the way a person would, against a server that is actually running. It signs a user in, signs them out, registers a new account, and signs in as that account.
+
+Maestro is used rather than XCUITest because the sign-in and sign-up forms are not static native views. The server returns a flow definition and the SDK renders it, and the Android and Flutter SDKs tag the resulting fields identically, so one set of selectors works across all three platforms.
+
+```text
+Tests/e2e/
+  flows/                       Maestro flows, the tests themselves
+    config.yaml                limits test entry points to the top level
+    signin.yaml
+    signup.yaml
+    subflows/                  shared building blocks, not run on their own
+  run-e2e.sh                   the whole run: server, provisioning, build, Maestro
+  thunderid-config.yaml        the test application, declaratively
+```
+
+:::note
+This repository uses `Tests/e2e` rather than `tests/e2e`, matching the case of the existing `Tests` directory it lives under.
+:::
+
+### Configure and Run
+
+Install [Maestro](https://maestro.mobile.dev/getting-started/installing-maestro). `run-e2e.sh` boots an iOS Simulator itself if none is already running, so booting one first is optional, useful mainly when you want to pick a specific device.
+
+:::warning[macOS only]
+This suite builds the sample with Xcode and drives an iOS Simulator, so it cannot run on Windows
+or Linux, and there is no PowerShell counterpart to `run-e2e.sh`. Contributing to the iOS SDK
+requires a Mac. On Windows, contribute to the [Android SDK](../../android/overview) instead,
+whose suite has a `run-e2e.ps1`.
+:::
+
+One script does the whole run: it downloads and starts a server, provisions the test
+application and user, configures and installs the sample, then drives it with Maestro.
+
+```bash
+cd Tests/e2e
+./run-e2e.sh
+```
+
+Every stage is idempotent, so re-running is the normal way to iterate. A server already serving
+on `:8090` is reused rather than restarted, which matters because all three mobile suites bind
+that port. Skip the stages you do not need, and pass a flow path to run just one:
+
+```bash
+./run-e2e.sh --skip-server --skip-build
+./run-e2e.sh flows/signin.yaml
+```
+
+Provisioning creates one application and one user:
+
+| Resource | Value |
+|----------|-------|
+| Application | `019e5b10-1001-7a2b-9c3d-4e5f60718293` |
+| User | `e2e_mobile_user` / `TestPassword@123` |
+
+Set `THUNDERID_VERSION` to pin a specific server release instead of taking the latest:
+
+```bash
+THUNDERID_VERSION=1.0.1 ./run-e2e.sh
+```
+
+Rebuild and reinstall the sample after changing SDK source. Maestro drives the installed binary, so an edited SDK that has not been reinstalled still tests the old code.
+
+:::note
+The sample reaches a self-signed local server because its `Info.plist` carries an `NSAllowsArbitraryLoads` exemption, which disables ATS globally rather than trusting only the E2E certificate; it is a testing-only convenience for this sample and must not be carried into a production target. Passkeys and App Attest cannot be exercised here: passkeys need a real associated domain, and App Attest does not exist in the Simulator.
+:::
+
+### Writing Tests
+
+A flow is a YAML file: a header naming the application under test, then a list of commands after the `---` separator.
+
+```yaml
+appId: dev.thunderid.Quickstart
+name: Sign in and sign out
+tags:
+  - auth
+env:
+  E2E_USERNAME: e2e_mobile_user
+  E2E_PASSWORD: TestPassword@123
+---
+- launchApp:
+    clearState: true
+- tapOn: "Sign in"
+```
+
+Override any `env` value from the command line with `-e E2E_USERNAME=someone`.
+
+#### Targeting Fields and Buttons
+
+The SDK tags every flow-driven field and action with `.accessibilityIdentifier`, which reaches the accessibility tree directly. Target those identifiers rather than on-screen labels, which change with locale and theme:
+
+- Fields use the server's field identifier: `thunderid-field-username`
+- Actions use the action's ref: `thunderid-action-action_001`
+
+```yaml
+- tapOn:
+    id: "thunderid-field-username"
+- inputText: ${E2E_USERNAME}
+```
+
+Action refs differ per flow type. Authentication submits with `action_001`, while registration submits its credentials step with `action_credentials` and its attributes step with `action_schema_attrs`. Read the identifiers off a running application rather than guessing:
+
+```bash
+maestro hierarchy | grep -o 'thunderid-[a-z]*-[A-Za-z0-9_]*' | sort -u
+```
+
+#### Starting From a Known State
+
+Never assume a clean device. Tokens live in the Keychain, which sits outside the application container and survives both `clearState: true` and reinstalling the application, so a previous run can leave the application signed in. Every flow starts by calling a shared subflow that signs out when a session is present:
+
+```yaml
+- launchApp:
+    clearState: true
+- runFlow: subflows/ensure-signed-out.yaml
+```
+
+Put anything used by more than one flow in `subflows/`. The `config.yaml` entry limits test discovery to the top level, so subflows are building blocks rather than tests that run on their own.
+
+#### Handling Interruptions
+
+Guard anything that appears only sometimes with a conditional subflow instead of an unconditional wait. iOS offers to save credentials after a password field is submitted, and whether it prompts depends on prior AutoFill state:
+
+```yaml
+- runFlow:
+    when:
+      visible: "Save Password?"
+    commands:
+      - tapOn: "Not Now"
+```
+
+An unconditional wait here passes on the machine where the dialog appears and fails everywhere else.
+
+#### Keeping Flows Independent
+
+Each flow leaves the application as it found it, signed out on the landing screen, so flows run in any order. Where a flow needs a unique value, generate one:
+
+```yaml
+- evalScript: ${output.username = 'e2e_signup_' + Date.now()}
+```
+
+Registering a user leaves that account behind on the target server. That is fine against a disposable CI instance; against a long-lived development server, expect the accounts to accumulate.
+
+Note that registration completes without establishing a session, so a sign-up flow ends on the landing screen. Signing in afterward with the credentials just registered is what proves the account works.
+
+## Continuous Integration
+
+`nightly.yml` runs the suite against the latest published server release at 02:30 UTC, and the `e2e` job in `pr-builder.yml` runs it on every pull request. Both call the same `run-e2e-suite.yml` reusable workflow, which runs the same script you run locally, so the two cannot drift. On failure it uploads Maestro's screenshots and recorded hierarchy alongside the server log, which is how you tell a real regression from a flake after the run is gone.

--- a/docs/community/contributing/contributing-code/sdk-development/javascript/overview.mdx
+++ b/docs/community/contributing/contributing-code/sdk-development/javascript/overview.mdx
@@ -1,0 +1,77 @@
+---
+title: JavaScript SDK Development
+docType: community
+description: "Repository layout, package hierarchy, and build commands for contributing to the {{ProductName}} JavaScript SDKs."
+sidebar_position: 1
+hide_table_of_contents: false
+---
+
+# JavaScript SDK Development
+
+The JavaScript SDKs live in [javascript-sdks](https://github.com/thunder-id/javascript-sdks), a pnpm workspace managed with Turborepo. Every package publishes under the `@thunderid` scope.
+
+## Packages
+
+| Package | Purpose |
+|---------|---------|
+| `@thunderid/javascript` | Framework-agnostic core: auth flows, token management, i18n, utilities |
+| `@thunderid/browser` | Browser runtime: storage, session sync, WebAuthn |
+| `@thunderid/node` | Node runtime: cookies, server sessions |
+| `@thunderid/react` | React SDK |
+| `@thunderid/vue` | Vue SDK |
+| `@thunderid/nextjs` | Next.js SDK |
+| `@thunderid/nuxt` | Nuxt module |
+| `@thunderid/express` | Express SDK |
+| `@thunderid/react-router` | React Router integration |
+| `@thunderid/tanstack-router` | TanStack Router integration |
+
+They build on each other rather than standing alone. Each arrow points from a package to the ones built on top of it:
+
+```mermaid
+flowchart TD
+  javascript:::accent --> browser
+  javascript --> node
+  browser --> react
+  browser --> vue
+  react --> rr[react-router]
+  react --> tr[tanstack-router]
+  react --> nextjs
+  vue --> nuxt
+  node --> nextjs
+  node --> nuxt
+  node --> express
+```
+
+Put a shared helper as close to the root as it can go. A utility used by both React and Vue belongs in `browser`, or in `javascript` if it needs nothing from the browser, rather than being duplicated in each.
+
+## Commands
+
+Run these from the repository root:
+
+```bash
+pnpm install
+pnpm build
+pnpm test
+pnpm lint          # pnpm lint:fix to apply
+pnpm typecheck
+pnpm format:check  # pnpm format:fix to apply
+```
+
+Scope any of them to one package with a filter:
+
+```bash
+pnpm --filter @thunderid/react run build
+```
+
+Two other commands are worth knowing: `pnpm symlink` links packages for local development against another project, and `pnpm clean` clears build output.
+
+## Conventions
+
+- **Dependency versions are centralized.** `pnpm-workspace.yaml` holds a `catalog:` of pinned versions plus an `overrides` block of security pins. Add or bump a shared dependency there rather than in an individual package.
+- **Every source file carries a copyright header**, enforced by the `@thunderid/copyright-header` ESLint rule. Files under `samples/` are exempt.
+- **Do not hardcode the vendor name** in runtime keys such as storage keys or log tags. Resolve it with `getVendorPrefix(vendor)` so a consumer's `vendor` override applies.
+- Formatting comes from `@thunderid/prettier-config`. Run `pnpm format:fix` rather than hand-formatting.
+
+## Next Steps
+
+- [Testing](../testing)

--- a/docs/community/contributing/contributing-code/sdk-development/javascript/testing.mdx
+++ b/docs/community/contributing/contributing-code/sdk-development/javascript/testing.mdx
@@ -1,0 +1,117 @@
+---
+title: JavaScript SDK Testing
+docType: community
+description: "How to run and write the Vitest unit tests and the Playwright end-to-end suite for the {{ProductName}} JavaScript SDKs."
+sidebar_position: 2
+hide_table_of_contents: false
+---
+
+# Testing
+
+## Unit Tests
+
+Unit tests run on [Vitest](https://vitest.dev) and live beside the source they cover, in `src/**/__tests__/*.test.ts`. The Nuxt package is the exception, keeping its tests in `packages/nuxt/tests/unit`.
+
+```bash
+pnpm test                                  # every package
+pnpm --filter @thunderid/react test        # one package
+```
+
+Packages that render components (`browser`, `react`, `react-router`, `tanstack-router`) also expose `test:browser`, which runs the same specs in a real browser environment.
+
+## End-to-end Testing
+
+The end-to-end suite lives in `tests/e2e` and runs on [Playwright](https://playwright.dev). It drives the sample apps in a real browser against a real <ProductName /> server, covering what unit tests cannot: the redirect handoff to Gate, cookie and session behaviour across a reload, and each framework integration wiring the core SDK up correctly.
+
+Six sample apps are exercised, each on its own port:
+
+| Sample | Port |
+|--------|------|
+| browser | 5173 |
+| react | 5174 |
+| vue | 5175 |
+| express | 3000 |
+| nextjs | 3001 |
+| nuxt | 3002 |
+
+The `samples/node/quickstart` app has no UI and is spawned directly by its own spec.
+
+### Configure and Run
+
+You need `curl`, `jq`, `unzip`, `pnpm`, and `lsof` on your PATH. One script does everything:
+
+```bash
+cd tests/e2e
+./run-e2e.sh
+```
+
+Arguments pass through to Playwright, so run a single spec with:
+
+```bash
+./run-e2e.sh tests/react-quickstart/sign-in-out.spec.ts
+```
+
+The script owns the whole lifecycle. It downloads and starts a server, mints an admin token, imports the test applications, writes each sample's `.env`, starts all six apps, runs the tests, then stops the apps and restores any `.env` it replaced.
+
+:::note
+`run-e2e.sh` aborts if anything already answers on `https://localhost:8090`. Stop any server you started by hand before running it.
+:::
+
+Set `THUNDERID_VERSION` to pin a specific server release instead of taking the latest:
+
+```bash
+THUNDERID_VERSION=1.0.1 ./run-e2e.sh
+```
+
+Configuration comes from `defaults.env`, copied to `.env` on the first run. Values in `.env` win, and `defaults.env` fills the gaps:
+
+| Variable | Default |
+|----------|---------|
+| `SERVER_URL` | `https://localhost:8090` |
+| `ADMIN_USERNAME` / `ADMIN_PASSWORD` | `admin` / `admin` |
+| `TEST_USER_USERNAME` | `e2e-test-user` |
+| `TEST_USER_PASSWORD` | `E2ePassword@123` |
+| `BROWSER_APP_URL` | `http://localhost:5173` |
+| `REACT_APP_URL` | `http://localhost:5174` |
+| `VUE_APP_URL` | `http://localhost:5175` |
+| `EXPRESS_APP_URL` | `http://localhost:3000` |
+| `NEXTJS_APP_URL` | `http://localhost:3001` |
+| `NUXT_APP_URL` | `http://localhost:3002` |
+
+`global-setup.ts` fails the run and lists anything missing, so a partial `.env` surfaces immediately rather than midway through a spec.
+
+Once a run has finished, `pnpm report` opens the HTML report and `pnpm ui` opens Playwright's interactive mode against an already-running server.
+
+### Writing Tests
+
+Applications are declared, not created by hand. `thunderid-config/sample-apps.yaml` holds one entry per sample with a fixed application ID, imported through `/import` with `upsert` enabled. Add a sample by adding an entry there rather than clicking through the Console, so every contributor and CI provision the same thing.
+
+The test user is different: `global-setup.ts` creates it through the API before the run and `global-teardown.ts` deletes it afterward. Teardown fails loudly if the delete does not succeed, so a leaked user surfaces as a failure rather than silently accumulating.
+
+Tests use the page object model. Shared page classes live in `pages/`, and Playwright fixtures in `fixtures/sample-apps/` expose one page object per sample. A spec asks for the fixture it needs and never constructs a page itself:
+
+```ts
+test('TC001: signs in with valid credentials', async ({reactQuickstartPage}) => {
+  await reactQuickstartPage.goto(appUrl);
+  await reactQuickstartPage.verifyHomePageLoaded();
+  await reactQuickstartPage.clickSignInButton();
+  await reactQuickstartPage.verifyLoginPageLoaded();
+  await reactQuickstartPage.login(username, password);
+  await reactQuickstartPage.verifyLoggedIn();
+});
+```
+
+Specs are grouped one directory per sample under `tests/`, and each test name carries a `TCnnn:` identifier.
+
+Put assertions about the login screen in the shared `gate-login.page.ts`, since every sample redirects to the same Gate DOM. The React, Vue, Next.js, and Nuxt samples share `thunderid-web-sample.page.ts` because they render the same markup; only the browser and Express samples need their own page objects.
+
+#### Things to Know
+
+- **The server uses a self-signed certificate.** Playwright sets `ignoreHTTPSErrors`, and direct API calls go through an undici agent configured to accept it. A new HTTP call made outside those helpers fails certificate validation.
+- **There is no Playwright `webServer` block.** One backend and six sample apps are shared across the run, so the script starts them rather than Playwright.
+- **Do not run a sample's own `prepare-dev.cjs`.** It rewrites `workspace:*` dependencies to `latest`, which takes the sample off your local build.
+- Cleanup frees ports 8090, 5173-5175, and 3000-3002, and removes the downloaded server. A run interrupted with Ctrl+C may leave a port bound; rerun the script and it clears them.
+
+## Continuous Integration
+
+`pr-builder.yml` runs on every pull request: an audit, dependency review, a build-lint-test job, and the end-to-end suite through the `run-e2e-suite` composite action. `e2e-nightly.yml` runs the same suite on a schedule at 18:30 UTC and uploads its report as an artifact.

--- a/docs/community/contributing/contributing-code/sdk-development/overview.mdx
+++ b/docs/community/contributing/contributing-code/sdk-development/overview.mdx
@@ -1,33 +1,40 @@
 ---
 title: Overview
 docType: community
-description: "Overview of the {{ProductName}} SDKs and how the product integrates with them."
+description: "Overview of the {{ProductName}} SDKs, where each one lives, and how the product consumes them."
 sidebar_position: 1
 hide_table_of_contents: false
 ---
 
 # SDK Development
 
-<ProductName /> publishes client SDKs under the [thunder-id](https://github.com/thunder-id) GitHub organization. Each SDK targets a different language or framework and provides authentication and identity management capabilities for applications built on <ProductName />.
+<ProductName /> publishes client SDKs from its [GitHub organization](https://github.com/thunder-id). Each repository groups the SDKs for one language or platform, so a single repository can publish several packages.
 
 ## Available SDKs
 
-| SDK | Repository | Description |
-|-----|------------|-------------|
-| JavaScript | [thunderid-sdk-javascript](https://github.com/thunder-id/thunderid-sdk-javascript) | Core JavaScript/TypeScript SDK |
-| React | [thunderid-sdk-react](https://github.com/thunder-id/thunderid-sdk-react) | React hooks and components |
-| React Router | [thunderid-sdk-react-router](https://github.com/thunder-id/thunderid-sdk-react-router) | React Router integration |
-| iOS | [thunderid-sdk-ios](https://github.com/thunder-id/thunderid-sdk-ios) | Native iOS SDK |
-| Android | [thunderid-sdk-android](https://github.com/thunder-id/thunderid-sdk-android) | Native Android SDK |
-| Flutter | [thunderid-sdk-flutter](https://github.com/thunder-id/thunderid-sdk-flutter) | Flutter SDK |
+| SDK | Repository | Contents |
+|-----|------------|----------|
+| JavaScript | [javascript-sdks](https://github.com/thunder-id/javascript-sdks) | The `@thunderid/*` packages: a framework-agnostic core, browser and Node runtimes, and integrations for React, Vue, Next.js, Nuxt, Express, React Router, and TanStack Router |
+| iOS | [ios-sdks](https://github.com/thunder-id/ios-sdks) | The `ThunderID` Swift SDK and the `ThunderIDSwiftUI` component library |
+| Android | [android-sdks](https://github.com/thunder-id/android-sdks) | The `dev.thunderid.android` Kotlin SDK and the `dev.thunderid.compose` Jetpack Compose component library |
+| Flutter | [flutter-sdks](https://github.com/thunder-id/flutter-sdks) | The `thunderid_flutter` plugin, bridging to the native iOS and Android SDKs |
 
-Visit the [thunder-id](https://github.com/thunder-id) organization for the full list of repositories.
+Each repository ships a Quickstart sample app that exercises the full authentication lifecycle. The samples are what the end-to-end suites drive, so they are the fastest way to see an SDK working against a live server.
 
 ## How the Product Uses the SDKs
 
-The <ProductName /> product itself consumes two SDKs:
+The <ProductName /> frontend consumes two of the JavaScript packages:
 
-- **React SDK**: provides the core authentication context, hooks (e.g. `useThunderID`), and identity state management used throughout the Gate and Console frontends.
-- **React Router SDK**: builds on the React SDK to add route-level guards and redirect helpers that protect pages requiring an authenticated session.
+- **`@thunderid/react`** provides the authentication context, hooks, and identity state used throughout the Gate and Console apps.
+- **`@thunderid/react-router`** builds on it to add route-level guards and redirect helpers for pages that require a session.
 
-Both SDKs are consumed as published npm packages in normal builds. Clone the SDK repositories only when you need to develop or debug the SDK itself, or test the product against unreleased SDK changes.
+Both are consumed as published npm packages in a normal build. Clone an SDK repository when you need to develop or debug the SDK itself, or to test the product against unreleased SDK changes.
+
+## Contributing to an SDK
+
+Each SDK has its own development and testing guide:
+
+- [JavaScript SDK Development](../javascript/overview)
+- [iOS SDK Development](../ios/overview)
+- [Android SDK Development](../android/overview)
+- [Flutter SDK Development](../flutter/overview)

--- a/docs/content/sdks/android/guides/try-the-sample-app.mdx
+++ b/docs/content/sdks/android/guides/try-the-sample-app.mdx
@@ -1,0 +1,103 @@
+---
+title: Try the Android Sample App
+docType: guide
+description: Run the {{ProductName}} Android sample app to see the full authentication lifecycle end to end.
+---
+
+# Try the Android Sample App
+
+The SDK repository ships a sample app in
+[`samples/quickstart`](https://github.com/thunder-id/android-sdks/tree/main/samples/quickstart)
+that exercises the full authentication lifecycle end to end: sign-in, sign-up, and sign-out via
+the SDK's app-native Flow Execution.
+
+<SdkQuickstartDownload packageId="android" icon={<AndroidLogo size={22} />} />
+
+## Prerequisites
+
+- Android Studio 2022.3+
+- A running <ProductName /> instance
+
+## Prepare the Android Sample
+
+```bash
+cd samples/quickstart
+cp config.properties.example config.properties
+```
+
+## Configure the Android Sample
+
+:::note
+This sample uses app-native authentication (Flow Execution API), so only the base URL and
+application ID are required, no OAuth2 client ID or redirect URIs.
+:::
+
+| Variable | Description |
+|----------|-------------|
+| `THUNDERID_BASE_URL` | Base URL of your <ProductName /> server (HTTPS) |
+| `THUNDERID_APPLICATION_ID` | Application UUID from <ProductName /> console |
+
+`config.properties` is gitignored. Never commit real credentials.
+
+:::note
+If your <ProductName /> server is running on `localhost`, don't use `localhost` in `THUNDERID_BASE_URL`
+directly:
+- **Emulator**: use `https://10.0.2.2:8090`, the emulator's alias for your host machine's loopback.
+- **Physical device**: run `adb reverse tcp:8090 tcp:8090` to forward the port over USB and keep
+  using `https://localhost:8090`, or point the URL at your host machine's LAN IP.
+:::
+
+## Attestation via Google Play Integrity (optional)
+
+If the application enforces Google Play Integrity attestation, set
+`THUNDERID_ATTESTATION_ENABLED=true` and `THUNDERID_CLOUD_PROJECT_NUMBER` to the number (not the
+ID) of the Google Cloud project linked to your Play Console app, then rebuild. When enabled, the
+sample mints a token via `PlayIntegrityTokenProvider` (Play Integrity Standard API) and sends it
+with every native flow-initiate request.
+
+Testing this end-to-end requires:
+- The app uploaded to a Play Console listing (an internal testing track is enough) with your test
+  device's Google account added as a tester, so Play recognizes the package name and signing
+  certificate.
+- The Play Integrity API enabled on the linked Google Cloud project.
+- A release build signed with the certificate registered on the <ProductName /> application's
+  attestation config (`certificateSha256Digests`), a debug-signed APK will fail the
+  signing-identity check.
+
+## Passkeys (WebAuthn)
+
+Passkey registration/authentication via Jetpack Credential Manager
+(`CreatePublicKeyCredentialRequest`/`GetPublicKeyCredentialOption` in `PasskeyClient`) requires the
+server's passkey relying party (`rp.id`) to be a real HTTPS domain, not `localhost` or `10.0.2.2`.
+Android verifies the caller is allowed to use that `rp.id` via **Digital Asset Links**: the domain
+must serve `https://<domain>/.well-known/assetlinks.json` declaring this app's package name and
+signing certificate SHA-256 fingerprint(s) under `delegate_permission/common.get_login_creds`.
+Without this, Credential Manager rejects the ceremony.
+
+This sample ships `assetlinks.json.example` with a placeholder `sha256_cert_fingerprints` entry for
+the sample's `applicationId` (`dev.thunderid.Quickstart`). To exercise passkeys end-to-end:
+
+1. Rename/copy `assetlinks.json.example` to `assetlinks.json` and replace
+   `<YOUR_APP_SIGNING_CERT_SHA256_FINGERPRINT>` with the SHA-256 fingerprint of the signing
+   certificate for the build you'll test with (get it via
+   `keytool -list -v -keystore <your.keystore> -alias <alias>` or `./gradlew signingReport` for a
+   debug build).
+2. Host that file at `https://<your-thunderid-domain>/.well-known/assetlinks.json`, the domain
+   must serve valid HTTPS (self-signed certs will not work).
+3. Make sure the server's passkey `rp.id` matches that same domain, the SDK's `PasskeyClient`
+   passes whatever `rp.id`/relying-party options the server returns straight through to Credential
+   Manager.
+4. No `AndroidManifest.xml` change is required for this, unlike iOS's Associated Domains
+   entitlement, Digital Asset Links verification is purely a server-hosted file requirement and
+   does not need an App Links intent filter (this sample doesn't declare one).
+
+Exposing a local <ProductName /> instance under a real, HTTPS-reachable domain (e.g. via a tunnel) is
+left to you, this sample only wires up the template file/documentation, not the tunnel itself.
+
+## Run
+
+Open in Android Studio, sync Gradle, and run on an API 24+ emulator or device.
+
+## Next Steps
+
+- [Accessing Protected APIs](../accessing-protected-apis): Make authenticated API requests from an Android application using OkHttp with automatic bearer token injection

--- a/docs/content/sdks/android/overview.mdx
+++ b/docs/content/sdks/android/overview.mdx
@@ -16,6 +16,10 @@ The <ProductName /> Android SDK provides two libraries for integrating authentic
 
 Both libraries require a minimum SDK version of API 24 (Android 7.0).
 
+## Try the Sample App
+
+See the [Try the Android Sample App](../guides/try-the-sample-app) guide to run the sample app and see the full authentication lifecycle end to end.
+
 ## Installation
 
 <CodeGroup>

--- a/docs/content/sdks/android/sidebar.ts
+++ b/docs/content/sdks/android/sidebar.ts
@@ -82,6 +82,11 @@ const sidebar: SidebarsConfig = {
       items: [
         {
           type: 'doc',
+          id: 'sdks/android/guides/try-the-sample-app',
+          label: 'Try the Sample App',
+        },
+        {
+          type: 'doc',
           id: 'sdks/android/guides/accessing-protected-apis',
           label: 'Accessing Protected APIs',
         },

--- a/docs/content/sdks/flutter/guides/try-the-sample-app.mdx
+++ b/docs/content/sdks/flutter/guides/try-the-sample-app.mdx
@@ -1,0 +1,134 @@
+---
+title: Try the Flutter Sample App
+docType: guide
+description: Run the {{ProductName}} Flutter sample app to see the full authentication lifecycle end to end.
+---
+
+# Try the Flutter Sample App
+
+The SDK repository ships a sample app in
+[`samples/quickstart`](https://github.com/thunder-id/flutter-sdks/tree/main/samples/quickstart)
+that exercises the full authentication lifecycle end to end: sign-in, sign-up, and sign-out via
+the SDK's app-native Flow Execution, on both iOS and Android.
+
+<SdkQuickstartDownload packageId="flutter" icon={<FlutterLogo size={22} />} />
+
+## Prerequisites
+
+- Flutter 3.16+
+- A running <ProductName /> instance
+- iOS 16+ or Android API 26+
+
+## Prepare the Flutter Sample
+
+```bash
+cd samples/quickstart
+
+# 1. Copy and fill in your environment
+cp .env.example .env
+
+# 2. Install dependencies
+flutter pub get
+```
+
+## Configure the Flutter Sample
+
+:::note
+This sample uses app-native authentication (Flow Execution API), so only the base URL and
+application ID are required, no OAuth2 client ID or redirect URIs.
+:::
+
+| Variable | Description |
+|----------|-------------|
+| `THUNDERID_BASE_URL` | Base URL of your <ProductName /> server (HTTPS) |
+| `THUNDERID_APP_ID` | Application UUID from <ProductName /> console |
+| `THUNDERID_ATTESTATION_ENABLED` | `true` to send a platform attestation token on native flows |
+| `THUNDERID_CLOUD_PROJECT_NUMBER` | Google Cloud project number (Android Play Integrity) |
+
+`.env` is gitignored. Never commit real credentials.
+
+## Attestation via Google Play Integrity / Apple App Attest (optional)
+
+Set `THUNDERID_ATTESTATION_ENABLED=true` to send a platform attestation token on native
+sign-in/sign-up. The token is minted natively by the plugin, Apple App Attest on iOS,
+Google Play Integrity on Android.
+
+Requirements to test end-to-end:
+- **Android**: set `THUNDERID_CLOUD_PROJECT_NUMBER`, and publish the app to a Play Console
+  track linked to that Cloud project (Play Integrity needs a recognized package + signature).
+- **iOS**: a physical device and the **App Attest** capability on the `Runner` target (adds the
+  `com.apple.developer.devicecheck.appattest-environment` entitlement). App Attest does not work
+  in the simulator.
+- **Server**: the **Team ID** and **Bundle ID** registered on the <ProductName /> application's
+  attestation settings must match the ones the app is signed with. <ProductName /> derives the expected
+  App ID from `<TeamID>.<BundleID>` and rejects a token whose attested App ID differs.
+
+The plugin generates the App Attest challenge locally. <ProductName /> does not yet bind verification to
+a server-issued challenge, so this is sufficient to exercise the flow end to end; move to a
+server-issued challenge once that check lands.
+
+## Passkeys (WebAuthn)
+
+Passkey registration/authentication requires the server's passkey relying party (`rp.id`) to be a
+real HTTPS domain, not `localhost`, `127.0.0.1`, or `10.0.2.2`. Each platform verifies the calling
+app is allowed to use that `rp.id` differently, and this Flutter sample packages both a native iOS
+runner and a native Android app, so both verification mechanisms apply:
+
+**iOS, Associated Domains entitlement.** `ASAuthorizationPlatformPublicKeyCredentialProvider`
+requires the app to declare a `webcredentials:<domain>` Associated Domain, backed by a hosted
+`apple-app-site-association` file. Without this, `ASAuthorizationController` fails immediately with
+`Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004`.
+
+This sample ships `ios/Runner/Runner.entitlements` with a placeholder
+`webcredentials:your-thunderid-domain.example` entry, wired into `ios/Runner.xcodeproj` via
+`CODE_SIGN_ENTITLEMENTS`. To exercise passkeys end-to-end:
+
+1. Replace the placeholder domain in `ios/Runner/Runner.entitlements` with the domain your
+   <ProductName /> server is actually reachable at (must serve valid HTTPS, self-signed certs and
+   `localhost` will not work).
+2. Host an `apple-app-site-association` file at
+   `https://<that-domain>/.well-known/apple-app-site-association` declaring this app's Team ID and
+   bundle identifier (`dev.thunderid.Quickstart`) under `webcredentials.apps`.
+3. Make sure the server's passkey `rp.id` matches that same domain.
+4. Set a `DEVELOPMENT_TEAM` and enable the **Associated Domains** capability for the Runner target
+   in Xcode (Signing & Capabilities) so the entitlement is actually applied to the build.
+
+**Android, Digital Asset Links.** Android's Credential Manager requires the domain to serve
+`https://<domain>/.well-known/assetlinks.json` declaring this app's package name and signing
+certificate SHA-256 fingerprint(s) under `delegate_permission/common.get_login_creds`. Without this,
+Credential Manager rejects the ceremony.
+
+This sample ships `assetlinks.json.example` with a placeholder `sha256_cert_fingerprints` entry for
+the app's `applicationId` (`dev.thunderid.flutter_quickstart`). To exercise passkeys end-to-end:
+
+1. Rename/copy `assetlinks.json.example` to `assetlinks.json` and replace
+   `<YOUR_APP_SIGNING_CERT_SHA256_FINGERPRINT>` with the SHA-256 fingerprint of the signing
+   certificate for the build you'll test with (get it via
+   `keytool -list -v -keystore <your.keystore> -alias <alias>` or a Gradle `signingReport`).
+2. Host that file at `https://<your-thunderid-domain>/.well-known/assetlinks.json` (same domain as
+   the iOS setup above, and matching the server's `rp.id`).
+3. No `AndroidManifest.xml` change is required, Digital Asset Links verification is purely a
+   server-hosted file requirement, no App Links intent filter needed.
+
+Exposing a local <ProductName /> instance under a real, HTTPS-reachable domain (e.g. via a tunnel) is
+left to you, this sample only wires up the entitlement/template file/documentation on each
+platform, not the tunnel itself.
+
+## Run
+
+Open the project in your IDE, or open a terminal in the project directory:
+
+```bash
+# List available devices
+flutter devices
+
+# Launch a specific emulator
+flutter emulators --launch <emulator_id>
+
+# Run on a specific device
+flutter run -d <device_id>
+```
+
+## Next Steps
+
+- [Accessing Protected APIs](../accessing-protected-apis): Use <ProductName /> Flutter SDK access tokens to call your backend APIs

--- a/docs/content/sdks/flutter/overview.mdx
+++ b/docs/content/sdks/flutter/overview.mdx
@@ -15,6 +15,10 @@ The <ProductName /> Flutter SDK provides a single Dart package for integrating a
 
 The package targets Flutter 3.16+ and Dart 3.2+. All protocol operations (OAuth2/OIDC, PKCE, token validation, token refresh) are delegated to the native <ProductName /> iOS and Android SDKs via Flutter platform channels: no OAuth2/OIDC logic runs in Dart.
 
+## Try the Sample App
+
+See the [Try the Flutter Sample App](../guides/try-the-sample-app) guide to run the sample app and see the full authentication lifecycle end to end.
+
 ## Installation
 
 ```yaml title="pubspec.yaml"

--- a/docs/content/sdks/flutter/sidebar.ts
+++ b/docs/content/sdks/flutter/sidebar.ts
@@ -82,6 +82,11 @@ const sidebar: SidebarsConfig = {
       items: [
         {
           type: 'doc',
+          id: 'sdks/flutter/guides/try-the-sample-app',
+          label: 'Try the Sample App',
+        },
+        {
+          type: 'doc',
           id: 'sdks/flutter/guides/accessing-protected-apis',
           label: 'Accessing Protected APIs',
         },

--- a/docs/content/sdks/ios/guides/try-the-sample-app.mdx
+++ b/docs/content/sdks/ios/guides/try-the-sample-app.mdx
@@ -1,0 +1,90 @@
+---
+title: Try the iOS Sample App
+docType: guide
+description: Run the {{ProductName}} iOS sample app to see the full authentication lifecycle end to end.
+---
+
+# Try the iOS Sample App
+
+The SDK repository ships a sample app in
+[`Samples/Quickstart`](https://github.com/thunder-id/ios-sdks/tree/main/Samples/Quickstart) that
+exercises the full authentication lifecycle end to end: sign-in, sign-up, and sign-out via the
+SDK's app-native Flow Execution.
+
+<SdkQuickstartDownload packageId="ios" icon={<IOSLogo size={22} />} />
+
+## Prerequisites
+
+- Xcode 15+
+- A running <ProductName /> instance
+
+## Prepare the iOS Sample
+
+```bash
+cd Samples/Quickstart
+cp Config.plist.example Sources/Config.plist
+# Edit Sources/Config.plist with your {{ProductName}} base URL and application ID
+```
+
+:::note
+This sample uses app-native authentication (Flow Execution API), so only the base URL and
+application ID are required, no OAuth2 client ID or redirect URIs.
+:::
+
+| Variable | Description |
+|----------|-------------|
+| `THUNDERID_BASE_URL` | Base URL of your <ProductName /> server (HTTPS) |
+| `THUNDERID_APP_ID` | Application UUID from <ProductName /> console |
+
+`Sources/Config.plist` is gitignored. Never commit real credentials.
+
+## Attestation via Apple App Attest (optional)
+
+If the application enforces platform attestation, set `THUNDERID_ATTESTATION_ENABLED` to `true` in
+`Sources/Config.plist`, then rebuild. When enabled, the sample mints a token via
+`AppAttestTokenProvider` (Apple App Attest) and sends it with every native flow-initiate request.
+
+Testing this end-to-end requires:
+- A **physical device**, App Attest is unavailable in the simulator.
+- A signing team and the **App Attest capability** enabled on the target, so Xcode adds the
+  `com.apple.developer.devicecheck.appattest-environment` entitlement.
+- The **Team ID** and **Bundle ID** registered on the <ProductName /> application's attestation settings
+  to match the ones the app is signed with. <ProductName /> derives the expected App ID from
+  `<TeamID>.<BundleID>` and rejects a token whose attested App ID differs.
+
+The `Attestation-Token` header carries the base64-encoded App Attest attestation object exactly as
+`DCAppAttestService.attestKey` returns it, do not wrap it in a JSON envelope. The challenge should
+come from the server in production; this sample generates it locally to exercise the SDK hook.
+
+## Passkeys (WebAuthn)
+
+Passkey registration/authentication via `ASAuthorizationPlatformPublicKeyCredentialProvider`
+requires the app's relying party ID to be backed by a real **Associated Domain**, not `localhost`.
+Without this, `ASAuthorizationController` fails immediately with
+`Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004`.
+
+This sample ships `Sources/Quickstart.entitlements` with a placeholder
+`webcredentials:your-thunderid-domain.example` entry. To exercise passkeys end-to-end:
+
+1. Replace the placeholder domain in `Sources/Quickstart.entitlements` with the domain your
+   <ProductName /> server is actually reachable at (it must serve valid HTTPS, self-signed certs and
+   `localhost` will not work).
+2. Host an `apple-app-site-association` file at
+   `https://<that-domain>/.well-known/apple-app-site-association` declaring this app's Team ID and
+   `PRODUCT_BUNDLE_IDENTIFIER` (`dev.thunderid.Quickstart`) under `webcredentials.apps`.
+3. Make sure the server's passkey `rp.id` matches that same domain, the SDK
+   (`PasskeyAuthSession`) passes whatever `rp.id` the server returns straight through to
+   `ASAuthorizationPlatformPublicKeyCredentialProvider`.
+4. Set a `DEVELOPMENT_TEAM` and enable the **Associated Domains** capability for the target in
+   Xcode (Signing & Capabilities) so the entitlement is actually applied to the build.
+
+Exposing a local <ProductName /> instance under a real, HTTPS-reachable domain (e.g. via a tunnel) is
+left to you, this sample only wires up the entitlement/documentation, not the tunnel itself.
+
+## Run
+
+Open in Xcode via `Package.swift` and run on an iOS 16+ simulator or device.
+
+## Next Steps
+
+- [Accessing Protected APIs](../accessing-protected-apis): Make authenticated API requests from an iOS application using bearer tokens from the <ProductName /> SDK

--- a/docs/content/sdks/ios/overview.mdx
+++ b/docs/content/sdks/ios/overview.mdx
@@ -16,6 +16,10 @@ The <ProductName /> iOS SDK provides two Swift packages for integrating authenti
 
 Both packages target iOS 16+ and macOS 13+.
 
+## Try the Sample App
+
+See the [Try the iOS Sample App](../guides/try-the-sample-app) guide to run the sample app and see the full authentication lifecycle end to end.
+
 ## Installation
 
 <CodeGroup>

--- a/docs/content/sdks/ios/sidebar.ts
+++ b/docs/content/sdks/ios/sidebar.ts
@@ -82,6 +82,11 @@ const sidebar: SidebarsConfig = {
       items: [
         {
           type: 'doc',
+          id: 'sdks/ios/guides/try-the-sample-app',
+          label: 'Try the Sample App',
+        },
+        {
+          type: 'doc',
           id: 'sdks/ios/guides/accessing-protected-apis',
           label: 'Accessing Protected APIs',
         },

--- a/docs/sidebarsCommunity.ts
+++ b/docs/sidebarsCommunity.ts
@@ -131,6 +131,46 @@ const sidebars: SidebarsConfig = {
                   label: 'Overview',
                   key: 'sdk-overview',
                 },
+                {
+                  type: 'category',
+                  label: 'JavaScript SDK Development',
+                  collapsed: true,
+                  collapsible: true,
+                  items: [
+                    {type: 'doc', id: 'contributing/contributing-code/sdk-development/javascript/overview', label: 'Overview', key: 'js-sdk-overview'},
+                    {type: 'doc', id: 'contributing/contributing-code/sdk-development/javascript/testing', label: 'Testing', key: 'js-sdk-testing'},
+                  ],
+                },
+                {
+                  type: 'category',
+                  label: 'iOS SDK Development',
+                  collapsed: true,
+                  collapsible: true,
+                  items: [
+                    {type: 'doc', id: 'contributing/contributing-code/sdk-development/ios/overview', label: 'Overview', key: 'ios-sdk-overview'},
+                    {type: 'doc', id: 'contributing/contributing-code/sdk-development/ios/testing', label: 'Testing', key: 'ios-sdk-testing'},
+                  ],
+                },
+                {
+                  type: 'category',
+                  label: 'Android SDK Development',
+                  collapsed: true,
+                  collapsible: true,
+                  items: [
+                    {type: 'doc', id: 'contributing/contributing-code/sdk-development/android/overview', label: 'Overview', key: 'android-sdk-overview'},
+                    {type: 'doc', id: 'contributing/contributing-code/sdk-development/android/testing', label: 'Testing', key: 'android-sdk-testing'},
+                  ],
+                },
+                {
+                  type: 'category',
+                  label: 'Flutter SDK Development',
+                  collapsed: true,
+                  collapsible: true,
+                  items: [
+                    {type: 'doc', id: 'contributing/contributing-code/sdk-development/flutter/overview', label: 'Overview', key: 'flutter-sdk-overview'},
+                    {type: 'doc', id: 'contributing/contributing-code/sdk-development/flutter/testing', label: 'Testing', key: 'flutter-sdk-testing'},
+                  ],
+                },
               ],
             },
             {

--- a/docs/src/components/SdkQuickstartDownload.tsx
+++ b/docs/src/components/SdkQuickstartDownload.tsx
@@ -166,7 +166,7 @@ export default function SdkQuickstartDownload({
     <Callout>
       <IconBadge aria-hidden="true">{icon}</IconBadge>
       <CardBody>
-        <CardTitle>Skip the setup, run the quickstart app instead</CardTitle>
+        <CardTitle>Skip the setup, run the sample app instead</CardTitle>
         <CardMeta>
           <span>{asset.sizeLabel}</span>
           {packageName && (

--- a/docs/versioned_docs/version-v1.0.x/sdks/android/guides/try-the-sample-app.mdx
+++ b/docs/versioned_docs/version-v1.0.x/sdks/android/guides/try-the-sample-app.mdx
@@ -1,0 +1,103 @@
+---
+title: Try the Android Sample App
+docType: guide
+description: Run the {{ProductName}} Android sample app to see the full authentication lifecycle end to end.
+---
+
+# Try the Android Sample App
+
+The SDK repository ships a sample app in
+[`samples/quickstart`](https://github.com/thunder-id/android-sdks/tree/main/samples/quickstart)
+that exercises the full authentication lifecycle end to end: sign-in, sign-up, and sign-out via
+the SDK's app-native Flow Execution.
+
+<SdkQuickstartDownload packageId="android" icon={<AndroidLogo size={22} />} />
+
+## Prerequisites
+
+- Android Studio 2022.3+
+- A running <ProductName /> instance
+
+## Prepare the Android Sample
+
+```bash
+cd samples/quickstart
+cp config.properties.example config.properties
+```
+
+## Configure the Android Sample
+
+:::note
+This sample uses app-native authentication (Flow Execution API), so only the base URL and
+application ID are required, no OAuth2 client ID or redirect URIs.
+:::
+
+| Variable | Description |
+|----------|-------------|
+| `THUNDERID_BASE_URL` | Base URL of your <ProductName /> server (HTTPS) |
+| `THUNDERID_APPLICATION_ID` | Application UUID from <ProductName /> console |
+
+`config.properties` is gitignored. Never commit real credentials.
+
+:::note
+If your <ProductName /> server is running on `localhost`, don't use `localhost` in `THUNDERID_BASE_URL`
+directly:
+- **Emulator**: use `https://10.0.2.2:8090`, the emulator's alias for your host machine's loopback.
+- **Physical device**: run `adb reverse tcp:8090 tcp:8090` to forward the port over USB and keep
+  using `https://localhost:8090`, or point the URL at your host machine's LAN IP.
+:::
+
+## Attestation via Google Play Integrity (optional)
+
+If the application enforces Google Play Integrity attestation, set
+`THUNDERID_ATTESTATION_ENABLED=true` and `THUNDERID_CLOUD_PROJECT_NUMBER` to the number (not the
+ID) of the Google Cloud project linked to your Play Console app, then rebuild. When enabled, the
+sample mints a token via `PlayIntegrityTokenProvider` (Play Integrity Standard API) and sends it
+with every native flow-initiate request.
+
+Testing this end-to-end requires:
+- The app uploaded to a Play Console listing (an internal testing track is enough) with your test
+  device's Google account added as a tester, so Play recognizes the package name and signing
+  certificate.
+- The Play Integrity API enabled on the linked Google Cloud project.
+- A release build signed with the certificate registered on the <ProductName /> application's
+  attestation config (`certificateSha256Digests`), a debug-signed APK will fail the
+  signing-identity check.
+
+## Passkeys (WebAuthn)
+
+Passkey registration/authentication via Jetpack Credential Manager
+(`CreatePublicKeyCredentialRequest`/`GetPublicKeyCredentialOption` in `PasskeyClient`) requires the
+server's passkey relying party (`rp.id`) to be a real HTTPS domain, not `localhost` or `10.0.2.2`.
+Android verifies the caller is allowed to use that `rp.id` via **Digital Asset Links**: the domain
+must serve `https://<domain>/.well-known/assetlinks.json` declaring this app's package name and
+signing certificate SHA-256 fingerprint(s) under `delegate_permission/common.get_login_creds`.
+Without this, Credential Manager rejects the ceremony.
+
+This sample ships `assetlinks.json.example` with a placeholder `sha256_cert_fingerprints` entry for
+the sample's `applicationId` (`dev.thunderid.Quickstart`). To exercise passkeys end-to-end:
+
+1. Rename/copy `assetlinks.json.example` to `assetlinks.json` and replace
+   `<YOUR_APP_SIGNING_CERT_SHA256_FINGERPRINT>` with the SHA-256 fingerprint of the signing
+   certificate for the build you'll test with (get it via
+   `keytool -list -v -keystore <your.keystore> -alias <alias>` or `./gradlew signingReport` for a
+   debug build).
+2. Host that file at `https://<your-thunderid-domain>/.well-known/assetlinks.json`, the domain
+   must serve valid HTTPS (self-signed certs will not work).
+3. Make sure the server's passkey `rp.id` matches that same domain, the SDK's `PasskeyClient`
+   passes whatever `rp.id`/relying-party options the server returns straight through to Credential
+   Manager.
+4. No `AndroidManifest.xml` change is required for this, unlike iOS's Associated Domains
+   entitlement, Digital Asset Links verification is purely a server-hosted file requirement and
+   does not need an App Links intent filter (this sample doesn't declare one).
+
+Exposing a local <ProductName /> instance under a real, HTTPS-reachable domain (e.g. via a tunnel) is
+left to you, this sample only wires up the template file/documentation, not the tunnel itself.
+
+## Run
+
+Open in Android Studio, sync Gradle, and run on an API 24+ emulator or device.
+
+## Next Steps
+
+- [Accessing Protected APIs](../accessing-protected-apis): Make authenticated API requests from an Android application using OkHttp with automatic bearer token injection

--- a/docs/versioned_docs/version-v1.0.x/sdks/android/overview.mdx
+++ b/docs/versioned_docs/version-v1.0.x/sdks/android/overview.mdx
@@ -16,6 +16,10 @@ The <ProductName /> Android SDK provides two libraries for integrating authentic
 
 Both libraries require a minimum SDK version of API 24 (Android 7.0).
 
+## Try the Sample App
+
+See the [Try the Android Sample App](../guides/try-the-sample-app) guide to run the sample app and see the full authentication lifecycle end to end.
+
 ## Installation
 
 <CodeGroup>

--- a/docs/versioned_docs/version-v1.0.x/sdks/flutter/guides/try-the-sample-app.mdx
+++ b/docs/versioned_docs/version-v1.0.x/sdks/flutter/guides/try-the-sample-app.mdx
@@ -1,0 +1,134 @@
+---
+title: Try the Flutter Sample App
+docType: guide
+description: Run the {{ProductName}} Flutter sample app to see the full authentication lifecycle end to end.
+---
+
+# Try the Flutter Sample App
+
+The SDK repository ships a sample app in
+[`samples/quickstart`](https://github.com/thunder-id/flutter-sdks/tree/main/samples/quickstart)
+that exercises the full authentication lifecycle end to end: sign-in, sign-up, and sign-out via
+the SDK's app-native Flow Execution, on both iOS and Android.
+
+<SdkQuickstartDownload packageId="flutter" icon={<FlutterLogo size={22} />} />
+
+## Prerequisites
+
+- Flutter 3.16+
+- A running <ProductName /> instance
+- iOS 16+ or Android API 26+
+
+## Prepare the Flutter Sample
+
+```bash
+cd samples/quickstart
+
+# 1. Copy and fill in your environment
+cp .env.example .env
+
+# 2. Install dependencies
+flutter pub get
+```
+
+## Configure the Flutter Sample
+
+:::note
+This sample uses app-native authentication (Flow Execution API), so only the base URL and
+application ID are required, no OAuth2 client ID or redirect URIs.
+:::
+
+| Variable | Description |
+|----------|-------------|
+| `THUNDERID_BASE_URL` | Base URL of your <ProductName /> server (HTTPS) |
+| `THUNDERID_APP_ID` | Application UUID from <ProductName /> console |
+| `THUNDERID_ATTESTATION_ENABLED` | `true` to send a platform attestation token on native flows |
+| `THUNDERID_CLOUD_PROJECT_NUMBER` | Google Cloud project number (Android Play Integrity) |
+
+`.env` is gitignored. Never commit real credentials.
+
+## Attestation via Google Play Integrity / Apple App Attest (optional)
+
+Set `THUNDERID_ATTESTATION_ENABLED=true` to send a platform attestation token on native
+sign-in/sign-up. The token is minted natively by the plugin, Apple App Attest on iOS,
+Google Play Integrity on Android.
+
+Requirements to test end-to-end:
+- **Android**: set `THUNDERID_CLOUD_PROJECT_NUMBER`, and publish the app to a Play Console
+  track linked to that Cloud project (Play Integrity needs a recognized package + signature).
+- **iOS**: a physical device and the **App Attest** capability on the `Runner` target (adds the
+  `com.apple.developer.devicecheck.appattest-environment` entitlement). App Attest does not work
+  in the simulator.
+- **Server**: the **Team ID** and **Bundle ID** registered on the <ProductName /> application's
+  attestation settings must match the ones the app is signed with. <ProductName /> derives the expected
+  App ID from `<TeamID>.<BundleID>` and rejects a token whose attested App ID differs.
+
+The plugin generates the App Attest challenge locally. <ProductName /> does not yet bind verification to
+a server-issued challenge, so this is sufficient to exercise the flow end to end; move to a
+server-issued challenge once that check lands.
+
+## Passkeys (WebAuthn)
+
+Passkey registration/authentication requires the server's passkey relying party (`rp.id`) to be a
+real HTTPS domain, not `localhost`, `127.0.0.1`, or `10.0.2.2`. Each platform verifies the calling
+app is allowed to use that `rp.id` differently, and this Flutter sample packages both a native iOS
+runner and a native Android app, so both verification mechanisms apply:
+
+**iOS, Associated Domains entitlement.** `ASAuthorizationPlatformPublicKeyCredentialProvider`
+requires the app to declare a `webcredentials:<domain>` Associated Domain, backed by a hosted
+`apple-app-site-association` file. Without this, `ASAuthorizationController` fails immediately with
+`Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004`.
+
+This sample ships `ios/Runner/Runner.entitlements` with a placeholder
+`webcredentials:your-thunderid-domain.example` entry, wired into `ios/Runner.xcodeproj` via
+`CODE_SIGN_ENTITLEMENTS`. To exercise passkeys end-to-end:
+
+1. Replace the placeholder domain in `ios/Runner/Runner.entitlements` with the domain your
+   <ProductName /> server is actually reachable at (must serve valid HTTPS, self-signed certs and
+   `localhost` will not work).
+2. Host an `apple-app-site-association` file at
+   `https://<that-domain>/.well-known/apple-app-site-association` declaring this app's Team ID and
+   bundle identifier (`dev.thunderid.Quickstart`) under `webcredentials.apps`.
+3. Make sure the server's passkey `rp.id` matches that same domain.
+4. Set a `DEVELOPMENT_TEAM` and enable the **Associated Domains** capability for the Runner target
+   in Xcode (Signing & Capabilities) so the entitlement is actually applied to the build.
+
+**Android, Digital Asset Links.** Android's Credential Manager requires the domain to serve
+`https://<domain>/.well-known/assetlinks.json` declaring this app's package name and signing
+certificate SHA-256 fingerprint(s) under `delegate_permission/common.get_login_creds`. Without this,
+Credential Manager rejects the ceremony.
+
+This sample ships `assetlinks.json.example` with a placeholder `sha256_cert_fingerprints` entry for
+the app's `applicationId` (`dev.thunderid.flutter_quickstart`). To exercise passkeys end-to-end:
+
+1. Rename/copy `assetlinks.json.example` to `assetlinks.json` and replace
+   `<YOUR_APP_SIGNING_CERT_SHA256_FINGERPRINT>` with the SHA-256 fingerprint of the signing
+   certificate for the build you'll test with (get it via
+   `keytool -list -v -keystore <your.keystore> -alias <alias>` or a Gradle `signingReport`).
+2. Host that file at `https://<your-thunderid-domain>/.well-known/assetlinks.json` (same domain as
+   the iOS setup above, and matching the server's `rp.id`).
+3. No `AndroidManifest.xml` change is required, Digital Asset Links verification is purely a
+   server-hosted file requirement, no App Links intent filter needed.
+
+Exposing a local <ProductName /> instance under a real, HTTPS-reachable domain (e.g. via a tunnel) is
+left to you, this sample only wires up the entitlement/template file/documentation on each
+platform, not the tunnel itself.
+
+## Run
+
+Open the project in your IDE, or open a terminal in the project directory:
+
+```bash
+# List available devices
+flutter devices
+
+# Launch a specific emulator
+flutter emulators --launch <emulator_id>
+
+# Run on a specific device
+flutter run -d <device_id>
+```
+
+## Next Steps
+
+- [Accessing Protected APIs](../accessing-protected-apis): Use <ProductName /> Flutter SDK access tokens to call your backend APIs

--- a/docs/versioned_docs/version-v1.0.x/sdks/flutter/overview.mdx
+++ b/docs/versioned_docs/version-v1.0.x/sdks/flutter/overview.mdx
@@ -15,6 +15,10 @@ The <ProductName /> Flutter SDK provides a single Dart package for integrating a
 
 The package targets Flutter 3.16+ and Dart 3.2+. All protocol operations (OAuth2/OIDC, PKCE, token validation, token refresh) are delegated to the native <ProductName /> iOS and Android SDKs via Flutter platform channels: no OAuth2/OIDC logic runs in Dart.
 
+## Try the Sample App
+
+See the [Try the Flutter Sample App](../guides/try-the-sample-app) guide to run the sample app and see the full authentication lifecycle end to end.
+
 ## Installation
 
 ```yaml title="pubspec.yaml"

--- a/docs/versioned_docs/version-v1.0.x/sdks/ios/guides/try-the-sample-app.mdx
+++ b/docs/versioned_docs/version-v1.0.x/sdks/ios/guides/try-the-sample-app.mdx
@@ -1,0 +1,90 @@
+---
+title: Try the iOS Sample App
+docType: guide
+description: Run the {{ProductName}} iOS sample app to see the full authentication lifecycle end to end.
+---
+
+# Try the iOS Sample App
+
+The SDK repository ships a sample app in
+[`Samples/Quickstart`](https://github.com/thunder-id/ios-sdks/tree/main/Samples/Quickstart) that
+exercises the full authentication lifecycle end to end: sign-in, sign-up, and sign-out via the
+SDK's app-native Flow Execution.
+
+<SdkQuickstartDownload packageId="ios" icon={<IOSLogo size={22} />} />
+
+## Prerequisites
+
+- Xcode 15+
+- A running <ProductName /> instance
+
+## Prepare the iOS Sample
+
+```bash
+cd Samples/Quickstart
+cp Config.plist.example Sources/Config.plist
+# Edit Sources/Config.plist with your {{ProductName}} base URL and application ID
+```
+
+:::note
+This sample uses app-native authentication (Flow Execution API), so only the base URL and
+application ID are required, no OAuth2 client ID or redirect URIs.
+:::
+
+| Variable | Description |
+|----------|-------------|
+| `THUNDERID_BASE_URL` | Base URL of your <ProductName /> server (HTTPS) |
+| `THUNDERID_APP_ID` | Application UUID from <ProductName /> console |
+
+`Sources/Config.plist` is gitignored. Never commit real credentials.
+
+## Attestation via Apple App Attest (optional)
+
+If the application enforces platform attestation, set `THUNDERID_ATTESTATION_ENABLED` to `true` in
+`Sources/Config.plist`, then rebuild. When enabled, the sample mints a token via
+`AppAttestTokenProvider` (Apple App Attest) and sends it with every native flow-initiate request.
+
+Testing this end-to-end requires:
+- A **physical device**, App Attest is unavailable in the simulator.
+- A signing team and the **App Attest capability** enabled on the target, so Xcode adds the
+  `com.apple.developer.devicecheck.appattest-environment` entitlement.
+- The **Team ID** and **Bundle ID** registered on the <ProductName /> application's attestation settings
+  to match the ones the app is signed with. <ProductName /> derives the expected App ID from
+  `<TeamID>.<BundleID>` and rejects a token whose attested App ID differs.
+
+The `Attestation-Token` header carries the base64-encoded App Attest attestation object exactly as
+`DCAppAttestService.attestKey` returns it, do not wrap it in a JSON envelope. The challenge should
+come from the server in production; this sample generates it locally to exercise the SDK hook.
+
+## Passkeys (WebAuthn)
+
+Passkey registration/authentication via `ASAuthorizationPlatformPublicKeyCredentialProvider`
+requires the app's relying party ID to be backed by a real **Associated Domain**, not `localhost`.
+Without this, `ASAuthorizationController` fails immediately with
+`Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004`.
+
+This sample ships `Sources/Quickstart.entitlements` with a placeholder
+`webcredentials:your-thunderid-domain.example` entry. To exercise passkeys end-to-end:
+
+1. Replace the placeholder domain in `Sources/Quickstart.entitlements` with the domain your
+   <ProductName /> server is actually reachable at (it must serve valid HTTPS, self-signed certs and
+   `localhost` will not work).
+2. Host an `apple-app-site-association` file at
+   `https://<that-domain>/.well-known/apple-app-site-association` declaring this app's Team ID and
+   `PRODUCT_BUNDLE_IDENTIFIER` (`dev.thunderid.Quickstart`) under `webcredentials.apps`.
+3. Make sure the server's passkey `rp.id` matches that same domain, the SDK
+   (`PasskeyAuthSession`) passes whatever `rp.id` the server returns straight through to
+   `ASAuthorizationPlatformPublicKeyCredentialProvider`.
+4. Set a `DEVELOPMENT_TEAM` and enable the **Associated Domains** capability for the target in
+   Xcode (Signing & Capabilities) so the entitlement is actually applied to the build.
+
+Exposing a local <ProductName /> instance under a real, HTTPS-reachable domain (e.g. via a tunnel) is
+left to you, this sample only wires up the entitlement/documentation, not the tunnel itself.
+
+## Run
+
+Open in Xcode via `Package.swift` and run on an iOS 16+ simulator or device.
+
+## Next Steps
+
+- [Accessing Protected APIs](../accessing-protected-apis): Make authenticated API requests from an iOS application using bearer tokens from the <ProductName /> SDK

--- a/docs/versioned_docs/version-v1.0.x/sdks/ios/overview.mdx
+++ b/docs/versioned_docs/version-v1.0.x/sdks/ios/overview.mdx
@@ -16,6 +16,10 @@ The <ProductName /> iOS SDK provides two Swift packages for integrating authenti
 
 Both packages target iOS 16+ and macOS 13+.
 
+## Try the Sample App
+
+See the [Try the iOS Sample App](../guides/try-the-sample-app) guide to run the sample app and see the full authentication lifecycle end to end.
+
 ## Installation
 
 <CodeGroup>

--- a/docs/versioned_sidebars/version-v1.0.x-sidebars.json
+++ b/docs/versioned_sidebars/version-v1.0.x-sidebars.json
@@ -2453,6 +2453,11 @@
       "items": [
         {
           "type": "doc",
+          "id": "sdks/ios/guides/try-the-sample-app",
+          "label": "Try the Sample App"
+        },
+        {
+          "type": "doc",
           "id": "sdks/ios/guides/accessing-protected-apis",
           "label": "Accessing Protected APIs"
         }
@@ -2537,6 +2542,11 @@
       "items": [
         {
           "type": "doc",
+          "id": "sdks/android/guides/try-the-sample-app",
+          "label": "Try the Sample App"
+        },
+        {
+          "type": "doc",
           "id": "sdks/android/guides/accessing-protected-apis",
           "label": "Accessing Protected APIs"
         }
@@ -2619,6 +2629,11 @@
       "collapsed": false,
       "className": "sidebar-section-icon-guides",
       "items": [
+        {
+          "type": "doc",
+          "id": "sdks/flutter/guides/try-the-sample-app",
+          "label": "Try the Sample App"
+        },
         {
           "type": "doc",
           "id": "sdks/flutter/guides/accessing-protected-apis",


### PR DESCRIPTION
### Purpose

The SDK Development section had a single Overview page, and its contents had drifted badly. It listed six repositories, `thunderid-sdk-javascript`, `thunderid-sdk-react`, `thunderid-sdk-react-router`, `thunderid-sdk-ios`, `thunderid-sdk-android` and `thunderid-sdk-flutter`, and every one of those links returns a 404. There was also nothing describing how to build, test, or contribute to any individual SDK.

This restructures the section per SDK and documents the new mobile end to end suites added under thunder-id/thunderid#5181.

### Approach

**Per-SDK layout.** Each of the four SDKs gets its own category with an Overview and a Testing page:

```
SDK Development
  Overview
  JavaScript SDK Development   Overview, Testing
  iOS SDK Development          Overview, Testing
  Android SDK Development      Overview, Testing
  Flutter SDK Development      Overview, Testing
```

Each Overview covers repository layout, packages or modules, build commands, and the conventions a contributor needs (lint rules that gate CI, vendor naming, dependency hierarchy). Each Testing page covers the unit tests and the end to end suite, split into how to configure and run it and how to write one.

**Corrected the repository table.** The four real repositories are `javascript-sdks`, `ios-sdks`, `android-sdks` and `flutter-sdks`. The JavaScript entry covers all ten `@thunderid/*` packages rather than implying one repository each. I also verified the claim about which SDKs the product itself consumes rather than carrying it over: Gate and Console both depend on `@thunderid/react` and `@thunderid/react-router`, so that section stands with the package names corrected.

**Corrected the sign-up description.** The mobile quickstart READMEs said the user "completes the flow and logs in", ending authenticated. Driving the flow directly showed that registration completes with `flowStatus: COMPLETE` and no assertion, so no session is established and the app returns to the landing screen. I confirmed this is intentional rather than a defect by reading the seeded flow graph: the `provisioning` node routes `onSuccess` to `end`, never to `call_authentication`.

**Content is verified, not assumed.** The mobile pages come from building and running those suites. The JavaScript page was researched against that repository directly and documents its real Playwright setup. Two things I deliberately left out because I could not confirm intent: the `build-lint-test` job in `javascript-sdks` appears to filter `packages/**` out of its lint and test runs, and its `e2e` job is described in comments as label gated but has no `if:` condition. Both may be deliberate or may be bugs, and neither seemed safe to state as fact in public documentation.

The dependency hierarchy on the JavaScript page is a Mermaid diagram rather than ASCII art, per the diagram guidance in the docs skill.

### Related Issues

- thunder-id/thunderid#5181

### Related PRs

- thunder-id/ios-sdks#21
- thunder-id/android-sdks#27
- thunder-id/flutter-sdks#31

### Checklist

- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
  - This PR is the documentation.
- [ ] Tests provided. (Add links if there are any)
  - [ ] Unit Tests
  - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
  - [ ] Breaking changes section filled.
  - [ ] `breaking change` label added.

### Security checks

- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

The credentials shown on the Testing pages belong to a throwaway account the suites create on a local development server. They are not secrets.

### Verification

`docs-lint.sh` reports 0 Vale errors, warnings and suggestions across all nine pages, and structural checks pass. `docusaurus build` exits 0 with no broken links or anchors on any of these pages. Both the current and the v1.0.x versioned copies are updated and verified identical, and every sidebar entry resolves to a real file in both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added SDK development and testing guides for JavaScript, iOS, Android, and Flutter.
  * Documented local build, lint, unit test, and end-to-end testing workflows.
  * Updated current and versioned SDK overviews to reflect the repository structure and contribution process.
  * Added sample app guides for Android, iOS, and Flutter, including setup, authentication flows, attestation, and passkey requirements.
  * Added dedicated SDK development sections and navigation links across current and versioned documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->