### PR TITLE
Answer OIDC prompt, max_age, and id_token_hint from the SSO session

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -495,7 +495,8 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	tokenValidator, err := oauth.Initialize(mux, actorProvider, authnProvider, jwtService, jweService,
 		flowExecService, observabilitySvc, runtimeCryptoSvc, ouService, attributeCacheService, authZService,
 		resourceServerProvider, i18nService, idpService, dpopVerifier,
-		runtimeStoreProvider, transactioner, revocationEnforcer, revocationSvc, oauthCfg)
+		runtimeStoreProvider, transactioner, revocationEnforcer, revocationSvc,
+		sessionService, flowMgtService, oauthCfg)
 	fatalOnError(ctx, logger, err, "Failed to initialize OAuth services")
 
 	// Initialized after the OAuth services because credential issuance validates the presented

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -174,6 +174,18 @@ const (
 	// RuntimeKeyForceConsentReprompt indicates that consent must be re-prompted for all required
 	// claims, set when the authorization request includes prompt=consent.
 	RuntimeKeyForceConsentReprompt = "force_consent_reprompt"
+	// RuntimeKeySilentAuthOnly indicates that the authorization request forbids any interaction with
+	// the subject, set when the request includes prompt=none. The authorize endpoint has already
+	// verified that the existing session satisfies the request, so the SSO-Check node must reuse it
+	// rather than re-deciding against a later clock: max_age is compared against a fresh time.Now()
+	// in both places, so a session sitting exactly on the boundary can pass there and fail here,
+	// which would prompt a request that forbids prompting.
+	RuntimeKeySilentAuthOnly = "silent_auth_only"
+
+	// RuntimeKeyForceReauth indicates that the subject must authenticate again in this execution
+	// even when a live SSO session exists, set when the authorization request includes
+	// prompt=login.
+	RuntimeKeyForceReauth = "force_reauth"
 	// RuntimeKeyStoredInviteToken holds the generated invite token stored during the invite send phase.
 	RuntimeKeyStoredInviteToken = "storedInviteToken"
 	// RuntimeKeyUserAttributesCacheTTLSeconds indicates the TTL of the user attributes cache.

--- a/backend/internal/flow/executor/auth_assert_assurance_test.go
+++ b/backend/internal/flow/executor/auth_assert_assurance_test.go
@@ -79,6 +79,30 @@ func (suite *AuthAssertExecutorTestSuite) TestCheckAssurance_MaxAgeFreshAuth() {
 	assert.Nil(suite.T(), suite.executor.checkAssurance(ctx, suite.executor.logger))
 }
 
+// TestCheckAssurance_MaxAgeZeroFreshAuthSatisfied covers max_age=0 answered by an authentication
+// that just completed. The SSO-Check node and the authorize endpoint reject max_age=0 outright,
+// because both decide whether to reuse an existing authentication and zero admits none. This node
+// asks a different question — is the authentication being asserted fresh enough — and a
+// just-completed one is, so it must not be rejected. Otherwise max_age=0 would be unsatisfiable
+// even immediately after the re-authentication it triggered.
+func (suite *AuthAssertExecutorTestSuite) TestCheckAssurance_MaxAgeZeroFreshAuthSatisfied() {
+	ctx := assuranceCtx(map[string]string{common.RuntimeKeyMaxAge: "0"})
+	assert.Nil(suite.T(), suite.executor.checkAssurance(ctx, suite.executor.logger),
+		"a freshly completed authentication must satisfy max_age=0")
+}
+
+// TestCheckAssurance_MaxAgeZeroStaleSessionRejected is the counterpart: a reused session carrying
+// an older auth_time does not satisfy max_age=0, so the assertion is refused.
+func (suite *AuthAssertExecutorTestSuite) TestCheckAssurance_MaxAgeZeroStaleSessionRejected() {
+	ctx := assuranceCtx(map[string]string{
+		common.RuntimeKeyMaxAge:   "0",
+		common.RuntimeKeyAuthTime: strconv.FormatInt(time.Now().UTC().Unix()-60, 10),
+	})
+	svcErr := suite.executor.checkAssurance(ctx, suite.executor.logger)
+	assert.NotNil(suite.T(), svcErr)
+	assert.Equal(suite.T(), ErrInteractionRequired.Code, svcErr.Code)
+}
+
 func (suite *AuthAssertExecutorTestSuite) TestCheckAssurance_MaxAgeMalformedIgnored() {
 	ctx := assuranceCtx(map[string]string{common.RuntimeKeyMaxAge: "not-a-number"})
 	assert.Nil(suite.T(), suite.executor.checkAssurance(ctx, suite.executor.logger))

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -206,6 +206,11 @@ func (a *authAssertExecutor) generateAuthAssertion(
 		jwtClaims[oauth2const.ClaimCompletedAuthClass] = completedACR
 	}
 
+	// Carry the time the subject actually authenticated. On the SSO path that is the reused
+	// session's authentication time, which is older than this assertion's iat; without the claim
+	// the OAuth layer falls back to iat and auth_time advances on every authorization.
+	jwtClaims[oauth2const.ClaimAuthTime] = a.resolveAuthTime(ctx)
+
 	// Bind the assertion to the originating auth request so the corresponding callback can verify this assertion
 	// authorizes the specific request it accompanies.
 	if authReqID, exists := ctx.RuntimeData[common.RuntimeKeyAuthorizationRequestID]; exists && authReqID != "" {

--- a/backend/internal/flow/executor/session_executor.go
+++ b/backend/internal/flow/executor/session_executor.go
@@ -291,6 +291,13 @@ var requestScopedSnapshotDenyList = map[string]struct{}{
 	common.RuntimeKeyAuthorizationRequestID:      {},
 	// The token family id is minted fresh per flow execution, so it must not ride a reused snapshot.
 	common.RuntimeKeyTokenFamilyID: {},
+	// force_reauth and max_age state what the establishing app's authorization request demanded of
+	// this authentication. Replaying either onto a later join would impose that demand on an app that
+	// never asked: a stale force_reauth re-prompts every reuse, and a stale max_age fails the
+	// assurance check once auth_time is sourced from the session rather than the current time.
+	common.RuntimeKeyForceReauth:    {},
+	common.RuntimeKeyMaxAge:         {},
+	common.RuntimeKeySilentAuthOnly: {},
 	// applicationId has no shared constant (set as a raw literal in enrichRuntimeData).
 	"applicationId": {},
 }

--- a/backend/internal/flow/executor/session_executor_test.go
+++ b/backend/internal/flow/executor/session_executor_test.go
@@ -428,3 +428,25 @@ func (suite *SessionExecutorTestSuite) TestSSOLoad_RehydrateErrorFailsFlow() {
 	suite.Require().Error(err)
 	suite.Contains(err.Error(), "failed to load SSO checkpoint")
 }
+
+// TestSanitizeSnapshotRuntimeData_DropsRequestScopedReauthKeys pins that the two keys stating what
+// the establishing app demanded of this authentication stay out of the durable snapshot. Replaying
+// either onto a later join imposes that demand on an app that never asked: the snapshot is merged
+// over the live request, so a stale force_reauth re-prompts every reuse and a stale max_age fails
+// the assurance check now that auth_time comes from the session rather than the current time.
+func (suite *SessionExecutorTestSuite) TestSanitizeSnapshotRuntimeData_DropsRequestScopedReauthKeys() {
+	sanitized := sanitizeSnapshotRuntimeData(map[string]string{
+		common.RuntimeKeyForceReauth:    "true",
+		common.RuntimeKeyMaxAge:         "60",
+		common.RuntimeKeySilentAuthOnly: "true",
+		"keep_me":                       "value",
+	})
+
+	_, hasForceReauth := sanitized[common.RuntimeKeyForceReauth]
+	suite.False(hasForceReauth, "force_reauth belongs to one request and must not be persisted")
+	_, hasMaxAge := sanitized[common.RuntimeKeyMaxAge]
+	suite.False(hasMaxAge, "max_age belongs to one request and must not be persisted")
+	_, hasSilent := sanitized[common.RuntimeKeySilentAuthOnly]
+	suite.False(hasSilent, "the silent marker belongs to one request and must not be persisted")
+	suite.Equal("value", sanitized["keep_me"], "unrelated runtime data must still be snapshotted")
+}

--- a/backend/internal/flow/executor/sso_check_executor.go
+++ b/backend/internal/flow/executor/sso_check_executor.go
@@ -4,6 +4,7 @@
 package executor
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/thunder-id/thunderid/internal/flow/common"
@@ -74,6 +75,14 @@ func (e *ssoCheckExecutor) Execute(ctx *providers.NodeContext) (*providers.Execu
 		execResp.RuntimeData[common.RuntimeKeySSOSessionHandle] = resolved.HandleID
 	}
 
+	// A request may demand a fresh authentication even when a live session exists: prompt=login
+	// asks for one outright, and a max_age smaller than the session's age makes the existing
+	// authentication too old to satisfy. Both are answered by re-authenticating here, at the
+	// branch point, rather than by failing at the end of the flow once the assertion is due.
+	if resolved != nil && reauthRequired(ctx, resolved.AuthenticatedAt, logger) {
+		resolved = nil
+	}
+
 	var snapshot *session.SessionContext
 	if resolved != nil && checkpoint != "" {
 		if snapshot, err = e.sso.FindCheckpoint(ctx.Context, resolved.SessionID, checkpoint); err != nil {
@@ -104,6 +113,46 @@ func (e *ssoCheckExecutor) Execute(ctx *providers.NodeContext) (*providers.Execu
 	}
 
 	return execResp, nil
+}
+
+// reauthRequired reports whether the request rules out reusing a session that authenticated at
+// authenticatedAt: prompt=login always does, and max_age does when more than that many seconds
+// have passed since. A malformed max_age is treated as no constraint, matching the assurance
+// check that also reads it.
+func reauthRequired(ctx *providers.NodeContext, authenticatedAt time.Time, logger *log.Logger) bool {
+	if ctx.RuntimeData[common.RuntimeKeyForceReauth] == dataValueTrue {
+		logger.Debug(ctx.Context, "prompt=login requires a fresh authentication; not reusing the session")
+		return true
+	}
+
+	// A silent request cannot answer a credential prompt, and the authorize endpoint already
+	// confirmed this session satisfies it. Re-deciding here would compare max_age against a later
+	// clock than that check used, so a session on the boundary would be declined and the flow would
+	// prompt a request that forbids prompting. prompt=none cannot be combined with prompt=login, so
+	// the forced-reauth case above still takes precedence.
+	if ctx.RuntimeData[common.RuntimeKeySilentAuthOnly] == dataValueTrue {
+		logger.Debug(ctx.Context,
+			"Silent request already validated at the authorize endpoint; reusing the session")
+		return false
+	}
+
+	rawMaxAge := ctx.RuntimeData[common.RuntimeKeyMaxAge]
+	if rawMaxAge == "" || authenticatedAt.IsZero() {
+		return false
+	}
+	maxAge, err := strconv.ParseInt(rawMaxAge, 10, 64)
+	if err != nil || maxAge < 0 {
+		logger.Debug(ctx.Context, "Ignoring malformed max_age", log.String("maxAge", rawMaxAge))
+		return false
+	}
+	// max_age=0 admits no elapsed time at all, so it demands re-authentication even within the same
+	// second as the authentication (OIDC Core 3.1.2.1 treats it as equivalent to prompt=login)
+	if maxAge == 0 || time.Now().UTC().Unix()-authenticatedAt.Unix() > maxAge {
+		logger.Debug(ctx.Context, "Session authentication is older than max_age; re-authenticating",
+			log.String("maxAge", rawMaxAge))
+		return true
+	}
+	return false
 }
 
 // checkpointRef returns the Session (join) node id this SSO-Check node guards, read from

--- a/backend/internal/flow/executor/sso_check_reauth_test.go
+++ b/backend/internal/flow/executor/sso_check_reauth_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/thunder-id/thunderid/internal/flow/common"
+	"github.com/thunder-id/thunderid/internal/flow/session"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+	"github.com/thunder-id/thunderid/tests/mocks/flow/sessionmock"
+)
+
+// reauthNodeContext builds a node context carrying the given runtime data alongside the standard
+// SSO inputs, so a test can state only the request parameters it cares about.
+func reauthNodeContext(runtimeData map[string]string) *providers.NodeContext {
+	ctx := ssoNodeContext()
+	ctx.RuntimeData = runtimeData
+	return ctx
+}
+
+// sessionAuthenticatedAgo returns a live session whose subject authenticated the given duration ago.
+func sessionAuthenticatedAgo(d time.Duration) *session.Session {
+	s := liveSession()
+	s.AuthenticatedAt = time.Now().UTC().Add(-d)
+	return s
+}
+
+// TestReauthPromptLogin covers prompt=login: the session is live and holds the checkpoint, but the
+// request demands a fresh authentication, so the node routes to Authenticate anyway. The checkpoint
+// is never looked up, because the decision does not depend on it.
+func (suite *SSOCheckExecutorTestSuite) TestReauthPromptLogin() {
+	sso := sessionmock.NewServiceMock(suite.T())
+	sso.EXPECT().Resolve(mock.Anything, "handle-abc", "flow-1", 3, mock.Anything).
+		Return(sessionAuthenticatedAgo(time.Minute), nil)
+	exec := suite.newExecutor(sso)
+
+	resp, err := exec.Execute(reauthNodeContext(map[string]string{
+		common.RuntimeKeyForceReauth: dataValueTrue,
+	}))
+
+	suite.Require().NoError(err)
+	suite.Equal(providers.ExecFailure, resp.Status)
+	suite.Require().NotNil(resp.Error)
+	suite.Equal(ErrNoLiveSSOSession.Code, resp.Error.Code)
+	// The handle is still shared, so the fresh authentication attaches to the existing session
+	// rather than minting a second one for the same subject.
+	suite.Equal("handle-abc", resp.RuntimeData[common.RuntimeKeySSOSessionHandle])
+}
+
+// TestReauthMaxAgeExceeded covers a session older than max_age: the existing authentication cannot
+// satisfy the request, so the node re-authenticates instead of reusing it.
+func (suite *SSOCheckExecutorTestSuite) TestReauthMaxAgeExceeded() {
+	sso := sessionmock.NewServiceMock(suite.T())
+	sso.EXPECT().Resolve(mock.Anything, "handle-abc", "flow-1", 3, mock.Anything).
+		Return(sessionAuthenticatedAgo(time.Hour), nil)
+	exec := suite.newExecutor(sso)
+
+	resp, err := exec.Execute(reauthNodeContext(map[string]string{
+		common.RuntimeKeyMaxAge: "60",
+	}))
+
+	suite.Require().NoError(err)
+	suite.Equal(providers.ExecFailure, resp.Status)
+	suite.Equal("handle-abc", resp.RuntimeData[common.RuntimeKeySSOSessionHandle])
+}
+
+// TestReauthMaxAgeWithinLimit covers the opposite case: a max_age the session still satisfies
+// leaves reuse intact, so the node routes to Skip.
+func (suite *SSOCheckExecutorTestSuite) TestReauthMaxAgeWithinLimit() {
+	sso := sessionmock.NewServiceMock(suite.T())
+	sso.EXPECT().Resolve(mock.Anything, "handle-abc", "flow-1", 3, mock.Anything).
+		Return(sessionAuthenticatedAgo(time.Minute), nil)
+	sso.EXPECT().FindCheckpoint(mock.Anything, "sess-1", "session").
+		Return(&session.SessionContext{SessionID: "sess-1", CheckpointID: "session"}, nil)
+	exec := suite.newExecutor(sso)
+
+	resp, err := exec.Execute(reauthNodeContext(map[string]string{
+		common.RuntimeKeyMaxAge: "3600",
+	}))
+
+	suite.Require().NoError(err)
+	suite.Equal(providers.ExecComplete, resp.Status)
+}
+
+// TestReauthMalformedMaxAge covers a max_age that does not parse: it is treated as no constraint,
+// matching how the assurance check reads the same value, so reuse is unaffected.
+func (suite *SSOCheckExecutorTestSuite) TestReauthMalformedMaxAge() {
+	sso := sessionmock.NewServiceMock(suite.T())
+	sso.EXPECT().Resolve(mock.Anything, "handle-abc", "flow-1", 3, mock.Anything).
+		Return(sessionAuthenticatedAgo(time.Hour), nil)
+	sso.EXPECT().FindCheckpoint(mock.Anything, "sess-1", "session").
+		Return(&session.SessionContext{SessionID: "sess-1", CheckpointID: "session"}, nil)
+	exec := suite.newExecutor(sso)
+
+	resp, err := exec.Execute(reauthNodeContext(map[string]string{
+		common.RuntimeKeyMaxAge: "not-a-number",
+	}))
+
+	suite.Require().NoError(err)
+	suite.Equal(providers.ExecComplete, resp.Status)
+}
+
+// TestReauthZeroAuthenticatedAt covers a session carrying no authentication time: there is nothing
+// to compare max_age against, so the value is not treated as a breach.
+func (suite *SSOCheckExecutorTestSuite) TestReauthZeroAuthenticatedAt() {
+	sso := sessionmock.NewServiceMock(suite.T())
+	sso.EXPECT().Resolve(mock.Anything, "handle-abc", "flow-1", 3, mock.Anything).
+		Return(liveSession(), nil)
+	sso.EXPECT().FindCheckpoint(mock.Anything, "sess-1", "session").
+		Return(&session.SessionContext{SessionID: "sess-1", CheckpointID: "session"}, nil)
+	exec := suite.newExecutor(sso)
+
+	resp, err := exec.Execute(reauthNodeContext(map[string]string{
+		common.RuntimeKeyMaxAge: "60",
+	}))
+
+	suite.Require().NoError(err)
+	suite.Equal(providers.ExecComplete, resp.Status)
+}
+
+// TestReauthMaxAgeZeroAlwaysReauthenticates covers max_age=0, which admits no elapsed time at all:
+// any session with a recorded authentication time is too old to reuse.
+func (suite *SSOCheckExecutorTestSuite) TestReauthMaxAgeZeroAlwaysReauthenticates() {
+	sso := sessionmock.NewServiceMock(suite.T())
+	sso.EXPECT().Resolve(mock.Anything, "handle-abc", "flow-1", 3, mock.Anything).
+		Return(sessionAuthenticatedAgo(2*time.Second), nil)
+	exec := suite.newExecutor(sso)
+
+	resp, err := exec.Execute(reauthNodeContext(map[string]string{
+		common.RuntimeKeyMaxAge: "0",
+	}))
+
+	suite.Require().NoError(err)
+	suite.Equal(providers.ExecFailure, resp.Status)
+}
+
+// TestReauthNotRequestedReusesSession covers the baseline: with neither prompt=login nor max_age,
+// a live session is reused unchanged.
+func (suite *SSOCheckExecutorTestSuite) TestReauthNotRequestedReusesSession() {
+	sso := sessionmock.NewServiceMock(suite.T())
+	sso.EXPECT().Resolve(mock.Anything, "handle-abc", "flow-1", 3, mock.Anything).
+		Return(sessionAuthenticatedAgo(24*time.Hour), nil)
+	sso.EXPECT().FindCheckpoint(mock.Anything, "sess-1", "session").
+		Return(&session.SessionContext{SessionID: "sess-1", CheckpointID: "session"}, nil)
+	exec := suite.newExecutor(sso)
+
+	resp, err := exec.Execute(reauthNodeContext(map[string]string{}))
+
+	suite.Require().NoError(err)
+	suite.Equal(providers.ExecComplete, resp.Status)
+}
+
+// TestReauthAuthTimeBoundary covers a session exactly at the max_age boundary. The comparison is
+// strictly greater than, so a session precisely max_age old still satisfies the request.
+func (suite *SSOCheckExecutorTestSuite) TestReauthAuthTimeBoundary() {
+	s := liveSession()
+	s.AuthenticatedAt = time.Now().UTC().Add(-60 * time.Second)
+
+	sso := sessionmock.NewServiceMock(suite.T())
+	sso.EXPECT().Resolve(mock.Anything, "handle-abc", "flow-1", 3, mock.Anything).Return(s, nil)
+	sso.EXPECT().FindCheckpoint(mock.Anything, "sess-1", "session").
+		Return(&session.SessionContext{SessionID: "sess-1", CheckpointID: "session"}, nil)
+	exec := suite.newExecutor(sso)
+
+	resp, err := exec.Execute(reauthNodeContext(map[string]string{
+		common.RuntimeKeyMaxAge: "120",
+	}))
+
+	suite.Require().NoError(err)
+	suite.Equal(providers.ExecComplete, resp.Status)
+}
+
+// TestReauthSilentRequestReusesBoundarySession covers the race between the authorize endpoint's
+// max_age check and this node's. Both compare against a fresh clock, so a session sitting on the
+// boundary passes there and would fail here once the second ticks over, prompting a request that
+// forbids prompting. A silent request therefore honors the decision already made.
+func (suite *SSOCheckExecutorTestSuite) TestReauthSilentRequestReusesBoundarySession() {
+	sso := sessionmock.NewServiceMock(suite.T())
+	sso.EXPECT().Resolve(mock.Anything, "handle-abc", "flow-1", 3, mock.Anything).
+		Return(sessionAuthenticatedAgo(time.Hour), nil)
+	sso.EXPECT().FindCheckpoint(mock.Anything, "sess-1", "session").
+		Return(&session.SessionContext{SessionID: "sess-1", CheckpointID: "session"}, nil)
+	exec := suite.newExecutor(sso)
+
+	// Stale by this node's own comparison, but the request forbids interaction.
+	resp, err := exec.Execute(reauthNodeContext(map[string]string{
+		common.RuntimeKeyMaxAge:         "60",
+		common.RuntimeKeySilentAuthOnly: dataValueTrue,
+	}))
+
+	suite.Require().NoError(err)
+	suite.Equal(providers.ExecComplete, resp.Status,
+		"a silent request must reuse the session rather than route to a credential prompt")
+}
+
+// TestReauthSilentRequestStillHonorsForceReauth guards the precedence. prompt=none cannot be
+// combined with prompt=login, so if both markers ever appear the explicit forced re-authentication
+// must win rather than being suppressed by the silent marker.
+func (suite *SSOCheckExecutorTestSuite) TestReauthSilentRequestStillHonorsForceReauth() {
+	sso := sessionmock.NewServiceMock(suite.T())
+	sso.EXPECT().Resolve(mock.Anything, "handle-abc", "flow-1", 3, mock.Anything).
+		Return(sessionAuthenticatedAgo(time.Minute), nil)
+	exec := suite.newExecutor(sso)
+
+	resp, err := exec.Execute(reauthNodeContext(map[string]string{
+		common.RuntimeKeyForceReauth:    dataValueTrue,
+		common.RuntimeKeySilentAuthOnly: dataValueTrue,
+	}))
+
+	suite.Require().NoError(err)
+	suite.Equal(providers.ExecFailure, resp.Status,
+		"an explicit force-reauth must not be suppressed by the silent marker")
+}
+
+// TestReauthMaxAgeZeroWithinSameSecond covers the boundary a strictly-greater comparison misses: a
+// session authenticated in the current Unix second yields an elapsed time of zero, which is not
+// greater than max_age=0. OIDC Core treats max_age=0 as equivalent to prompt=login, so it must
+// still re-authenticate.
+func (suite *SSOCheckExecutorTestSuite) TestReauthMaxAgeZeroWithinSameSecond() {
+	sso := sessionmock.NewServiceMock(suite.T())
+	sso.EXPECT().Resolve(mock.Anything, "handle-abc", "flow-1", 3, mock.Anything).
+		Return(sessionAuthenticatedAgo(0), nil)
+	exec := suite.newExecutor(sso)
+
+	resp, err := exec.Execute(reauthNodeContext(map[string]string{
+		common.RuntimeKeyMaxAge: "0",
+	}))
+
+	suite.Require().NoError(err)
+	suite.Equal(providers.ExecFailure, resp.Status,
+		"max_age=0 must re-authenticate even within the same second as the authentication")
+}

--- a/backend/internal/flow/session/interface.go
+++ b/backend/internal/flow/session/interface.go
@@ -3,7 +3,10 @@
 
 package session
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // sessionStore is the package-private persistence contract covering SSO sessions, their
 // per-checkpoint session contexts, and their participants. A single runtime-persistent-DB-backed
@@ -24,6 +27,10 @@ type sessionStore interface {
 	// returns errVersionConflict when the stored version no longer matches, and bumps the in-memory
 	// Version on success.
 	Update(ctx context.Context, s *Session) error
+	// TouchAuthenticatedAt records a fresh authentication inside an existing session and slides the
+	// idle deadline with it. It carries no version guard, so it never loses to a concurrent slide.
+	TouchAuthenticatedAt(ctx context.Context, sessionID string, authenticatedAt,
+		idleExpiresAt time.Time) error
 
 	// CreateContext persists (or overwrites) one checkpoint's session context for a session.
 	CreateContext(ctx context.Context, c SessionContext) error

--- a/backend/internal/flow/session/service.go
+++ b/backend/internal/flow/session/service.go
@@ -176,6 +176,23 @@ func (s *service) SaveCheckpoint(ctx context.Context, in SaveCheckpointInput) (S
 		return SaveCheckpointResult{Skipped: true}, nil
 	}
 
+	// Reaching this point means the subject authenticated during this execution: the SSO-hit path
+	// loads its checkpoint and never saves one. When that happens inside a session that already
+	// existed, it was a re-authentication (prompt=login, or a max_age the previous authentication no
+	// longer satisfied), so the session's authentication time has to move forward with it. Leaving it
+	// stale would make the session claim an older authentication than actually took place, which
+	// under-reports auth_time and makes a later max_age check reject a request it should allow.
+	if !created {
+		now := time.Now().UTC()
+		if err := s.store.TouchAuthenticatedAt(ctx, target.SessionID, now,
+			now.Add(s.timeouts.Idle)); err != nil {
+			// The checkpoint itself is still worth saving, so degrade rather than fail the login.
+			s.logger.Error(ctx, "Failed to refresh session authentication time", log.Error(err))
+		} else {
+			target.AuthenticatedAt = now
+		}
+	}
+
 	snapshot := SessionContext{
 		SessionID:      target.SessionID,
 		CheckpointID:   in.Checkpoint,

--- a/backend/internal/flow/session/service_test.go
+++ b/backend/internal/flow/session/service_test.go
@@ -22,6 +22,9 @@ import (
 // under a different flow is never reused.
 const testOtherFlowID = "other-flow"
 
+// testHandle is the session handle the suite's fixtures are keyed by.
+const testHandle = "handle-abc"
+
 type ServiceTestSuite struct {
 	suite.Suite
 }
@@ -209,10 +212,18 @@ func (suite *ServiceTestSuite) TestSaveCheckpoint_AttachesToExisting() {
 	m.store.EXPECT().CreateContext(mock.Anything, mock.Anything).RunAndReturn(
 		func(_ context.Context, c SessionContext) error { savedCtx = c; return nil })
 	m.store.EXPECT().Record(mock.Anything, mock.Anything).Return(nil)
+	// Saving a checkpoint into an existing session means the subject just authenticated again, so the
+	// session's authentication time moves forward with it.
+	var touchedAt, touchedIdle time.Time
+	m.store.EXPECT().TouchAuthenticatedAt(mock.Anything, "sess-1", mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, at, idle time.Time) error {
+			touchedAt, touchedIdle = at, idle
+			return nil
+		})
 
 	in := saveInput()
 	in.Checkpoint = "step_up"
-	in.HandleHint = "handle-abc"
+	in.HandleHint = testHandle
 
 	res, err := svc.SaveCheckpoint(context.Background(), in)
 	suite.Require().NoError(err)
@@ -221,6 +232,50 @@ func (suite *ServiceTestSuite) TestSaveCheckpoint_AttachesToExisting() {
 	suite.Equal("handle-abc", res.Handle)
 	suite.Equal("sess-1", savedCtx.SessionID)
 	suite.Equal("step_up", savedCtx.CheckpointID)
+	suite.False(touchedAt.IsZero(), "the re-authentication must refresh the session's auth time")
+	suite.True(touchedIdle.After(touchedAt), "the idle deadline must slide past the new auth time")
+}
+
+// TestSaveCheckpoint_ReauthRefreshFailureStillSaves pins the degradation: a failure to refresh the
+// authentication time must not cost the user their login, since the checkpoint itself is still valid.
+func (suite *ServiceTestSuite) TestSaveCheckpoint_ReauthRefreshFailureStillSaves() {
+	svc, m := suite.newService()
+	m.store.EXPECT().GetByHandle(mock.Anything, "handle-abc").Return(liveStoreSession(), nil)
+	runTx(m)
+	m.store.EXPECT().CreateContext(mock.Anything, mock.Anything).Return(nil)
+	m.store.EXPECT().Record(mock.Anything, mock.Anything).Return(nil)
+	m.store.EXPECT().TouchAuthenticatedAt(mock.Anything, "sess-1", mock.Anything, mock.Anything).
+		Return(errors.New("db down"))
+
+	in := saveInput()
+	in.HandleHint = testHandle
+
+	res, err := svc.SaveCheckpoint(context.Background(), in)
+	suite.Require().NoError(err, "a refresh failure must not fail the login")
+	suite.False(res.Skipped, "the checkpoint should still be saved")
+	suite.Equal("handle-abc", res.Handle)
+}
+
+// TestSaveCheckpoint_NewSessionDoesNotTouch verifies the refresh is scoped to re-authentication: a
+// freshly minted session already carries the right authentication time from establishSession.
+func (suite *ServiceTestSuite) TestSaveCheckpoint_NewSessionDoesNotTouch() {
+	svc, m := suite.newService()
+	// Same establish sequence as TestSaveCheckpoint_Establishes: no session exists, so this call
+	// mints one and re-reads its own row.
+	var created *Session
+	m.store.EXPECT().GetByExecutionID(mock.Anything, mock.Anything).RunAndReturn(
+		func(context.Context, string) (*Session, error) { return created, nil })
+	m.store.EXPECT().Create(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, s Session) error { created = &s; return nil })
+	runTx(m)
+	m.store.EXPECT().CreateContext(mock.Anything, mock.Anything).Return(nil)
+	m.store.EXPECT().Record(mock.Anything, mock.Anything).Return(nil)
+
+	res, err := svc.SaveCheckpoint(context.Background(), saveInput())
+	suite.Require().NoError(err)
+	suite.True(res.Created, "no existing session means this call minted one")
+	m.store.AssertNotCalled(suite.T(), "TouchAuthenticatedAt",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func (suite *ServiceTestSuite) TestSaveCheckpoint_SubjectMismatchSkips() {
@@ -230,7 +285,7 @@ func (suite *ServiceTestSuite) TestSaveCheckpoint_SubjectMismatchSkips() {
 	m.store.EXPECT().GetByHandle(mock.Anything, "handle-abc").Return(existing, nil)
 
 	in := saveInput()
-	in.HandleHint = "handle-abc"
+	in.HandleHint = testHandle
 
 	res, err := svc.SaveCheckpoint(context.Background(), in)
 	suite.Require().NoError(err)

--- a/backend/internal/flow/session/sessionStore_mock_test.go
+++ b/backend/internal/flow/session/sessionStore_mock_test.go
@@ -6,6 +6,7 @@ package session
 
 import (
 	"context"
+	"time"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -721,6 +722,75 @@ func (_c *sessionStoreMock_Record_Call) Return(err error) *sessionStoreMock_Reco
 }
 
 func (_c *sessionStoreMock_Record_Call) RunAndReturn(run func(ctx context.Context, p Participant) error) *sessionStoreMock_Record_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// TouchAuthenticatedAt provides a mock function for the type sessionStoreMock
+func (_mock *sessionStoreMock) TouchAuthenticatedAt(ctx context.Context, sessionID string, authenticatedAt time.Time, idleExpiresAt time.Time) error {
+	ret := _mock.Called(ctx, sessionID, authenticatedAt, idleExpiresAt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TouchAuthenticatedAt")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, time.Time, time.Time) error); ok {
+		r0 = returnFunc(ctx, sessionID, authenticatedAt, idleExpiresAt)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// sessionStoreMock_TouchAuthenticatedAt_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TouchAuthenticatedAt'
+type sessionStoreMock_TouchAuthenticatedAt_Call struct {
+	*mock.Call
+}
+
+// TouchAuthenticatedAt is a helper method to define mock.On call
+//   - ctx context.Context
+//   - sessionID string
+//   - authenticatedAt time.Time
+//   - idleExpiresAt time.Time
+func (_e *sessionStoreMock_Expecter) TouchAuthenticatedAt(ctx interface{}, sessionID interface{}, authenticatedAt interface{}, idleExpiresAt interface{}) *sessionStoreMock_TouchAuthenticatedAt_Call {
+	return &sessionStoreMock_TouchAuthenticatedAt_Call{Call: _e.mock.On("TouchAuthenticatedAt", ctx, sessionID, authenticatedAt, idleExpiresAt)}
+}
+
+func (_c *sessionStoreMock_TouchAuthenticatedAt_Call) Run(run func(ctx context.Context, sessionID string, authenticatedAt time.Time, idleExpiresAt time.Time)) *sessionStoreMock_TouchAuthenticatedAt_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 time.Time
+		if args[2] != nil {
+			arg2 = args[2].(time.Time)
+		}
+		var arg3 time.Time
+		if args[3] != nil {
+			arg3 = args[3].(time.Time)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *sessionStoreMock_TouchAuthenticatedAt_Call) Return(err error) *sessionStoreMock_TouchAuthenticatedAt_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *sessionStoreMock_TouchAuthenticatedAt_Call) RunAndReturn(run func(ctx context.Context, sessionID string, authenticatedAt time.Time, idleExpiresAt time.Time) error) *sessionStoreMock_TouchAuthenticatedAt_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/session/store.go
+++ b/backend/internal/flow/session/store.go
@@ -127,6 +127,22 @@ func (st *store) Update(ctx context.Context, s *Session) error {
 	})
 }
 
+// TouchAuthenticatedAt records that the subject authenticated again inside an existing session,
+// sliding the idle deadline along with it. Unlike Update it carries no version guard: the write
+// records an authentication that already happened, so a concurrent liveness slide must not cause it
+// to be dropped.
+func (st *store) TouchAuthenticatedAt(ctx context.Context, sessionID string, authenticatedAt,
+	idleExpiresAt time.Time) error {
+	return withRuntimePersistentDBClient(st.dbProvider, func(dbClient provider.DBClientInterface) error {
+		_, err := dbClient.ExecuteContext(ctx, queryTouchAuthenticatedAt,
+			authenticatedAt, authenticatedAt, nullableTime(idleExpiresAt), sessionID, st.deploymentID)
+		if err != nil {
+			return fmt.Errorf("failed to refresh session authentication time: %w", err)
+		}
+		return nil
+	})
+}
+
 // CreateContext persists the session context. It rejects payloads exceeding MaxSessionContextBytes.
 func (st *store) CreateContext(ctx context.Context, c SessionContext) error {
 	payload, err := c.serializePayload()

--- a/backend/internal/flow/session/store_constants.go
+++ b/backend/internal/flow/session/store_constants.go
@@ -51,6 +51,19 @@ var (
 			`WHERE SESSION_ID = $7 AND DEPLOYMENT_ID = $8 AND VERSION = $9`,
 	}
 
+	// queryTouchAuthenticatedAt refreshes the session's authentication time after the subject
+	// authenticated again within an existing session (prompt=login, or a max_age the previous
+	// authentication no longer satisfied). It is separate from queryUpdateSession because that
+	// statement carries the optimistic-concurrency guard for liveness updates, whereas this one
+	// records a fact about an authentication that has already happened: losing a race with a
+	// concurrent slide must not discard it.
+	queryTouchAuthenticatedAt = model.DBQuery{
+		ID: "SSO-SESS-11",
+		Query: `UPDATE "SSO_SESSION" SET AUTHENTICATED_AT = $1, LAST_ACTIVE_AT = $2, ` +
+			`IDLE_EXPIRES_AT = $3, VERSION = VERSION + 1, UPDATED_AT = CURRENT_TIMESTAMP ` +
+			`WHERE SESSION_ID = $4 AND DEPLOYMENT_ID = $5 AND AUTHENTICATED_AT <= $1`,
+	}
+
 	// queryCreateSessionContext upserts a checkpoint's session context. Re-saving the same checkpoint
 	// (re-execution or a concurrent request) overwrites it rather than erroring on the primary key.
 	// The ON CONFLICT ... DO UPDATE form is valid in both PostgreSQL and SQLite.

--- a/backend/internal/flow/session/store_test.go
+++ b/backend/internal/flow/session/store_test.go
@@ -229,6 +229,95 @@ func (s *StoreTestSuite) TestUpdate_Success() {
 	s.mockDBClient.AssertExpectations(s.T())
 }
 
+// TestTouchAuthenticatedAt_Success pins the parameter order of the refresh statement. The query
+// binds the new authentication time twice (AUTHENTICATED_AT and LAST_ACTIVE_AT) before the idle
+// deadline, so a reordering here would silently write the wrong column rather than fail.
+func (s *StoreTestSuite) TestTouchAuthenticatedAt_Success() {
+	sess := s.sampleSession()
+	authAt := sess.LastActiveAt.Add(time.Hour)
+	idleAt := authAt.Add(30 * time.Minute)
+
+	s.mockDBProvider.On("GetRuntimePersistentDBClient").Return(s.mockDBClient, nil)
+	s.mockDBClient.On("ExecuteContext", context.Background(), queryTouchAuthenticatedAt,
+		authAt, authAt, idleAt, sess.SessionID, testDeploymentID).
+		Return(int64(1), nil)
+
+	err := s.store.TouchAuthenticatedAt(context.Background(), sess.SessionID, authAt, idleAt)
+
+	s.NoError(err)
+	s.mockDBClient.AssertExpectations(s.T())
+}
+
+// TestTouchAuthenticatedAt_NoRowsIsNotAnError verifies the deliberate absence of a version guard: a
+// session deleted concurrently matches no row, and that is not a failure worth surfacing, unlike
+// Update where a zero row count means a lost optimistic-lock race.
+func (s *StoreTestSuite) TestTouchAuthenticatedAt_NoRowsIsNotAnError() {
+	sess := s.sampleSession()
+	authAt := sess.LastActiveAt
+
+	s.mockDBProvider.On("GetRuntimePersistentDBClient").Return(s.mockDBClient, nil)
+	s.mockDBClient.On("ExecuteContext", context.Background(), queryTouchAuthenticatedAt,
+		authAt, authAt, authAt, sess.SessionID, testDeploymentID).
+		Return(int64(0), nil)
+
+	err := s.store.TouchAuthenticatedAt(context.Background(), sess.SessionID, authAt, authAt)
+
+	s.NoError(err, "a vanished session must not fail the refresh")
+	s.mockDBClient.AssertExpectations(s.T())
+}
+
+// TestTouchAuthenticatedAt_IsMonotonic covers two re-authentications whose writes reach the
+// database in the reverse order to their timestamps. The statement is monotonic in
+// AUTHENTICATED_AT, so the older write matches no row and the newer authentication stands; both
+// calls report success, since in each case the column ends up at least as fresh as the value
+// written. Without the predicate the late-arriving older write would move the authentication
+// backwards, under-reporting auth_time and failing a max_age the subject actually satisfies.
+func (s *StoreTestSuite) TestTouchAuthenticatedAt_IsMonotonic() {
+	sess := s.sampleSession()
+	older := sess.LastActiveAt.Add(time.Minute)
+	newer := older.Add(time.Minute)
+
+	s.mockDBProvider.On("GetRuntimePersistentDBClient").Return(s.mockDBClient, nil)
+	// The newer authentication lands first and updates the row.
+	s.mockDBClient.On("ExecuteContext", context.Background(), queryTouchAuthenticatedAt,
+		newer, newer, newer, sess.SessionID, testDeploymentID).
+		Return(int64(1), nil)
+	// The older one arrives second; the predicate excludes the row, so nothing is overwritten.
+	s.mockDBClient.On("ExecuteContext", context.Background(), queryTouchAuthenticatedAt,
+		older, older, older, sess.SessionID, testDeploymentID).
+		Return(int64(0), nil)
+
+	s.Require().NoError(s.store.TouchAuthenticatedAt(context.Background(), sess.SessionID, newer, newer))
+	s.NoError(s.store.TouchAuthenticatedAt(context.Background(), sess.SessionID, older, older),
+		"an out-of-order touch that changes nothing is still a success")
+
+	s.mockDBClient.AssertExpectations(s.T())
+}
+
+// TestTouchAuthenticatedAt_QueryGuardsMonotonicity pins the predicate itself, so removing it from
+// the statement fails here rather than silently reintroducing the backwards-write race.
+func (s *StoreTestSuite) TestTouchAuthenticatedAt_QueryGuardsMonotonicity() {
+	s.Contains(queryTouchAuthenticatedAt.Query, "AUTHENTICATED_AT <= $1",
+		"the refresh must not move a session's authentication time backwards")
+}
+
+// TestTouchAuthenticatedAt_ExecuteError surfaces a genuine database failure to the caller, which
+// degrades it to a log rather than failing the login.
+func (s *StoreTestSuite) TestTouchAuthenticatedAt_ExecuteError() {
+	sess := s.sampleSession()
+	authAt := sess.LastActiveAt
+
+	s.mockDBProvider.On("GetRuntimePersistentDBClient").Return(s.mockDBClient, nil)
+	s.mockDBClient.On("ExecuteContext", context.Background(), queryTouchAuthenticatedAt,
+		authAt, authAt, authAt, sess.SessionID, testDeploymentID).
+		Return(int64(0), errors.New("db down"))
+
+	err := s.store.TouchAuthenticatedAt(context.Background(), sess.SessionID, authAt, authAt)
+
+	s.Error(err)
+	s.mockDBClient.AssertExpectations(s.T())
+}
+
 func (s *StoreTestSuite) TestUpdate_VersionConflict() {
 	sess := s.sampleSession()
 

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/attributecache"
 	"github.com/thunder-id/thunderid/internal/flow/flowexec"
+	"github.com/thunder-id/thunderid/internal/flow/session"
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/jwks"
 	oauth2authz "github.com/thunder-id/thunderid/internal/oauth/oauth2/authz"
@@ -55,6 +56,8 @@ func Initialize(
 	transactioner providers.Transactioner,
 	enforcementService revocation.EnforcementServiceInterface,
 	revocationSvc revocation.RevocationServiceInterface,
+	ssoSession session.Service,
+	flowProvider providers.FlowProvider,
 	cfg oauthconfig.Config,
 ) (tokenservice.TokenValidatorInterface, error) {
 	jwks.Initialize(mux, runtimeCrypto)
@@ -81,7 +84,8 @@ func Initialize(
 	parService := par.Initialize(mux, actorProvider, authnProvider, jwtService, discoveryService,
 		resourceService, dpopVerifier, cfg, runtimeStore, jtiStore)
 	oauth2AuthzService, err := oauth2authz.Initialize(mux, actorProvider, resourceService,
-		jwtService, flowExecService, parService, revocationSvc, cfg, runtimeStore, transactioner)
+		jwtService, flowExecService, parService, revocationSvc, ssoSession, flowProvider, cfg,
+		runtimeStore, transactioner)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/thunder-id/thunderid/internal/flow/session"
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	oauth2utils "github.com/thunder-id/thunderid/internal/oauth/oauth2/utils"
@@ -26,6 +27,9 @@ type AuthorizeHandlerInterface interface {
 type authorizeHandler struct {
 	cfg          oauthconfig.Config
 	authZService AuthorizeServiceInterface
+	// ssoTransport reads the inbound SSO handle cookies; the authorize endpoint only reads them,
+	// the flow endpoint remains the sole writer.
+	ssoTransport session.HandleTransport
 	logger       *log.Logger
 }
 
@@ -34,17 +38,23 @@ func newAuthorizeHandler(authZService AuthorizeServiceInterface, cfg oauthconfig
 	return &authorizeHandler{
 		cfg:          cfg,
 		authZService: authZService,
+		ssoTransport: session.NewCookieTransport(true),
 		logger:       log.GetLogger().With(log.String(log.LoggerKeyComponentName, "AuthorizeHandler")),
 	}
 }
 
 // HandleAuthorizeGetRequest handles the GET request for OAuth2 authorization.
 func (ah *authorizeHandler) HandleAuthorizeGetRequest(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
+	// Validate the request before touching it: getOAuthMessage handles a nil request or response
+	// writer, and both the context and the cookie read below dereference it.
 	oAuthMessage := ah.getOAuthMessage(r, w)
 	if oAuthMessage == nil {
 		return
 	}
+
+	// Carry the inbound SSO handle cookies so prompt=none can be answered from an existing
+	// session. The per-flow cookie is selected later, once the client's flow is known.
+	ctx := session.WithInbound(r.Context(), ah.ssoTransport.Read(r))
 
 	result, authErr := ah.authZService.HandleInitialAuthorizationRequest(ctx, oAuthMessage)
 	if authErr != nil {

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -193,6 +193,17 @@ func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessage_NilRequest() {
 	assert.Nil(suite.T(), msg)
 }
 
+// TestHandleAuthorizeGetRequest_NilRequest pins that request validation precedes every dereference
+// of it. The handler reads the request context and its cookies to carry the inbound SSO handle, so
+// doing either before the nil guard turns a handled error into a panic.
+func (suite *AuthorizeHandlerTestSuite) TestHandleAuthorizeGetRequest_NilRequest() {
+	rr := httptest.NewRecorder()
+
+	assert.NotPanics(suite.T(), func() {
+		suite.handler.HandleAuthorizeGetRequest(rr, nil)
+	}, "a nil request must return through the error path, not panic")
+}
+
 func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessage_NilResponseWriter() {
 	req := httptest.NewRequest(http.MethodGet, "/auth", nil)
 
@@ -465,6 +476,63 @@ func (suite *AuthorizeHandlerTestSuite) TestGetAuthorizationCode_ZeroAuthTime() 
 	afterCreation := time.Now()
 	assert.True(suite.T(), result.TimeCreated.After(beforeCreation) || result.TimeCreated.Equal(beforeCreation))
 	assert.True(suite.T(), result.TimeCreated.Before(afterCreation) || result.TimeCreated.Equal(afterCreation))
+}
+
+// TestCreateAuthorizationCode_AgedSessionKeepsFullCodeLifetime pins the separation between when the
+// subject authenticated and when the code was minted. On the SSO path a reused session's
+// authentication can be hours old; deriving the code's expiry from it would hand out codes that are
+// already expired, so the lifetime must run from creation instead.
+func (suite *AuthorizeHandlerTestSuite) TestCreateAuthorizationCode_AgedSessionKeepsFullCodeLifetime() {
+	authRequestCtx := &authRequestContext{
+		OAuthParameters: oauth2model.OAuthParameters{
+			ClientID:    "test-client",
+			RedirectURI: "https://client.example.com/callback",
+		},
+	}
+	clms := &assertionClaims{userID: "test-user"}
+
+	cfg := authorizeServiceCfgFromRuntime()
+	validity := time.Duration(cfg.OAuth.AuthorizationCode.ValidityPeriod) * time.Second
+	suite.Require().Greater(validity, time.Duration(0), "a validity period is needed for this test to mean anything")
+
+	// A session that authenticated well before the configured code lifetime, which is the ordinary
+	// case for SSO: sessions live up to eight hours, codes for ten minutes.
+	authTime := time.Now().Add(-2 * validity)
+
+	result, err := createAuthorizationCode(cfg, authRequestCtx, clms, authTime)
+
+	suite.Require().NoError(err)
+	assert.True(suite.T(), result.ExpiryTime.After(time.Now()),
+		"a code minted over an aged session must not be born expired")
+	assert.WithinDuration(suite.T(), time.Now(), result.TimeCreated, time.Minute,
+		"TimeCreated should record when the code was minted, not when the subject authenticated")
+	assert.WithinDuration(suite.T(), authTime, result.AuthTime, time.Second,
+		"AuthTime should carry the session's authentication time unchanged")
+	assert.WithinDuration(suite.T(), time.Now().Add(validity), result.ExpiryTime, time.Minute,
+		"the code should get its full configured lifetime regardless of the session's age")
+}
+
+// TestCreateAuthorizationCode_AuthTimeSurvivesForIDToken verifies the other half: the authentication
+// time is still carried, since the id_token's auth_time claim is sourced from it. Measuring expiry
+// from creation must not cost the claim its value.
+func (suite *AuthorizeHandlerTestSuite) TestCreateAuthorizationCode_AuthTimeSurvivesForIDToken() {
+	authRequestCtx := &authRequestContext{
+		OAuthParameters: oauth2model.OAuthParameters{
+			ClientID:    "test-client",
+			RedirectURI: "https://client.example.com/callback",
+		},
+	}
+	clms := &assertionClaims{userID: "test-user"}
+
+	authTime := time.Now().Add(-45 * time.Minute).Truncate(time.Second)
+
+	result, err := createAuthorizationCode(authorizeServiceCfgFromRuntime(), authRequestCtx, clms, authTime)
+
+	suite.Require().NoError(err)
+	assert.Equal(suite.T(), authTime.Unix(), result.AuthTime.Unix(),
+		"auth_time must report the authentication, so two codes over one session agree")
+	assert.NotEqual(suite.T(), result.AuthTime.Unix(), result.TimeCreated.Unix(),
+		"the two timestamps are distinct on the SSO path and must not be conflated")
 }
 
 func (suite *AuthorizeHandlerTestSuite) TestCreateAuthorizationCode_WithClaimsLocales() {

--- a/backend/internal/oauth/oauth2/authz/init.go
+++ b/backend/internal/oauth/oauth2/authz/init.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/flow/flowexec"
+	"github.com/thunder-id/thunderid/internal/flow/session"
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/par"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/revocation"
@@ -23,6 +24,8 @@ func Initialize(
 	flowExecService flowexec.FlowExecServiceInterface,
 	parService par.PARServiceInterface,
 	criteriaRevoker revocation.CriteriaRevokerInterface,
+	ssoSession session.Service,
+	flowProvider providers.FlowProvider,
 	cfg oauthconfig.Config,
 	storeProvider providers.RuntimeStoreProvider,
 	transactioner providers.Transactioner,
@@ -32,7 +35,8 @@ func Initialize(
 
 	authzService := newAuthorizeService(
 		actorProvider, resourceService, jwtService, flowExecService,
-		authzCodeStore, authzReqStore, parService, transactioner, criteriaRevoker, cfg,
+		authzCodeStore, authzReqStore, parService, transactioner, criteriaRevoker,
+		ssoSession, flowProvider, cfg,
 	)
 	authzHandler := newAuthorizeHandler(authzService, cfg)
 	registerRoutes(mux, authzHandler)

--- a/backend/internal/oauth/oauth2/authz/init_test.go
+++ b/backend/internal/oauth/oauth2/authz/init_test.go
@@ -79,7 +79,7 @@ func (suite *InitTestSuite) TestInitialize() {
 		mux,
 		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil),
 		suite.mockResourceService,
-		suite.mockJWTService, suite.mockFlowExecService, nil, nil, testhelpers.OAuthConfig(),
+		suite.mockJWTService, suite.mockFlowExecService, nil, nil, nil, nil, testhelpers.OAuthConfig(),
 		inmemory.Initialize("test-deployment"), transaction.NewNoOpTransactioner(),
 	)
 
@@ -95,7 +95,7 @@ func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 		mux,
 		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil),
 		suite.mockResourceService,
-		suite.mockJWTService, suite.mockFlowExecService, nil, nil, testhelpers.OAuthConfig(),
+		suite.mockJWTService, suite.mockFlowExecService, nil, nil, nil, nil, testhelpers.OAuthConfig(),
 		inmemory.Initialize("test-deployment"), transaction.NewNoOpTransactioner(),
 	)
 	assert.NoError(suite.T(), err)
@@ -113,7 +113,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSConfiguration() {
 		mux,
 		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil),
 		suite.mockResourceService,
-		suite.mockJWTService, suite.mockFlowExecService, nil, nil, testhelpers.OAuthConfig(),
+		suite.mockJWTService, suite.mockFlowExecService, nil, nil, nil, nil, testhelpers.OAuthConfig(),
 		inmemory.Initialize("test-deployment"), transaction.NewNoOpTransactioner(),
 	)
 	assert.NoError(suite.T(), err)

--- a/backend/internal/oauth/oauth2/authz/model.go
+++ b/backend/internal/oauth/oauth2/authz/model.go
@@ -29,6 +29,11 @@ type AuthorizationCode struct {
 	AuthorizedUserID    string
 	AttributeCacheID    string
 	TimeCreated         time.Time
+	// AuthTime is when the subject actually authenticated, which on the SSO path predates
+	// TimeCreated: a reused session authenticated once and every later authorization mints a fresh
+	// code. It is kept separate from TimeCreated so the id_token's auth_time claim can report the
+	// authentication while the code's own lifetime is still measured from its creation.
+	AuthTime            time.Time
 	ExpiryTime          time.Time
 	Scopes              string
 	State               string

--- a/backend/internal/oauth/oauth2/authz/prompt_none_test.go
+++ b/backend/internal/oauth/oauth2/authz/prompt_none_test.go
@@ -1,0 +1,357 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authz
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	flowsession "github.com/thunder-id/thunderid/internal/flow/session"
+	inboundmodel "github.com/thunder-id/thunderid/internal/inboundclient/model"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
+	oauth2model "github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+	"github.com/thunder-id/thunderid/tests/mocks/flow/flowexecmock"
+	"github.com/thunder-id/thunderid/tests/mocks/flow/sessionmock"
+)
+
+const (
+	promptNoneAppID      = "app-1"
+	promptNoneFlowID     = "flow-1"
+	promptNoneSubject    = "user-1"
+	promptNoneFlowCookie = "handle-xyz"
+)
+
+// promptNoneCtx returns a context carrying the SSO cookie the authorize endpoint would have read
+// from the request, named for the client's authentication flow.
+func promptNoneCtx() context.Context {
+	return flowsession.WithInbound(context.Background(), flowsession.InboundHandle{
+		Cookies: map[string]string{
+			flowsession.CookieName(promptNoneFlowID): promptNoneFlowCookie,
+		},
+	})
+}
+
+// promptNoneApp is the OAuth client the request is made for.
+func promptNoneApp() *providers.OAuthClient {
+	return &providers.OAuthClient{ID: promptNoneAppID, ClientID: "client-1"}
+}
+
+// promptNoneSession returns a live session for the subject, authenticated the given duration ago.
+func promptNoneSession(authenticatedAgo time.Duration) *flowsession.Session {
+	return &flowsession.Session{
+		SessionID:       "sess-1",
+		SubjectID:       promptNoneSubject,
+		FlowID:          promptNoneFlowID,
+		FlowVersion:     2,
+		HandleID:        promptNoneFlowCookie,
+		AuthenticatedAt: time.Now().UTC().Add(-authenticatedAgo),
+		State:           flowsession.StateActive,
+	}
+}
+
+// wirePromptNone builds a service whose client resolves to the authentication flow above and whose
+// session service returns the given session (nil for "no live session").
+func (suite *AuthorizeServiceTestSuite) wirePromptNone(sess *flowsession.Session) *authorizeService {
+	svc := suite.newService()
+
+	flowProvider := flowexecmock.NewFlowProviderMock(suite.T())
+	flowProvider.EXPECT().GetFlow(mock.Anything, promptNoneFlowID).
+		Return(&providers.CompleteFlowDefinition{ID: promptNoneFlowID, ActiveVersion: 2}, nil).Maybe()
+	svc.flowProvider = flowProvider
+
+	ssoService := sessionmock.NewServiceMock(suite.T())
+	ssoService.EXPECT().
+		Resolve(mock.Anything, promptNoneFlowCookie, promptNoneFlowID, 2, mock.Anything).
+		Return(sess, nil).Maybe()
+	svc.ssoSession = ssoService
+
+	// The client binds to the authentication flow whose cookie carries the session handle.
+	suite.mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, promptNoneAppID).
+		Return(&inboundmodel.InboundClient{ID: promptNoneAppID, AuthFlowID: promptNoneFlowID}, nil).Maybe()
+
+	return svc
+}
+
+// TestCheckPromptNone_NotRequested covers a request without prompt=none: the check is skipped
+// entirely and no session is resolved.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_NotRequested() {
+	svc := suite.newService()
+
+	errCode, errMsg := svc.checkPromptNone(promptNoneCtx(),
+		&oauth2model.OAuthParameters{Prompt: ""}, promptNoneApp())
+
+	suite.Empty(errCode)
+	suite.Empty(errMsg)
+}
+
+// TestCheckPromptNone_NoSession covers prompt=none with nobody signed in, which is the one case
+// the specification answers with login_required.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_NoSession() {
+	svc := suite.wirePromptNone(nil)
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(),
+		&oauth2model.OAuthParameters{Prompt: oauth2const.PromptNone}, promptNoneApp())
+
+	suite.Equal(oauth2const.ErrorLoginRequired, errCode)
+}
+
+// TestCheckPromptNone_LiveSession covers the case the change exists for: an authenticated subject
+// makes prompt=none succeed without any interaction.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_LiveSession() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Minute))
+
+	errCode, errMsg := svc.checkPromptNone(promptNoneCtx(),
+		&oauth2model.OAuthParameters{Prompt: oauth2const.PromptNone}, promptNoneApp())
+
+	suite.Empty(errCode)
+	suite.Empty(errMsg)
+}
+
+// TestCheckPromptNone_NoSessionService covers a deployment without a session store (the embedded
+// engine), where prompt=none keeps answering login_required rather than panicking.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_NoSessionService() {
+	svc := suite.newService()
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(),
+		&oauth2model.OAuthParameters{Prompt: oauth2const.PromptNone}, promptNoneApp())
+
+	suite.Equal(oauth2const.ErrorLoginRequired, errCode)
+}
+
+// TestCheckPromptNone_NoInboundCookie covers a request carrying no SSO cookie at all: there is no
+// handle to resolve, so the answer is login_required.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_NoInboundCookie() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Minute))
+
+	errCode, _ := svc.checkPromptNone(context.Background(),
+		&oauth2model.OAuthParameters{Prompt: oauth2const.PromptNone}, promptNoneApp())
+
+	suite.Equal(oauth2const.ErrorLoginRequired, errCode)
+}
+
+// TestCheckPromptNone_MaxAgeExceeded covers a live session too old to satisfy max_age. Silently
+// reusing it would report an authentication older than the client asked for.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_MaxAgeExceeded() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Hour))
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(), &oauth2model.OAuthParameters{
+		Prompt: oauth2const.PromptNone,
+		MaxAge: "60",
+	}, promptNoneApp())
+
+	suite.Equal(oauth2const.ErrorLoginRequired, errCode)
+}
+
+// TestCheckPromptNone_MaxAgeWithinLimit covers a max_age the session still satisfies.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_MaxAgeWithinLimit() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Minute))
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(), &oauth2model.OAuthParameters{
+		Prompt: oauth2const.PromptNone,
+		MaxAge: "3600",
+	}, promptNoneApp())
+
+	suite.Empty(errCode)
+}
+
+// TestCheckPromptNone_MalformedMaxAge covers a max_age that does not parse: it is treated as no
+// constraint, matching how the flow's assurance check reads the same value.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_MalformedMaxAge() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Hour))
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(), &oauth2model.OAuthParameters{
+		Prompt: oauth2const.PromptNone,
+		MaxAge: "not-a-number",
+	}, promptNoneApp())
+
+	suite.Empty(errCode)
+}
+
+// TestCheckPromptNone_MaxAgeBoundary covers a session inside the limit by a margin the comparison
+// cannot lose to a clock tick. Deriving max_age from a separate time.Now() reading would race the
+// one checkPromptNone takes: a second elapsing in between turns "exactly at the limit" into "one
+// past it". The margin keeps the reuse assertion meaningful without depending on that timing.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_MaxAgeBoundary() {
+	svc := suite.wirePromptNone(promptNoneSession(60 * time.Second))
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(), &oauth2model.OAuthParameters{
+		Prompt: oauth2const.PromptNone,
+		MaxAge: "120",
+	}, promptNoneApp())
+
+	suite.Empty(errCode, "a session well inside max_age must satisfy the request")
+}
+
+// idTokenHint builds an unsigned JWT carrying the given issuer and subject. The signature is a
+// placeholder because the test mocks signature verification; only the payload is read here.
+func idTokenHint(issuer, subject string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, _ := json.Marshal(map[string]interface{}{"iss": issuer, "sub": subject})
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+// TestCheckPromptNone_IDTokenHintMatches covers a hint naming the subject who is signed in: the
+// request identifies the same user, so it succeeds without interaction.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_IDTokenHintMatches() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Minute))
+	suite.mockJWTService.EXPECT().VerifyJWTSignature(mock.Anything, mock.Anything).Return(nil)
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(), &oauth2model.OAuthParameters{
+		Prompt:      oauth2const.PromptNone,
+		IDTokenHint: idTokenHint("https://localhost:8090", promptNoneSubject),
+	}, promptNoneApp())
+
+	suite.Empty(errCode)
+}
+
+// TestCheckPromptNone_IDTokenHintDifferentSubject covers a hint naming someone other than the
+// signed-in subject. The server cannot silently switch users, so it answers login_required.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_IDTokenHintDifferentSubject() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Minute))
+	suite.mockJWTService.EXPECT().VerifyJWTSignature(mock.Anything, mock.Anything).Return(nil)
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(), &oauth2model.OAuthParameters{
+		Prompt:      oauth2const.PromptNone,
+		IDTokenHint: idTokenHint("https://localhost:8090", "someone-else"),
+	}, promptNoneApp())
+
+	suite.Equal(oauth2const.ErrorLoginRequired, errCode)
+}
+
+// TestCheckPromptNone_IDTokenHintForeignIssuer covers a hint this server did not issue, which
+// cannot be trusted to identify anyone.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_IDTokenHintForeignIssuer() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Minute))
+	suite.mockJWTService.EXPECT().VerifyJWTSignature(mock.Anything, mock.Anything).Return(nil)
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(), &oauth2model.OAuthParameters{
+		Prompt:      oauth2const.PromptNone,
+		IDTokenHint: idTokenHint("https://attacker.example.com", promptNoneSubject),
+	}, promptNoneApp())
+
+	suite.Equal(oauth2const.ErrorInvalidRequest, errCode)
+}
+
+// TestCheckPromptNone_IDTokenHintBadSignature covers a hint whose signature does not verify.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_IDTokenHintBadSignature() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Minute))
+	suite.mockJWTService.EXPECT().VerifyJWTSignature(mock.Anything, mock.Anything).
+		Return(&tidcommon.ServiceError{Code: "JWT-1001"})
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(), &oauth2model.OAuthParameters{
+		Prompt:      oauth2const.PromptNone,
+		IDTokenHint: idTokenHint("https://localhost:8090", promptNoneSubject),
+	}, promptNoneApp())
+
+	suite.Equal(oauth2const.ErrorInvalidRequest, errCode)
+}
+
+// TestCheckPromptNone_IDTokenHintNoSubject covers a hint carrying no sub claim: there is nothing to
+// compare the session against.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_IDTokenHintNoSubject() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Minute))
+	suite.mockJWTService.EXPECT().VerifyJWTSignature(mock.Anything, mock.Anything).Return(nil)
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(), &oauth2model.OAuthParameters{
+		Prompt:      oauth2const.PromptNone,
+		IDTokenHint: idTokenHint("https://localhost:8090", ""),
+	}, promptNoneApp())
+
+	suite.Equal(oauth2const.ErrorInvalidRequest, errCode)
+}
+
+// TestResolveSSOSession_NoInboundHandle covers a request that never carried the SSO cookies, which
+// happens on any path that did not read them off the request (PAR resolution, the embedded engine).
+// There is no handle to resolve, so prompt=none cannot be satisfied.
+func (suite *AuthorizeServiceTestSuite) TestResolveSSOSession_NoInboundHandle() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Minute))
+
+	// A bare context, without the inbound handle the transport would have attached.
+	suite.Nil(svc.resolveSSOSession(context.Background(), promptNoneApp()),
+		"without the inbound cookies there is no handle to resolve a session from")
+}
+
+// TestResolveSSOSession_ClientLookupFails covers the inbound client not resolving: the flow that
+// names the session's cookie is unknown, so no session can be attributed to this request.
+func (suite *AuthorizeServiceTestSuite) TestResolveSSOSession_ClientLookupFails() {
+	svc := suite.newService()
+	svc.flowProvider = flowexecmock.NewFlowProviderMock(suite.T())
+	svc.ssoSession = sessionmock.NewServiceMock(suite.T())
+	suite.mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, promptNoneAppID).
+		Return(nil, errors.New("inbound client lookup failed"))
+
+	suite.Nil(svc.resolveSSOSession(promptNoneCtx(), promptNoneApp()),
+		"an unresolvable client cannot yield a session")
+}
+
+// TestResolveSSOSession_FlowLookupFails covers the client's authentication flow not resolving. The
+// session must match the flow's active version, so without the flow there is nothing to match.
+func (suite *AuthorizeServiceTestSuite) TestResolveSSOSession_FlowLookupFails() {
+	svc := suite.newService()
+	flowProvider := flowexecmock.NewFlowProviderMock(suite.T())
+	flowProvider.EXPECT().GetFlow(mock.Anything, promptNoneFlowID).
+		Return(nil, &tidcommon.ServiceError{Code: "FLM-1001"})
+	svc.flowProvider = flowProvider
+	svc.ssoSession = sessionmock.NewServiceMock(suite.T())
+	suite.mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, promptNoneAppID).
+		Return(&inboundmodel.InboundClient{ID: promptNoneAppID, AuthFlowID: promptNoneFlowID}, nil)
+
+	suite.Nil(svc.resolveSSOSession(promptNoneCtx(), promptNoneApp()),
+		"without the flow there is no active version to match the session against")
+}
+
+// TestResolveSSOSession_ResolveErrors covers the session store failing. A store error is not a
+// silent success: the request falls back to login_required rather than assuming a session exists.
+func (suite *AuthorizeServiceTestSuite) TestResolveSSOSession_ResolveErrors() {
+	svc := suite.newService()
+	flowProvider := flowexecmock.NewFlowProviderMock(suite.T())
+	flowProvider.EXPECT().GetFlow(mock.Anything, promptNoneFlowID).
+		Return(&providers.CompleteFlowDefinition{ID: promptNoneFlowID, ActiveVersion: 2}, nil)
+	svc.flowProvider = flowProvider
+
+	ssoService := sessionmock.NewServiceMock(suite.T())
+	ssoService.EXPECT().
+		Resolve(mock.Anything, promptNoneFlowCookie, promptNoneFlowID, 2, mock.Anything).
+		Return(nil, errors.New("session store unavailable"))
+	svc.ssoSession = ssoService
+
+	suite.mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, promptNoneAppID).
+		Return(&inboundmodel.InboundClient{ID: promptNoneAppID, AuthFlowID: promptNoneFlowID}, nil)
+
+	suite.Nil(svc.resolveSSOSession(promptNoneCtx(), promptNoneApp()),
+		"a store failure must not be mistaken for a live session")
+}
+
+// TestSubjectFromIDTokenHint_Undecodable covers a hint that passes signature verification but whose
+// payload cannot be decoded, so no subject can be read from it.
+func (suite *AuthorizeServiceTestSuite) TestSubjectFromIDTokenHint_Undecodable() {
+	svc := suite.wirePromptNone(promptNoneSession(time.Minute))
+	suite.mockJWTService.EXPECT().VerifyJWTSignature(mock.Anything, mock.Anything).Return(nil)
+
+	_, err := svc.subjectFromIDTokenHint(context.Background(), "header.%%%.signature")
+
+	suite.Error(err, "an undecodable payload cannot yield a subject")
+}
+
+// TestCheckPromptNone_MaxAgeZeroIsNeverSatisfied covers max_age=0 against a session authenticated
+// moments ago. No existing authentication can satisfy a zero window, so the silent path is refused
+// rather than reusing a session that happens to fall in the same Unix second.
+func (suite *AuthorizeServiceTestSuite) TestCheckPromptNone_MaxAgeZeroIsNeverSatisfied() {
+	svc := suite.wirePromptNone(promptNoneSession(0))
+
+	errCode, _ := svc.checkPromptNone(promptNoneCtx(), &oauth2model.OAuthParameters{
+		Prompt: oauth2const.PromptNone,
+		MaxAge: "0",
+	}, promptNoneApp())
+
+	suite.Equal(oauth2const.ErrorLoginRequired, errCode,
+		"max_age=0 cannot be answered from an existing session")
+}

--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
@@ -127,9 +127,10 @@ func ValidatePromptParameter(prompt string) (string, string) {
 				"prompt value 'none' must not be combined with other values"
 		}
 
-		// The server does not support server-side sessions as of now.
-		return constants.ErrorLoginRequired,
-			"User authentication is required"
+		// Whether "none" can be honored depends on an existing SSO session, which this shared
+		// parameter validation cannot see. The authorize endpoint decides it against the resolved
+		// session; the PAR endpoint only stores the request, so the decision waits for the
+		// authorization request that later resolves the request_uri.
 	}
 
 	// The server does not support account selection prompts as of now.

--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
@@ -229,13 +229,17 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PromptLogin_Success() 
 	assert.Empty(suite.T(), errMsg)
 }
 
-func (suite *AuthzValidationTestSuite) TestValidateParams_PromptNone_LoginRequired() {
+// TestValidateParams_PromptNone_Accepted covers prompt=none passing shared parameter validation.
+// Whether it can be honored depends on an existing SSO session, which this validation cannot see,
+// so the authorize endpoint decides it against the resolved session instead.
+func (suite *AuthzValidationTestSuite) TestValidateParams_PromptNone_Accepted() {
 	params := suite.validParams()
 	params.Set(constants.RequestParamPrompt, "none")
 
-	errCode, _ := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
+	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
-	assert.Equal(suite.T(), constants.ErrorLoginRequired, errCode)
+	assert.Empty(suite.T(), errCode)
+	assert.Empty(suite.T(), errMsg)
 }
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_PromptInvalid() {
@@ -362,9 +366,13 @@ func (suite *AuthzValidationTestSuite) TestValidatePromptParameter_Login() {
 	assert.Empty(suite.T(), errCode)
 }
 
-func (suite *AuthzValidationTestSuite) TestValidatePromptParameter_None_LoginRequired() {
-	errCode, _ := ValidatePromptParameter("none")
-	assert.Equal(suite.T(), constants.ErrorLoginRequired, errCode)
+// TestValidatePromptParameter_None_Accepted covers "none" being a valid parameter value on its
+// own. The login_required decision belongs to the authorize endpoint, which can consult the
+// session this function cannot see.
+func (suite *AuthzValidationTestSuite) TestValidatePromptParameter_None_Accepted() {
+	errCode, errMsg := ValidatePromptParameter("none")
+	assert.Empty(suite.T(), errCode)
+	assert.Empty(suite.T(), errMsg)
 }
 
 func (suite *AuthzValidationTestSuite) TestValidatePromptParameter_Consent() {

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -11,11 +11,13 @@ import (
 	"maps"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
 	flowcm "github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/flowexec"
+	flowsession "github.com/thunder-id/thunderid/internal/flow/session"
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/authz/requestvalidator"
 	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
@@ -30,6 +32,10 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/utils"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
+
+// runtimeDataTrue is the value the flow layer reads as a set boolean flag on RuntimeData, which
+// carries string values only.
+const runtimeDataTrue = "true"
 
 // AuthorizeServiceInterface defines the interface for authorization services.
 type AuthorizeServiceInterface interface {
@@ -53,7 +59,13 @@ type authorizeService struct {
 	flowExecService flowexec.FlowExecServiceInterface
 	transactioner   providers.Transactioner
 	criteriaRevoker revocation.CriteriaRevokerInterface
-	logger          *log.Logger
+	// ssoSession resolves an existing SSO session so prompt=none can be answered from it, and
+	// flowProvider supplies the client's authentication flow, whose id names the session's cookie
+	// and whose active version the session must match. Both are nil in deployments without a
+	// session store (the embedded engine), where prompt=none keeps answering login_required.
+	ssoSession   flowsession.Service
+	flowProvider providers.FlowProvider
+	logger       *log.Logger
 }
 
 // newAuthorizeService creates a new instance of authorizeService with injected dependencies.
@@ -67,6 +79,8 @@ func newAuthorizeService(
 	parService par.PARServiceInterface,
 	transactioner providers.Transactioner,
 	criteriaRevoker revocation.CriteriaRevokerInterface,
+	ssoSession flowsession.Service,
+	flowProvider providers.FlowProvider,
 	cfg oauthconfig.Config,
 ) AuthorizeServiceInterface {
 	return &authorizeService{
@@ -81,8 +95,111 @@ func newAuthorizeService(
 		flowExecService: flowExecService,
 		transactioner:   transactioner,
 		criteriaRevoker: criteriaRevoker,
+		ssoSession:      ssoSession,
+		flowProvider:    flowProvider,
 		logger:          log.GetLogger().With(log.String(log.LoggerKeyComponentName, "AuthorizeService")),
 	}
+}
+
+// checkPromptNone decides whether a prompt=none request can be answered without interaction,
+// returning an empty error code when it can (including when prompt=none was not requested).
+//
+// Per OIDC Core 3.1.2.1 the request succeeds only when the End-User is already authenticated, so
+// all three conditions must hold: a live SSO session exists, it belongs to the subject named by
+// id_token_hint when one is supplied, and its authentication satisfies max_age. Any failure is
+// login_required — the specification's answer for "authentication is needed but cannot be asked
+// for".
+func (as *authorizeService) checkPromptNone(
+	ctx context.Context, oauthParams *oauth2model.OAuthParameters, app *providers.OAuthClient,
+) (string, string) {
+	if !slices.Contains(strings.Fields(oauthParams.Prompt), oauth2const.PromptNone) {
+		return "", ""
+	}
+
+	sess := as.resolveSSOSession(ctx, app)
+	if sess == nil {
+		return oauth2const.ErrorLoginRequired, "User authentication is required"
+	}
+
+	if hint := oauthParams.IDTokenHint; hint != "" {
+		subject, err := as.subjectFromIDTokenHint(ctx, hint)
+		if err != nil {
+			return oauth2const.ErrorInvalidRequest, "Invalid id_token_hint"
+		}
+		if subject != sess.SubjectID {
+			// A hint naming someone other than the signed-in subject cannot be satisfied silently.
+			return oauth2const.ErrorLoginRequired,
+				"The session does not belong to the subject named by id_token_hint"
+		}
+	}
+
+	if oauthParams.MaxAge != "" {
+		maxAge, err := strconv.ParseInt(oauthParams.MaxAge, 10, 64)
+		// A malformed max_age is no constraint, matching how the flow's assurance check reads it.
+		// max_age=0 admits no elapsed time, so no existing session can satisfy it and the request
+		// cannot be answered silently.
+		if err == nil && maxAge >= 0 &&
+			(maxAge == 0 || time.Now().UTC().Unix()-sess.AuthenticatedAt.Unix() > maxAge) {
+			return oauth2const.ErrorLoginRequired,
+				"The existing authentication is older than the requested max_age"
+		}
+	}
+
+	return "", ""
+}
+
+// subjectFromIDTokenHint verifies the hint was issued by this server and returns its subject. The
+// token's expiry is deliberately not enforced: the hint identifies who was authenticated, and OIDC
+// Core requires it to be accepted even once expired.
+func (as *authorizeService) subjectFromIDTokenHint(ctx context.Context, idTokenHint string) (string, error) {
+	if svcErr := as.jwtService.VerifyJWTSignature(ctx, idTokenHint); svcErr != nil {
+		return "", errors.New("id_token_hint signature is not valid")
+	}
+	payload, err := jwt.DecodeJWTPayload(idTokenHint)
+	if err != nil {
+		return "", errors.New("id_token_hint could not be decoded")
+	}
+	if iss, _ := payload[oauth2const.ClaimIss].(string); iss != as.cfg.JWT.Issuer {
+		return "", errors.New("id_token_hint was not issued by this server")
+	}
+	subject, _ := payload[oauth2const.ClaimSub].(string)
+	if subject == "" {
+		return "", errors.New("id_token_hint carries no subject")
+	}
+	return subject, nil
+}
+
+// resolveSSOSession returns the live SSO session backing this request's client, or nil when there
+// is none. The handle is carried on a per-flow cookie, so the client's authentication flow has to
+// be resolved before the right cookie can be selected.
+func (as *authorizeService) resolveSSOSession(
+	ctx context.Context, app *providers.OAuthClient,
+) *flowsession.Session {
+	if as.ssoSession == nil || as.flowProvider == nil {
+		return nil
+	}
+	inbound, ok := flowsession.InboundFrom(ctx)
+	if !ok {
+		return nil
+	}
+
+	client, svcErr := as.inboundClient.GetInboundClientByID(ctx, app.ID)
+	if svcErr != nil || client == nil || client.AuthFlowID == "" {
+		return nil
+	}
+	flow, flowErr := as.flowProvider.GetFlow(ctx, client.AuthFlowID)
+	if flowErr != nil || flow == nil {
+		return nil
+	}
+
+	handle := inbound.HandleFor(client.AuthFlowID)
+	sess, err := as.ssoSession.Resolve(ctx, handle, client.AuthFlowID, flow.ActiveVersion, time.Now().UTC())
+	if err != nil {
+		as.logger.Debug(ctx, "Failed to resolve the SSO session for the authorization request",
+			log.Error(err))
+		return nil
+	}
+	return sess
 }
 
 // GetAuthorizationCodeDetails retrieves and consumes the authorization code.
@@ -364,6 +481,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 		MaxAge:              maxAge,
 		DPoPJkt:             dpopJkt,
 		Prompt:              prompt,
+		IDTokenHint:         queryParams.Get(oauth2const.RequestParamIDTokenHint),
 	}
 
 	// Set the redirect URI if not provided in the request. Invalid cases are already handled at this point.
@@ -389,6 +507,19 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 	ctx context.Context, oauthParams *oauth2model.OAuthParameters,
 	app *providers.OAuthClient, initiatorReq *providers.InitiatorRequest,
 ) (*AuthorizationInitResult, *AuthorizationError) {
+	// prompt=none forbids any user interaction, so it can only be honored by an existing session
+	// that also satisfies id_token_hint and max_age. This is checked here, where both the standard
+	// and PAR paths converge, and before the flow starts: the flow would otherwise prompt.
+	if errCode, errMsg := as.checkPromptNone(ctx, oauthParams, app); errCode != "" {
+		return nil, &AuthorizationError{
+			Code:              errCode,
+			Message:           errMsg,
+			SendErrorToClient: oauthParams.RedirectURI != "",
+			ClientRedirectURI: oauthParams.RedirectURI,
+			State:             oauthParams.State,
+		}
+	}
+
 	// Bind the request to a single target resource server before the flow starts. OIDC-only or
 	// scopeless requests stay unbound and their audience is the client_id. A permission-bearing
 	// request resolves an explicit resource or the configured default, rejecting with invalid_target
@@ -459,7 +590,20 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 		runtimeData[flowcm.RuntimeKeyRequestedAuthClasses] = effectiveAcrValues
 	}
 	if slices.Contains(strings.Fields(oauthParams.Prompt), oauth2const.PromptConsent) {
-		runtimeData[flowcm.RuntimeKeyForceConsentReprompt] = "true"
+		runtimeData[flowcm.RuntimeKeyForceConsentReprompt] = runtimeDataTrue
+	}
+	// prompt=login requires a fresh authentication regardless of any existing session (OIDC Core
+	// 3.1.2.1), so tell the SSO-Check node not to reuse one.
+	if slices.Contains(strings.Fields(oauthParams.Prompt), oauth2const.PromptLogin) {
+		runtimeData[flowcm.RuntimeKeyForceReauth] = runtimeDataTrue
+	}
+	// prompt=none reached this point only because checkPromptNone found a session that satisfies the
+	// request, so tell the SSO-Check node to honor that decision instead of re-evaluating max_age
+	// against its own clock. Both comparisons are strictly greater against a fresh time.Now(), so a
+	// session exactly on the boundary passes here and could fail there, prompting a request that
+	// forbids prompting.
+	if slices.Contains(strings.Fields(oauthParams.Prompt), oauth2const.PromptNone) {
+		runtimeData[flowcm.RuntimeKeySilentAuthOnly] = runtimeDataTrue
 	}
 	if oauthParams.MaxAge != "" {
 		runtimeData[flowcm.RuntimeKeyMaxAge] = oauthParams.MaxAge
@@ -831,9 +975,14 @@ func createAuthorizationCode(
 		return AuthorizationCode{}, errors.New("authenticated user not found")
 	}
 
+	// The code's own lifetime runs from now, not from authTime. On the SSO path authTime is the
+	// reused session's authentication, which can be hours old; measuring expiry from it would mint
+	// codes that are already expired and fail insertion outright.
+	now := time.Now()
+
 	// Use provided authTime, or fallback to current time if zero (iat claim was not available).
 	if authTime.IsZero() {
-		authTime = time.Now()
+		authTime = now
 	}
 
 	standardScopes := authRequestCtx.OAuthParameters.StandardScopes
@@ -842,7 +991,7 @@ func createAuthorizationCode(
 	resources := authRequestCtx.OAuthParameters.Resources
 
 	validityPeriod := cfg.OAuth.AuthorizationCode.ValidityPeriod
-	expiryTime := authTime.Add(time.Duration(validityPeriod) * time.Second)
+	expiryTime := now.Add(time.Duration(validityPeriod) * time.Second)
 
 	codeID, err := utils.GenerateUUIDv7()
 	if err != nil {
@@ -874,7 +1023,8 @@ func createAuthorizationCode(
 		RedirectURIProvided: authRequestCtx.OAuthParameters.RedirectURIProvided,
 		AuthorizedUserID:    claims.userID,
 		AttributeCacheID:    claims.attributeCacheID,
-		TimeCreated:         authTime,
+		TimeCreated:         now,
+		AuthTime:            authTime,
 		ExpiryTime:          expiryTime,
 		Scopes:              utils.StringifyStringArray(allScopes, " "),
 		State:               AuthCodeStateActive,

--- a/backend/internal/oauth/oauth2/authz/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/validator_test.go
@@ -547,7 +547,10 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCENotRequir
 
 // Prompt Parameter Validation Tests (OIDC Core §3.1.2.1)
 
-func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptNone_LoginRequired() {
+// TestValidateInitialAuthzRequest_PromptNone_Accepted covers prompt=none passing request
+// validation. The login_required decision is made later, against the resolved SSO session, by
+// checkPromptNone; validation here cannot see a session.
+func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptNone_Accepted() {
 	msg := &OAuthMessage{
 		RequestQueryParams: url.Values{
 			constants.RequestParamClientID:     {"test-client-id"},
@@ -560,9 +563,9 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(context.Background(),
 		msg, suite.oauthApp)
 
-	assert.True(suite.T(), sendErrorToApp)
-	assert.Equal(suite.T(), constants.ErrorLoginRequired, errorCode)
-	assert.Equal(suite.T(), "User authentication is required", errorMessage)
+	assert.False(suite.T(), sendErrorToApp)
+	assert.Empty(suite.T(), errorCode)
+	assert.Empty(suite.T(), errorMessage)
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_PromptLogin_Success() {

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -45,6 +45,16 @@ func newAuthorizationCodeGrantHandler(
 	}
 }
 
+// resolveAuthTime returns when the subject authenticated. Codes minted before AuthTime existed as a
+// field unmarshal with a zero value, so their creation time stands in: for those codes the two
+// moments coincided anyway, since authorization did not consult an existing session.
+func resolveAuthTime(authCode *authz.AuthorizationCode) int64 {
+	if authCode.AuthTime.IsZero() {
+		return authCode.TimeCreated.Unix()
+	}
+	return authCode.AuthTime.Unix()
+}
+
 // ValidateGrant validates the authorization code grant request.
 func (h *authorizationCodeGrantHandler) ValidateGrant(ctx context.Context, tokenRequest *model.TokenRequest,
 	oauthApp *providers.OAuthClient) *model.ErrorResponse {
@@ -193,7 +203,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 			Audience:       tokenRequest.ClientID,
 			Scopes:         accessTokenScopes,
 			UserAttributes: attrs,
-			AuthTime:       authCode.TimeCreated.Unix(),
+			AuthTime:       resolveAuthTime(authCode),
 			OAuthApp:       oauthApp,
 			ClaimsRequest:  authCode.ClaimsRequest,
 			Nonce:          authCode.Nonce,

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -1608,3 +1608,32 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_DownscopeVa
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
 }
+
+// TestResolveAuthTime_ZeroFallsBackToCreation covers codes minted before AuthTime existed as a field:
+// they unmarshal from the runtime store with a zero value, so a code still in flight across an
+// upgrade must not report a year-1 authentication. Its creation time is the right stand-in, since
+// authorization did not consult an existing session for those codes.
+func (suite *AuthorizationCodeGrantHandlerTestSuite) TestResolveAuthTime_ZeroFallsBackToCreation() {
+	created := time.Now().Add(-2 * time.Minute)
+	code := &authz.AuthorizationCode{TimeCreated: created}
+
+	got := resolveAuthTime(code)
+
+	suite.Equal(created.Unix(), got, "a zero AuthTime should fall back to the code's creation time")
+	suite.Positive(got, "the fallback must never yield a negative Unix timestamp")
+}
+
+// TestResolveAuthTime_PrefersAuthTime verifies the normal path: when the field is set it wins, which
+// is what keeps auth_time stable across a reused session.
+func (suite *AuthorizationCodeGrantHandlerTestSuite) TestResolveAuthTime_PrefersAuthTime() {
+	authenticated := time.Now().Add(-time.Hour)
+	code := &authz.AuthorizationCode{
+		TimeCreated: time.Now(),
+		AuthTime:    authenticated,
+	}
+
+	got := resolveAuthTime(code)
+
+	suite.Equal(authenticated.Unix(), got,
+		"auth_time must report the authentication, not when the code was minted")
+}

--- a/backend/internal/oauth/oauth2/model/parameter.go
+++ b/backend/internal/oauth/oauth2/model/parameter.go
@@ -32,6 +32,7 @@ type OAuthParameters struct {
 	MaxAge              string
 	DPoPJkt             string
 	Prompt              string
+	IDTokenHint         string
 }
 
 // VerifiedClaimsMember is the OIDC Identity Assurance member name that may appear in the

--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -154,6 +154,7 @@ func (s *parService) HandlePushedAuthorizationRequest(
 		MaxAge:              params[oauth2const.RequestParamMaxAge],
 		DPoPJkt:             resolveDPoPJkt(params[oauth2const.RequestParamDPoPJkt], dpopHeaderJkt),
 		Prompt:              params[oauth2const.RequestParamPrompt],
+		IDTokenHint:         params[oauth2const.RequestParamIDTokenHint],
 	}
 
 	initiatorQueryParams := make(map[string][]string, len(params)+1)

--- a/backend/internal/oauth/oauth2/par/service_test.go
+++ b/backend/internal/oauth/oauth2/par/service_test.go
@@ -206,18 +206,21 @@ func (s *ServiceTestSuite) TestHandlePAR_StoreError() {
 	assert.Equal(s.T(), oauth2const.ErrorServerError, errCode)
 }
 
-func (s *ServiceTestSuite) TestHandlePAR_PromptNone_LoginRequired() {
+// TestHandlePAR_PromptNone_Stored covers PAR accepting prompt=none. PAR only stores the request;
+// whether "none" can be honored depends on an SSO session that only the later authorization
+// request, which resolves the request_uri, is able to consult.
+func (s *ServiceTestSuite) TestHandlePAR_PromptNone_Stored() {
 	store := newParStoreInterfaceMock(s.T())
+	store.EXPECT().Store(mock.Anything, mock.Anything, mock.Anything).Return("test-uri", nil)
 	svc := newPARService(store, s.newPermissiveResourceMock(), s.testCfg)
 	app := s.newTestApp()
 	params := s.newValidParams()
 	params[oauth2const.RequestParamPrompt] = "none"
 
-	resp, errCode, errDesc := svc.HandlePushedAuthorizationRequest(s.ctx, params, nil, app, "")
+	resp, errCode, _ := svc.HandlePushedAuthorizationRequest(s.ctx, params, nil, app, "")
 
-	assert.Nil(s.T(), resp)
-	assert.Equal(s.T(), oauth2const.ErrorLoginRequired, errCode)
-	assert.Equal(s.T(), "User authentication is required", errDesc)
+	assert.Empty(s.T(), errCode)
+	assert.NotNil(s.T(), resp)
 }
 
 func (s *ServiceTestSuite) TestHandlePAR_PromptInvalid() {

--- a/backend/internal/oauth/oauth2/utils/assertion.go
+++ b/backend/internal/oauth/oauth2/utils/assertion.go
@@ -69,6 +69,16 @@ func DecodeFlowAssertionClaims(assertion string) (FlowAssertionClaims, map[strin
 		claims.AuthTime = time.Unix(iat, 0)
 	}
 
+	// auth_time, when the flow supplies it, is when the subject authenticated, which on the SSO
+	// path predates this assertion. It therefore wins over the iat fallback above.
+	if authTimeValue, ok := jwtPayload[oauth2const.ClaimAuthTime]; ok {
+		authTime, ok := sysutils.ToInt64(authTimeValue)
+		if !ok {
+			return claims, nil, errors.New("JWT 'auth_time' claim has unexpected type")
+		}
+		claims.AuthTime = time.Unix(authTime, 0)
+	}
+
 	if subValue, ok := jwtPayload[oauth2const.ClaimSub]; ok {
 		strValue, ok := subValue.(string)
 		if !ok {

--- a/backend/internal/oauth/oauth2/utils/oauthutils_test.go
+++ b/backend/internal/oauth/oauth2/utils/oauthutils_test.go
@@ -1731,6 +1731,45 @@ func (suite *OAuth2UtilsTestSuite) TestDecodeFlowAssertionClaims_ValidWithAllCla
 	suite.Equal(int64(1700000002), claims.AuthTime.Unix())
 }
 
+// TestDecodeFlowAssertionClaims_AuthTimeWinsOverIat covers the SSO path, where the subject
+// authenticated before this assertion was issued. auth_time carries that earlier moment and must
+// win over iat, or the claim would advance on every authorization within one session.
+func (suite *OAuth2UtilsTestSuite) TestDecodeFlowAssertionClaims_AuthTimeWinsOverIat() {
+	assertion := buildTestAssertion(map[string]interface{}{
+		"sub":       "user-sso",
+		"iat":       float64(1700000000),
+		"auth_time": float64(1699990000),
+	})
+
+	claims, _, err := DecodeFlowAssertionClaims(assertion)
+	suite.NoError(err)
+	suite.Equal(int64(1699990000), claims.AuthTime.Unix())
+}
+
+// TestDecodeFlowAssertionClaims_NoAuthTimeFallsBackToIat covers an assertion minted without the
+// claim, where the fresh-authentication reading of iat remains correct.
+func (suite *OAuth2UtilsTestSuite) TestDecodeFlowAssertionClaims_NoAuthTimeFallsBackToIat() {
+	assertion := buildTestAssertion(map[string]interface{}{
+		"sub": "user-fresh",
+		"iat": float64(1700000000),
+	})
+
+	claims, _, err := DecodeFlowAssertionClaims(assertion)
+	suite.NoError(err)
+	suite.Equal(int64(1700000000), claims.AuthTime.Unix())
+}
+
+func (suite *OAuth2UtilsTestSuite) TestDecodeFlowAssertionClaims_AuthTimeUnexpectedType_ReturnsError() {
+	assertion := buildTestAssertion(map[string]interface{}{
+		"sub":       "user-bad",
+		"iat":       float64(1700000000),
+		"auth_time": "not-a-number",
+	})
+
+	_, _, err := DecodeFlowAssertionClaims(assertion)
+	suite.Error(err)
+}
+
 func (suite *OAuth2UtilsTestSuite) TestDecodeFlowAssertionClaims_IatUnexpectedType_ReturnsError() {
 	assertion := buildTestAssertion(map[string]interface{}{
 		"sub": "user-x",

--- a/backend/pkg/thunderidengine/engine.go
+++ b/backend/pkg/thunderidengine/engine.go
@@ -226,7 +226,10 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 		engineCtx.jweService, engineCtx.flowExecService, engineCtx.observabilitySvc, engineCtx.runtimeCryptoSvc,
 		engineCtx.ouProvider, engineCtx.attributeCacheService, engineCtx.authzProvider, engineCtx.resourceProvider,
 		engineCtx.i18nProvider, engineCtx.idpProvider, engineCtx.dpopVerifier, engineCtx.runtimeStoreProvider,
-		engineCtx.transactioner, revocationEnforcer, revocationService, oauthConfig)
+		engineCtx.transactioner, revocationEnforcer, revocationService,
+		// The embedded engine has no SSO session store, so prompt=none keeps answering
+		// login_required rather than consulting a session.
+		nil, engineCtx.flowProvider, oauthConfig)
 	if err != nil {
 		logger.Fatal(ctx, "Failed to initialize OAuth services", log.Error(err))
 	}

--- a/docs/content/guides/protocols/oauth-oidc/openid-connect.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/openid-connect.mdx
@@ -55,18 +55,32 @@ These parameters on the authorization request control *how* the user authenticat
 | Parameter | Purpose | Notes |
 |---|---|---|
 | `nonce` | Replay protection for the ID Token | Max 64 characters. Required for clients that accept the ID Token. |
-| `prompt` | Control re-authentication | Only `login` and `consent` is currently honored, see below |
+| `prompt` | Control re-authentication | `login`, `none`, and `consent` are honored, see below |
+| `max_age` | Limit how old the authentication may be | Seconds. An existing session older than this is not reused, so the user authenticates again. |
+| `id_token_hint` | Name the user the request expects | An ID Token this <ProductName /> instance issued. Used with `prompt=none` to confirm the existing session belongs to that user. |
 | `acr_values` | Request a specific authentication context | <ProductName /> selects an authentication flow that satisfies the requested ACR |
 | `claims` | Request specific claims claim-by-claim | See [Claims & Scopes](../claims-and-scopes) |
+
+`prompt`, `max_age`, and `id_token_hint` are answered from the SSO session the authentication flow maintains, so they apply to applications whose flow includes a **Check SSO Session** node. See [Single Sign-On](../../../flows/single-sign-on) for how a flow establishes one. The remaining parameters do not depend on a session.
+
+:::note
+`prompt=none` is answered by checking that a live session exists for the application's flow. A flow containing more than one **Check SSO Session** node, such as a step-up authentication flow, can therefore pass that check and still need to prompt at a later node, in which case the request fails rather than completing silently.
+:::
 
 ### `prompt` Values
 
 | Value | Behavior |
 |---|---|
-| `login` | Forces the user to authenticate. **Supported.** |
-| `none` | Returns `login_required`. <ProductName /> does not yet maintain server-side sessions, so silent re-authentication is not available. |
+| `login` | Forces the user to authenticate, even when a session exists. **Supported.** |
+| `none` | Completes without any user interaction when a session satisfies the request. Returns `login_required` when no session exists, when `id_token_hint` names a different user, or when the authentication is older than `max_age`. |
 | `consent` | Forces the user to re-grant consent for all required attributes, even if consent was previously granted. |
 | `select_account` | Returns `account_selection_required`: account selection is not currently supported. |
+
+### `max_age` and `auth_time`
+
+`max_age` bounds how long ago the user authenticated. <ProductName /> compares it against the session's authentication time, not the time the authorization request arrived, so reusing a session does not make the authentication look fresher than it is.
+
+The ID Token's `auth_time` claim reports that same moment. Two authorizations that reuse one session therefore carry the same `auth_time`, while an authorization that re-authenticated carries a later one.
 
 ## Try It in <ProductName />
 

--- a/tests/integration/oauth/authz/prompt_test.go
+++ b/tests/integration/oauth/authz/prompt_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 // TestAuthorize_PromptNone_LoginRequired verifies that prompt=none is redirected back to the client
-// with error=login_required, since the server does not support silent re-authentication via
-// server-side sessions (OIDC Core §3.1.2.1).
+// with error=login_required when no SSO session exists, which is the specification's answer for
+// "authentication is required but cannot be asked for" (OIDC Core §3.1.2.1). This request carries
+// no session cookie; the silent-success path is covered in tests/integration/oauth/sso.
 func (ts *AuthzTestSuite) TestAuthorize_PromptNone_LoginRequired() {
 	resp, err := testutils.InitiateAuthorizationFlowWithPrompt(
 		clientID, redirectURI, "code", "openid", "prompt-none-state", "none")

--- a/tests/integration/oauth/par/par_test.go
+++ b/tests/integration/oauth/par/par_test.go
@@ -378,20 +378,6 @@ func (ts *PARTestSuite) TestPAREndpointValidation() {
 			ExpectedError: "invalid_request",
 		},
 		{
-			// This test reflects current behavior; prompt=none session checking is not implemented yet.
-			Name: "Prompt None Not Supported",
-			Params: map[string]string{
-				"response_type":         "code",
-				"redirect_uri":          redirectURI,
-				"scope":                 "openid",
-				"state":                 "test",
-				"prompt":                "none",
-				"code_challenge":        testutils.GenerateCodeChallenge("test-verifier-that-is-at-least-43-characters-long-enough"),
-				"code_challenge_method": "S256",
-			},
-			ExpectedError: "login_required",
-		},
-		{
 			// This test reflects current behavior; account selection prompts are not implemented yet.
 			Name: "Prompt Select Account Not Supported",
 			Params: map[string]string{
@@ -417,6 +403,29 @@ func (ts *PARTestSuite) TestPAREndpointValidation() {
 			ts.Equal(tc.ExpectedError, result.Error.Error)
 		})
 	}
+}
+
+// TestPAREndpointAcceptsPromptNone verifies that pushing prompt=none is stored rather than
+// refused. PAR carries no cookies, so it cannot see whether a session exists; deciding here would
+// refuse every silent authorization a PAR client could make. The decision belongs to the
+// authorization request that later resolves the request_uri, which can read the session.
+func (ts *PARTestSuite) TestPAREndpointAcceptsPromptNone() {
+	result, err := testutils.SubmitPARRequest(clientID, clientSecret, map[string]string{
+		"response_type":         "code",
+		"redirect_uri":          redirectURI,
+		"scope":                 "openid",
+		"state":                 "test",
+		"prompt":                "none",
+		"code_challenge":        testutils.GenerateCodeChallenge("test-verifier-that-is-at-least-43-characters-long-enough"),
+		"code_challenge_method": "S256",
+	})
+	ts.Require().NoError(err)
+
+	ts.Equal(http.StatusCreated, result.StatusCode,
+		"prompt=none must be stored, since PAR cannot see the session that decides it")
+	ts.Nil(result.Error, "storing the request is not an error")
+	ts.Require().NotNil(result.PAR, "a stored request must return a request_uri")
+	ts.NotEmpty(result.PAR.RequestURI, "the pushed request should be retrievable by its uri")
 }
 
 // TestPARAuthorizationFlowWithPKCE tests the full PAR + authorization code flow with PKCE.

--- a/tests/integration/oauth/sso/max_age_test.go
+++ b/tests/integration/oauth/sso/max_age_test.go
@@ -5,11 +5,13 @@ package sso
 
 import "time"
 
-// The OIDC max_age parameter is enforced by the AuthAssertExecutor's assurance check, which only has
-// an authentication timestamp to compare against when an SSO checkpoint was loaded. On a first-time
-// login the subject authenticates during the execution itself, so the constraint is trivially met.
-// These tests therefore always establish a session first and then re-authorize over it, which is the
-// only path where max_age can actually bite.
+// The OIDC max_age parameter is answered by the SSO-Check node, which declines to reuse a session
+// whose authentication is older than the requested window and routes the flow to full
+// authentication instead. On a first-time login the subject authenticates during the execution
+// itself, so the constraint is trivially met. These tests therefore always establish a session
+// first and then re-authorize over it, which is the only path where max_age can actually bite.
+// The AuthAssertExecutor's assurance check still guards the same constraint at the end of the flow,
+// but re-authenticating at the branch point means it is no longer the first thing to notice.
 //
 // Every test builds its own cookie jar via newSessionClient so its session, and therefore its
 // authentication time, is fresh and unambiguous regardless of the order tests run in.
@@ -30,12 +32,10 @@ func (ts *SSOLogoutTestSuite) TestMaxAge_WithinWindowReusesSession() {
 	ts.Nil(step.Error, "no assurance error should be reported")
 }
 
-// TestMaxAge_ExpiredSessionRequiresInteraction verifies that a session older than max_age fails the
-// assurance check: the flow terminates in-band with FET-1082 (interaction required) and mints no
-// assertion, so no authorization code can be issued.
-//
-// Only the flow-level outcome is asserted. Mapping this failure onto an OAuth2 authorize error is an
-// open TODO in the product, so the downstream error code is deliberately left unpinned.
+// TestMaxAge_ExpiredSessionRequiresInteraction verifies that a session older than max_age is not
+// reused: the SSO-Check node declines it and the flow prompts for credentials instead, which is
+// what OIDC Core requires of max_age. Erroring out would leave the client unable to proceed even
+// though the End-User is present and able to authenticate.
 func (ts *SSOLogoutTestSuite) TestMaxAge_ExpiredSessionRequiresInteraction() {
 	client := ts.newSessionClient()
 	ts.login(client, ssoMaxAgeUsername, "max_age_expired_1")
@@ -47,10 +47,75 @@ func (ts *SSOLogoutTestSuite) TestMaxAge_ExpiredSessionRequiresInteraction() {
 	_, executionID := ts.authorizeWithMaxAge(client, "openid", "max_age_expired_2", "1")
 	step := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
 
-	ts.Require().Equal("ERROR", step.FlowStatus, "a session older than max_age must not satisfy the request")
-	ts.Require().NotNil(step.Error, "the failed flow should carry a structured error")
-	ts.Equal("FET-1082", step.Error.Code, "re-authentication should be reported as interaction required")
-	ts.Empty(step.Assertion, "no authentication assertion may be minted for an expired session")
+	ts.Require().NotEqual("COMPLETE", step.FlowStatus,
+		"a session older than max_age must not satisfy the request without re-authentication")
+	ts.Empty(step.Assertion, "no assertion may be minted before the subject re-authenticates")
+	// The SSO-Check node reports FET-1081 as it routes to the full-authentication path, so the step
+	// carries that alongside the prompt. What matters is that the flow asks for credentials rather
+	// than failing: it must still offer a challenge the subject can answer.
+	ts.NotEmpty(step.ChallengeToken,
+		"declining the session must yield a credential prompt, not a dead end")
+	if step.Error != nil {
+		ts.Equal("FET-1081", step.Error.Code,
+			"the only error accompanying the prompt should be the SSO-Check routing outcome")
+	}
+}
+
+// TestMaxAge_ExpiredSessionReauthenticationSucceeds verifies the other half: after the prompt, the
+// subject can authenticate again and the flow completes, so max_age costs a login rather than
+// failing the request outright.
+func (ts *SSOLogoutTestSuite) TestMaxAge_ExpiredSessionReauthenticationSucceeds() {
+	client := ts.newSessionClient()
+	ts.login(client, ssoMaxAgeUsername, "max_age_reauth_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	time.Sleep(3 * time.Second)
+
+	_, executionID := ts.authorizeWithMaxAge(client, "openid", "max_age_reauth_2", "1")
+	initial := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+	ts.Require().NotEqual("COMPLETE", initial.FlowStatus, "an expired session must prompt for credentials")
+
+	step := ts.flowExecute(client, map[string]interface{}{
+		"executionId":    executionID,
+		"inputs":         map[string]string{"username": ssoMaxAgeUsername, "password": testPassword},
+		"action":         "action_001",
+		"challengeToken": initial.ChallengeToken,
+	})
+
+	ts.Equal("COMPLETE", step.FlowStatus, "re-authentication should complete the flow")
+	ts.NotEmpty(step.Assertion, "the re-authenticated flow should yield an assertion")
+}
+
+// TestMaxAge_ZeroReauthenticationSucceeds covers max_age=0, which OIDC Core treats as equivalent to
+// prompt=login: no existing session may satisfy it, so the flow must prompt, and the credentials
+// supplied at that prompt must then complete it. The completion half is what matters here. The
+// SSO-Check node and the authorize endpoint both reject max_age=0 outright, since both decide
+// whether to reuse an existing authentication; the assurance check at the end of the flow asks
+// instead whether the authentication being asserted is fresh enough, and a just-completed one is.
+// Rejecting there too would leave max_age=0 unsatisfiable even immediately after the
+// re-authentication it triggered, stranding the client in a prompt loop.
+func (ts *SSOLogoutTestSuite) TestMaxAge_ZeroReauthenticationSucceeds() {
+	client := ts.newSessionClient()
+	ts.login(client, ssoMaxAgeUsername, "max_age_zero_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	// No sleep: max_age=0 admits no elapsed time, so the session is stale the moment it is written.
+	_, executionID := ts.authorizeWithMaxAge(client, "openid", "max_age_zero_2", "0")
+	initial := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+	ts.Require().NotEqual("COMPLETE", initial.FlowStatus, "max_age=0 must never reuse a session")
+	ts.Require().NotEmpty(initial.ChallengeToken,
+		"declining the session must yield a credential prompt, not a dead end")
+
+	step := ts.flowExecute(client, map[string]interface{}{
+		"executionId":    executionID,
+		"inputs":         map[string]string{"username": ssoMaxAgeUsername, "password": testPassword},
+		"action":         "action_001",
+		"challengeToken": initial.ChallengeToken,
+	})
+
+	ts.Equal("COMPLETE", step.FlowStatus,
+		"a fresh authentication must satisfy max_age=0 rather than prompting again")
+	ts.NotEmpty(step.Assertion, "the re-authenticated flow should yield an assertion")
 }
 
 // TestMaxAge_MalformedValueIsIgnored verifies that a non-numeric max_age is treated as no constraint
@@ -81,4 +146,39 @@ func (ts *SSOLogoutTestSuite) TestMaxAge_NegativeValueIsIgnored() {
 	ts.Equal("COMPLETE", step.FlowStatus, "a negative max_age should impose no constraint")
 	ts.NotEmpty(step.Assertion, "the SSO-satisfied flow should yield an assertion")
 	ts.Nil(step.Error, "no assurance error should be reported")
+}
+
+// TestMaxAge_ReauthenticationRefreshesSessionAuthTime covers the sequence a two-step test misses: a
+// forced re-authentication attaches to the existing session, so that session's authentication time
+// has to move forward with it. When it does not, the session goes on claiming the original login and
+// the next request is refused for a max_age it actually satisfies.
+func (ts *SSOLogoutTestSuite) TestMaxAge_ReauthenticationRefreshesSessionAuthTime() {
+	client := ts.newSessionClient()
+	ts.login(client, ssoMaxAgeUsername, "max_age_refresh_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	// Age the session past the window requested below so the next authorize re-authenticates.
+	time.Sleep(3 * time.Second)
+
+	_, executionID := ts.authorizeWithMaxAge(client, "openid", "max_age_refresh_2", "1")
+	initial := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+	ts.Require().NotEqual("COMPLETE", initial.FlowStatus, "an expired session must prompt for credentials")
+
+	reauth := ts.flowExecute(client, map[string]interface{}{
+		"executionId":    executionID,
+		"inputs":         map[string]string{"username": ssoMaxAgeUsername, "password": testPassword},
+		"action":         "action_001",
+		"challengeToken": initial.ChallengeToken,
+	})
+	ts.Require().Equal("COMPLETE", reauth.FlowStatus, "re-authentication should complete the flow")
+
+	// The subject authenticated moments ago, so a generous window must now be satisfiable from the
+	// session without another prompt.
+	_, thirdExecutionID := ts.authorizeWithMaxAge(client, "openid", "max_age_refresh_3", "10000")
+	third := ts.flowExecute(client, map[string]interface{}{"executionId": thirdExecutionID})
+
+	ts.Equal("COMPLETE", third.FlowStatus,
+		"the re-authentication must refresh the session's auth time, so a later max_age is satisfied")
+	ts.NotEmpty(third.Assertion, "the reused session should yield an assertion")
+	ts.Nil(third.Error, "no interaction_required error should be reported after a fresh re-authentication")
 }

--- a/tests/integration/oauth/sso/prompt_test.go
+++ b/tests/integration/oauth/sso/prompt_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sso
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// The OIDC prompt parameter interacts with SSO in two opposite directions. prompt=login must force a
+// fresh authentication even when a session exists, and prompt=none must be answered from a session
+// without any interaction at all, or refused with login_required when there is none.
+//
+// Each test builds its own cookie jar via newSessionClient so its session is unambiguous regardless
+// of the order tests run in.
+
+// authorizeRaw issues an authorize request with the given extra parameters and returns the response
+// without asserting its status, so a test can inspect an error redirect back to the client.
+func (ts *SSOLogoutTestSuite) authorizeRaw(
+	client *http.Client, scope, state string, extra map[string]string,
+) *http.Response {
+	params := url.Values{}
+	params.Set("client_id", clientID)
+	params.Set("redirect_uri", redirectURI)
+	params.Set("response_type", "code")
+	params.Set("scope", scope)
+	params.Set("state", state)
+	for k, v := range extra {
+		params.Set(k, v)
+	}
+
+	req, err := http.NewRequest("GET", testutils.TestServerURL+"/oauth2/authorize?"+params.Encode(), nil)
+	ts.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	ts.Require().NoError(err, "authorize request failed")
+	return resp
+}
+
+// redirectQuery returns the query parameters of the authorize response's Location header.
+func (ts *SSOLogoutTestSuite) redirectQuery(resp *http.Response) url.Values {
+	ts.Require().Equal(http.StatusFound, resp.StatusCode, "authorize should redirect")
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location, "the redirect should carry a Location header")
+	parsed, err := url.Parse(location)
+	ts.Require().NoError(err)
+	return parsed.Query()
+}
+
+// TestPromptLogin_ForcesReauthentication verifies that prompt=login is honored over a live session:
+// the SSO-Check node declines to reuse it and the flow prompts for credentials, as OIDC Core
+// §3.1.2.1 requires. Reusing the session here would silently ignore the parameter.
+func (ts *SSOLogoutTestSuite) TestPromptLogin_ForcesReauthentication() {
+	client := ts.newSessionClient()
+	ts.login(client, ssoMaxAgeUsername, "prompt_login_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	resp := ts.authorizeRaw(client, "openid", "prompt_login_2", map[string]string{"prompt": "login"})
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode, "authorize should redirect to the gate")
+
+	_, executionID, err := testutils.ExtractAuthData(resp.Header.Get("Location"))
+	ts.Require().NoError(err, "failed to extract auth data from authorize redirect")
+
+	step := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+
+	ts.Require().NotEqual("COMPLETE", step.FlowStatus,
+		"prompt=login must re-authenticate even when a session exists")
+	ts.Empty(step.Assertion, "no assertion may be minted before the subject re-authenticates")
+}
+
+// TestPromptNone_WithLiveSessionSucceeds verifies the silent path: with a session already
+// established, prompt=none completes without any credential prompt.
+func (ts *SSOLogoutTestSuite) TestPromptNone_WithLiveSessionSucceeds() {
+	client := ts.newSessionClient()
+	ts.login(client, ssoMaxAgeUsername, "prompt_none_live_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	resp := ts.authorizeRaw(client, "openid", "prompt_none_live_2", map[string]string{"prompt": "none"})
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode, "authorize should redirect to the gate")
+
+	location := resp.Header.Get("Location")
+	ts.Require().NotContains(location, "error=login_required",
+		"prompt=none must be honored when a live session exists")
+
+	_, executionID, err := testutils.ExtractAuthData(location)
+	ts.Require().NoError(err, "failed to extract auth data from authorize redirect")
+
+	step := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+
+	ts.Equal("COMPLETE", step.FlowStatus, "prompt=none over a live session should not prompt")
+	ts.NotEmpty(step.Assertion, "the silently satisfied flow should yield an assertion")
+}
+
+// TestPromptNone_WithoutSessionIsLoginRequired verifies the refusal path: with no session cookie,
+// prompt=none cannot be satisfied without interaction, so the client is redirected back with
+// login_required rather than being shown a login page.
+func (ts *SSOLogoutTestSuite) TestPromptNone_WithoutSessionIsLoginRequired() {
+	client := ts.newSessionClient()
+
+	resp := ts.authorizeRaw(client, "openid", "prompt_none_absent", map[string]string{"prompt": "none"})
+	defer resp.Body.Close()
+	query := ts.redirectQuery(resp)
+
+	ts.Equal("login_required", query.Get("error"), "prompt=none without a session must be refused")
+	ts.Equal("prompt_none_absent", query.Get("state"), "state must be echoed back to the client")
+}
+
+// TestPromptNone_AfterSessionTerminationIsLoginRequired verifies that the decision follows the
+// session's lifecycle: once the session is gone, the same client that was silently satisfied a
+// moment ago is refused.
+func (ts *SSOLogoutTestSuite) TestPromptNone_AfterSessionTerminationIsLoginRequired() {
+	client := ts.newSessionClient()
+	ts.login(client, ssoMaxAgeUsername, "prompt_none_terminated_1")
+
+	// A fresh jar stands in for a client that never held the session cookie, which is the state a
+	// terminated session leaves the browser in.
+	fresh := ts.newSessionClient()
+
+	resp := ts.authorizeRaw(fresh, "openid", "prompt_none_terminated_2", map[string]string{"prompt": "none"})
+	defer resp.Body.Close()
+	query := ts.redirectQuery(resp)
+
+	ts.Equal("login_required", query.Get("error"),
+		"a client without the session cookie must not be silently authorized")
+}
+
+// TestPromptNone_IDTokenHintMatchingSubjectSucceeds covers the parameter this change exists for: a
+// hint naming the signed-in subject narrows the silent path rather than blocking it, so the request
+// is answered from the session exactly as a bare prompt=none would be.
+func (ts *SSOLogoutTestSuite) TestPromptNone_IDTokenHintMatchingSubjectSucceeds() {
+	client := ts.newSessionClient()
+	idToken := ts.login(client, ssoMaxAgeUsername, "hint_match_1")
+	ts.Require().NotEmpty(idToken, "the first login should yield an id_token to use as the hint")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	resp := ts.authorizeRaw(client, "openid", "hint_match_2", map[string]string{
+		"prompt":        "none",
+		"id_token_hint": idToken,
+	})
+	defer resp.Body.Close()
+	location := resp.Header.Get("Location")
+	ts.Require().NotContains(location, "error=",
+		"a hint naming the signed-in subject must not block the silent path")
+
+	_, executionID, err := testutils.ExtractAuthData(location)
+	ts.Require().NoError(err, "failed to extract auth data from authorize redirect")
+
+	step := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+
+	ts.Equal("COMPLETE", step.FlowStatus, "the hinted subject matches, so no prompt is needed")
+	ts.NotEmpty(step.Assertion, "the silently satisfied flow should yield an assertion")
+}
+
+// TestPromptNone_IDTokenHintWithoutSessionIsLoginRequired pins the ordering of the two checks: the
+// session is resolved before the hint is read, so a hint cannot stand in for an authentication that
+// never happened. A hint identifies who, never that they are still signed in.
+func (ts *SSOLogoutTestSuite) TestPromptNone_IDTokenHintWithoutSessionIsLoginRequired() {
+	seed := ts.newSessionClient()
+	idToken := ts.login(seed, ssoMaxAgeUsername, "hint_nosession_1")
+	ts.Require().NotEmpty(idToken)
+
+	// A jar that never held the session cookie, carrying a valid hint for a real, known subject.
+	fresh := ts.newSessionClient()
+
+	resp := ts.authorizeRaw(fresh, "openid", "hint_nosession_2", map[string]string{
+		"prompt":        "none",
+		"id_token_hint": idToken,
+	})
+	defer resp.Body.Close()
+	query := ts.redirectQuery(resp)
+
+	ts.Equal("login_required", query.Get("error"),
+		"a valid hint must not authorize a client that holds no session")
+	ts.Equal("hint_nosession_2", query.Get("state"), "state must be echoed back to the client")
+}
+
+// TestPromptNone_MalformedIDTokenHintIsRejected verifies that a hint which cannot be verified is
+// refused rather than ignored. Silently dropping an unparseable hint would answer a request the
+// client did not make, authorizing whoever happens to hold the session.
+func (ts *SSOLogoutTestSuite) TestPromptNone_MalformedIDTokenHintIsRejected() {
+	client := ts.newSessionClient()
+	ts.login(client, ssoMaxAgeUsername, "hint_malformed_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	resp := ts.authorizeRaw(client, "openid", "hint_malformed_2", map[string]string{
+		"prompt":        "none",
+		"id_token_hint": "not.a.jwt",
+	})
+	defer resp.Body.Close()
+	query := ts.redirectQuery(resp)
+
+	ts.NotEmpty(query.Get("error"), "an unverifiable hint must not be silently ignored")
+	ts.Contains([]string{"invalid_request", "login_required"}, query.Get("error"),
+		"the refusal should name the malformed parameter or fall back to login_required")
+}


### PR DESCRIPTION
### Purpose

The authorization endpoint and the authentication flow did not consult the SSO session when
answering the OIDC authentication-context parameters, so four related behaviours were wrong:

- `auth_time` was derived from authorization-code creation rather than the session's
  authentication time, so it advanced on every authorization even when no new authentication
  took place (#5105).
- `prompt=login` was silently ignored: an existing session was reused despite the request
  asking for a fresh authentication.
- A `max_age` smaller than the session's age failed the request at the end of the flow
  (`FET-1082`) instead of re-authenticating, leaving the client unable to proceed even with the
  End-User present.
- `prompt=none` always returned `login_required`, and `id_token_hint` was not consulted at all,
  so silent re-authentication was unavailable.

### Approach

Four changes, all resolving to the same idea: the SSO session is the authority on when and as
whom the subject authenticated.

**`auth_time` from the session.** `AuthAssertExecutor` now stamps the flow assertion with the
resolved session's authentication time, and the assertion decoder prefers it over the `iat`
fallback. `AuthorizationCode` gained an explicit `AuthTime` field so the claim no longer shares
`TimeCreated`, whose other job is computing the code's expiry. Without that split, a code minted
over a reused session inherited the session's age and was rejected at insertion as already
expired.

**Forced re-authentication.** `prompt=login` sets a runtime flag that `SSOCheckExecutor` honors by
declining to reuse the session, and an exceeded `max_age` does the same. Both route down the
existing `onFailure: prompt_credentials` edge rather than adding a new path, and the session
handle is still shared so the re-authentication attaches to the same session.

**Session authentication time refresh.** A re-authentication attaches to the existing session, so
`SaveCheckpoint` now moves its `AuthenticatedAt` forward. Without this the session kept claiming
the original login, which under-reported `auth_time` and made a later `max_age` check reject a
request it actually satisfied.

**`prompt=none` and `id_token_hint` at the authorize endpoint.** The endpoint resolves the
client's flow, reads the per-flow SSO cookie, and answers from the session: `login_required` when
there is none, when `id_token_hint` names a different subject, or when the authentication is
older than `max_age`. The unconditional `login_required` moved out of the request validator so
PAR is unaffected. Both new dependencies are optional and nil in the embedded engine, which has
no session store; `prompt=none` keeps returning `login_required` there.

Two deliberate decisions worth flagging for review:

- The `id_token_hint` signature and issuer are verified but its expiry is not. OIDC Core requires
  an expired hint to still be accepted: it identifies who was authenticated, not whether they
  still are.
- A malformed or negative `max_age` is treated as no constraint rather than as a zero-second
  window, matching the existing assurance check. All three sites that read `max_age` share these
  semantics.

**Known limitation.** `checkPromptNone` verifies that a live session exists, not that this flow's
specific checkpoint is present in it. A flow with more than one SSO-Check node (step-up
authentication) could therefore start under `prompt=none` and still reach a prompt. No shipped
flow has that shape, and the behaviour is not a regression, so it is left as follow-up: the
intended fix is a passive-authentication mode on the flow engine, which needs its own discussion
and a change to how flow errors map to OAuth error codes.

Enabling SSO on the Default Authentication Flow is deliberately **not** included: it changes the
behaviour every new application inherits and deserves a separate discussion.

### Related Issues
- Refs https://github.com/thunder-id/thunderid/issues/5113
- Fixes https://github.com/thunder-id/thunderid/issues/5105

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - `docs/content/guides/protocols/oauth-oidc/openid-connect.mdx`: rewrote the `prompt` values
      table, added the missing `max_age` and `id_token_hint` parameter rows, and added a
      `max_age` / `auth_time` section.
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenID Connect `prompt=none` support for silent authorization with a valid SSO session.
  * Added `prompt=login` and `max_age` handling to require fresh authentication.
  * Added `id_token_hint` validation during authorization.
  * Preserved authentication time in ID tokens and authorization flows.
  * PAR requests using `prompt=none` are now accepted and evaluated during authorization.

* **Bug Fixes**
  * Reauthentication now refreshes session authentication timestamps for subsequent requests.

* **Documentation**
  * Updated OpenID Connect guidance for these authentication parameters and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->