### PR TITLE
Handle incompatible yq implementations

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -142,7 +142,7 @@ read_config() {
         PUBLIC_HOSTNAME=""
     else
         # Try yq first (YAML parser)
-        if command -v yq >/dev/null 2>&1; then
+        if command -v yq >/dev/null 2>&1 && yq eval '.' /dev/null >/dev/null 2>&1; then
             HOSTNAME=$(yq eval '.server.hostname // "localhost"' "$config_file" 2>/dev/null)
             PORT=$(yq eval '.server.port // 8090' "$config_file" 2>/dev/null)
             HTTP_ONLY=$(yq eval '.server.http_only // false' "$config_file" 2>/dev/null)

--- a/setup.sh
+++ b/setup.sh
@@ -254,7 +254,7 @@ read_config() {
     log_debug "Reading configuration from: $config_file"
 
     # Try yq first (YAML parser)
-    if command -v yq >/dev/null 2>&1; then
+    if command -v yq >/dev/null 2>&1 && yq eval '.' /dev/null >/dev/null 2>&1; then
         HOSTNAME=$(yq eval '.server.hostname // "localhost"' "$config_file" 2>/dev/null)
         PORT=$(yq eval '.server.port // 8090' "$config_file" 2>/dev/null)
         HTTP_ONLY=$(yq eval '.server.http_only // false' "$config_file" 2>/dev/null)


### PR DESCRIPTION
### Purpose
Prevent `setup.sh` and `build.sh` from terminating when an incompatible `yq` implementation is present in `PATH`.

Fixes #5216

### Approach
- Verify that the detected `yq` supports the required `eval` syntax before using it.
- Use the existing grep/awk configuration fallback when the compatibility probe fails.
- Apply the same check to both setup and source-build configuration parsing.

### Related Issues
- Fixes #5216

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. Not required for this change.
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. No new automated test framework was introduced for this shell capability check.
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. None.
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Validation
- `bash -n setup.sh build.sh`
- `git diff --check`
- Verified the compatibility probe against Python/jq `yq` 3.1.0, which is rejected and therefore selects the existing fallback.

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR does not commit keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration parsing when the installed `yq` tool is unavailable or not functioning correctly.
  * Automatically falls back to an alternate parsing method instead of producing empty configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->