### PR TITLE
Fix: intersect consented attributes against requested set in getRequiredUserAttributes

### DIFF
--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -390,6 +390,16 @@ func (a *authAssertExecutor) getRequiredUserAttributes(ctx *providers.NodeContex
 	if _, consentRecorded := ctx.RuntimeData[common.RuntimeKeyConsentID]; consentRecorded {
 		// Get user attributes from consented attributes if consent was collected in this flow
 		if consentedAttrsStr, exists := ctx.RuntimeData[common.RuntimeKeyConsentedAttributes]; exists {
+			// Build the originally-requested attribute set (essential + optional) to intersect against.
+			// This mirrors the defense resolvePermissionsForClaim applies for permissions: the consented
+			// set is narrowed to only those attributes that were actually part of the original request,
+			// preventing over-disclosure when a ConsentProvider does not itself validate scope.
+			requestedAttrs := buildRequestedAttributesSet(ctx)
+			if requestedAttrs != "" {
+				logger.Debug(ctx.Context, "Consent recorded; intersecting consented attributes against requested set")
+				return intersectAttributeSpaceList(consentedAttrsStr, requestedAttrs)
+			}
+
 			logger.Debug(ctx.Context, "Consent recorded with approved attributes")
 			return strings.Fields(consentedAttrsStr)
 		}
@@ -664,4 +674,39 @@ func intersectPermissionSpaceList(a, b string) string {
 		}
 	}
 	return strings.Join(out, " ")
+}
+
+// intersectAttributeSpaceList returns the attributes present in both space-separated inputs,
+// preserving the order of `a`. Empty inputs are handled as empty sets.
+func intersectAttributeSpaceList(a, b string) []string {
+	if a == "" || b == "" {
+		return []string{}
+	}
+	allowed := make(map[string]bool)
+	for _, p := range strings.Fields(b) {
+		allowed[p] = true
+	}
+	out := make([]string, 0, len(allowed))
+	for _, p := range strings.Fields(a) {
+		if allowed[p] {
+			out = append(out, p)
+			delete(allowed, p)
+		}
+	}
+	return out
+}
+
+// buildRequestedAttributesSet builds the space-separated union of essential and optional
+// attributes from runtime data — the attribute set that was originally resolved for the
+// authorization request and presented to the consent prompt.
+func buildRequestedAttributesSet(ctx *providers.NodeContext) string {
+	essential, _ := ctx.RuntimeData[common.RuntimeKeyRequiredEssentialAttributes]
+	optional, _ := ctx.RuntimeData[common.RuntimeKeyRequiredOptionalAttributes]
+	if essential != "" && optional != "" {
+		return essential + " " + optional
+	}
+	if essential != "" {
+		return essential
+	}
+	return optional
 }

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -860,6 +860,147 @@ func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_ConsentR
 	assert.Equal(suite.T(), []string{"email", "name"}, result)
 }
 
+// --- Consent + requested-set intersection tests ---
+
+func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_Consented_IntersectsWithEssential() {
+	// Consent approved "email name phone" but only "email name" were requested (essential).
+	// Should return only the intersection: [email name].
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			common.RuntimeKeyConsentID:              "consent-123",
+			common.RuntimeKeyConsentedAttributes:    "email name phone",
+			common.RuntimeKeyRequiredEssentialAttributes: "email name",
+		},
+	}
+
+	result := suite.executor.getRequiredUserAttributes(ctx)
+
+	assert.Equal(suite.T(), []string{"email", "name"}, result)
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_Consented_IntersectsWithEssentialAndOptional() {
+	// Consent approved "email phone address" but only "email" (essential) + "phone" (optional) were
+	// requested. The extra "address" must be dropped.
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			common.RuntimeKeyConsentID:              "consent-123",
+			common.RuntimeKeyConsentedAttributes:    "email phone address",
+			common.RuntimeKeyRequiredEssentialAttributes: "email",
+			common.RuntimeKeyRequiredOptionalAttributes:  "phone",
+		},
+	}
+
+	result := suite.executor.getRequiredUserAttributes(ctx)
+
+	assert.Equal(suite.T(), []string{"email", "phone"}, result)
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_Consented_NoOverlapWithRequested() {
+	// Consent approved attributes that were not part of the original request at all.
+	// Intersection should be empty.
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			common.RuntimeKeyConsentID:              "consent-123",
+			common.RuntimeKeyConsentedAttributes:    "address ssn",
+			common.RuntimeKeyRequiredEssentialAttributes: "email",
+			common.RuntimeKeyRequiredOptionalAttributes:  "phone",
+		},
+	}
+
+	result := suite.executor.getRequiredUserAttributes(ctx)
+
+	assert.Empty(suite.T(), result)
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_Consented_SubsetOfRequested() {
+	// Consent approved a subset of what was requested — should pass through unchanged.
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			common.RuntimeKeyConsentID:              "consent-123",
+			common.RuntimeKeyConsentedAttributes:    "email",
+			common.RuntimeKeyRequiredEssentialAttributes: "email",
+			common.RuntimeKeyRequiredOptionalAttributes:  "phone name",
+		},
+	}
+
+	result := suite.executor.getRequiredUserAttributes(ctx)
+
+	assert.Equal(suite.T(), []string{"email"}, result)
+}
+
+// --- intersectAttributeSpaceList unit tests ---
+
+func (suite *AuthAssertExecutorTestSuite) TestIntersectAttributeSpaceList_BothEmpty() {
+	result := intersectAttributeSpaceList("", "")
+	assert.Empty(suite.T(), result)
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestIntersectAttributeSpaceList_AEmpty() {
+	result := intersectAttributeSpaceList("", "email name")
+	assert.Empty(suite.T(), result)
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestIntersectAttributeSpaceList_BEmpty() {
+	result := intersectAttributeSpaceList("email name", "")
+	assert.Empty(suite.T(), result)
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestIntersectAttributeSpaceList_PartialOverlap() {
+	result := intersectAttributeSpaceList("email name phone", "name address phone")
+	assert.Equal(suite.T(), []string{"name", "phone"}, result)
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestIntersectAttributeSpaceList_NoOverlap() {
+	result := intersectAttributeSpaceList("email name", "address ssn")
+	assert.Empty(suite.T(), result)
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestIntersectAttributeSpaceList_Identical() {
+	result := intersectAttributeSpaceList("email name", "email name")
+	assert.Equal(suite.T(), []string{"email", "name"}, result)
+}
+
+// --- buildRequestedAttributesSet unit tests ---
+
+func (suite *AuthAssertExecutorTestSuite) TestBuildRequestedAttributesSet_BothPresent() {
+	ctx := &providers.NodeContext{
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequiredEssentialAttributes: "email",
+			common.RuntimeKeyRequiredOptionalAttributes:  "phone name",
+		},
+	}
+	assert.Equal(suite.T(), "email phone name", buildRequestedAttributesSet(ctx))
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestBuildRequestedAttributesSet_EssentialOnly() {
+	ctx := &providers.NodeContext{
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequiredEssentialAttributes: "email",
+		},
+	}
+	assert.Equal(suite.T(), "email", buildRequestedAttributesSet(ctx))
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestBuildRequestedAttributesSet_OptionalOnly() {
+	ctx := &providers.NodeContext{
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequiredOptionalAttributes: "phone",
+		},
+	}
+	assert.Equal(suite.T(), "phone", buildRequestedAttributesSet(ctx))
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestBuildRequestedAttributesSet_NeitherPresent() {
+	ctx := &providers.NodeContext{
+		RuntimeData: map[string]string{},
+	}
+	assert.Equal(suite.T(), "", buildRequestedAttributesSet(ctx))
+}
+
 func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_RuntimeEssentialOnly() {
 	ctx := &providers.NodeContext{
 		ExecutionID: "flow-123",
@@ -964,6 +1105,57 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConsentedAttributes_Fi
 			hasEmail := claims["email"] == testEmail
 			hasName := claims["name"] == testNameValue
 			return hasEmail && hasName && !hasPhone
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConsentedAttributes_IntersectsAgainstRequested() {
+	// Consent approved "email name address" but only "email" (essential) + "name" (optional)
+	// were requested. The intersection must drop "address" and only assert email + name.
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		EntityID:    "app-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		AuthUser:    newTestAuthenticatedAuthUser(),
+		RuntimeData: map[string]string{
+			common.RuntimeKeyConsentID:              "consent-123",
+			common.RuntimeKeyConsentedAttributes:    "email name address",
+			common.RuntimeKeyRequiredEssentialAttributes: "email",
+			common.RuntimeKeyRequiredOptionalAttributes:  "name",
+		},
+		ExecutionHistory: map[string]*providers.NodeExecutionRecord{},
+		Application: providers.Application{
+			InboundAuthProfile: providers.InboundAuthProfile{
+				Assertion: &inboundmodel.AssertionConfig{
+					UserAttributes: []string{"email", "name", "address"},
+				},
+			},
+		},
+	}
+
+	suite.setupGetEntityReference("", "")
+
+	suite.setupGetUserAttributesWith(map[string]*providers.AttributeResponse{
+		"email":   {Value: testEmail},
+		"name":    {Value: testNameValue},
+		"address": {Value: "123 Main St"},
+	})
+
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			// Should have email and name (intersection of consented vs requested)
+			// Must NOT have address (consented but not in the requested set)
+			hasEmail := claims["email"] == testEmail
+			hasName := claims["name"] == testNameValue
+			_, hasAddress := claims["address"]
+			return hasEmail && hasName && !hasAddress
 		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)


### PR DESCRIPTION
### Purpose

`getRequiredUserAttributes` in `auth_assert_executor.go` returned the full `RuntimeKeyConsentedAttributes` list without intersecting it against the essential/optional attribute set originally requested by the authorization request. This allowed attribute-scope over-disclosure: any `ConsentProvider` implementation that doesn't independently validate against the request scope could flow extra attributes straight into the JWT assertion and userinfo response.

`resolvePermissionsForClaim` already applies this defense for permissions (intersecting consented permissions against authorized permissions); the attributes path was unguarded — an inconsistency in the same file.

**Fixes #5137**

### Approach

**Mirrors the existing permissions defense for attributes.** Added two new helpers and an intersection step in `getRequiredUserAttributes`:

1. **`buildRequestedAttributesSet(ctx)`** — Reconstructs the originally-requested attribute set by reading `RuntimeKeyRequiredEssentialAttributes` and `RuntimeKeyRequiredOptionalAttributes` from runtime data (the same keys the authz executor populates and the consent prompt reads from). Returns their union as a space-separated string, or `""` if neither key is present.

2. **`intersectAttributeSpaceList(a, b)`** — Returns the attributes present in both space-separated inputs, preserving the order of `a`. Structurally identical to the existing `intersectPermissionSpaceList` but returns `[]string` to match `getRequiredUserAttributes`'s return type.

3. **Intersection in `getRequiredUserAttributes`** — When consent has been recorded and the requested attribute set is non-empty, the consented attribute list is intersected against the requested set before returning. This prevents the engine from asserting attributes that were never part of the original authorize request. When the requested set is empty (no runtime data keys present), the function falls through to the existing consented-attributes path unchanged — no behavior change for flows that don't set these keys.

**Design rationale.** The consent prompt is built from the same essential/optional attribute set, so any attribute in the consented list that isn't in the requested set is either a ConsentProvider bug or an artifact of a provider that doesn't validate scope. The engine-level intersection closes both paths without changing the consent UX. This is the same defense posture already applied to permissions in `resolvePermissionsForClaim` → `intersectPermissionSpaceList`.

### Related Issues
- [#5137 — `getRequiredUserAttributes` does not intersect consented attributes against the originally-requested attribute set](https://github.com/thunder-id/thunderid/issues/5137)

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests — 14 new test cases covering:
        - `getRequiredUserAttributes` consent + intersection scenarios (essential-only, essential+optional, no overlap, subset-of-requested)
        - `intersectAttributeSpaceList` unit tests (both empty, A empty, B empty, partial overlap, no overlap, identical)
        - `buildRequestedAttributesSet` unit tests (both present, essential only, optional only, neither)
        - End-to-end `Execute` integration test verifying JWT claims contain only the intersection (`email`, `name`) and exclude the unrequested attribute (`address`)
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

### Verification
All 14 new unit and integration tests pass. The existing `getRequiredUserAttributes` and `resolvePermissionsForClaim` test suites continue to pass with no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consent handling to ensure only requested user attributes are included in generated claims.
  * Prevented unrequested attributes from being disclosed when consent data contains broader permissions.
* **Tests**
  * Added coverage for matching, partial, empty, and non-overlapping attribute requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->