### PR TITLE
Fix high-severity pnpm audit findings for fast-uri and faker

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,7 @@ overrides:
   postcss-discard-unused>postcss-selector-parser: '>=7.1.3'
   browserslist: '>=4.28.7'
   mermaid: '>=11.16.1'
+  fast-uri: '>=3.1.6 <4'
 
 packageExtensionsChecksum: sha256-7EyWhva5Lcamo6pe18OzfUc27A7xbWt39+G/ofluF9k=
 
@@ -9619,11 +9620,13 @@ packages:
   eslint@9.0.0:
     resolution: {integrity: sha512-IMryZ5SudxzQvuod6rUdIUz29qFItWx281VhtFVc2Psy/ZhlCeD/5DT6lBIJ4H3G+iamGJoTln1v+QSuPw0p7Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -9634,6 +9637,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -9792,8 +9796,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -20652,7 +20656,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -21017,7 +21021,7 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.28.8
-      caniuse-lite: 1.0.30001792
+      caniuse-lite: 1.0.30001809
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
@@ -22590,7 +22594,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -214,6 +214,16 @@ overrides:
   # GHSA-3rrr-jr9j-h3q3 (prototype pollution in architecture diagrams), and GHSA XY chart
   # infinite-loop DoS. Transitive via @docusaurus/theme-mermaid.
   mermaid: '>=11.16.1'
+  # JUSTIFICATION: Fixes GHSA-5jgf-p345-68v8 (host confusion via skipped IDN canonicalization on
+  # scheme-relative references), GHSA-f65p-4m7j-42xc (SSRF via malformed IPv6 normalization),
+  # GHSA-fph4-wmhf-6fwf (SSRF via repeated hostname percent-decoding) and GHSA-jqff-g426-hqxp
+  # (host confusion via percent-encoded scheme normalization). Transitive via the Docusaurus
+  # webpack -> schema-utils -> ajv chain (100+ paths), so overridden globally. Constrained to the
+  # 3.x line: the consumers here (ajv) declare fast-uri ^3.0.1, and an open-ended '>=3.1.6' lets
+  # the resolver dedupe this edge onto the 4.x major, which those consumers were never tested
+  # against. 3.1.6 is a patch release on the 3.1.x line already resolved here (3.1.5), so no API
+  # change.
+  fast-uri: '>=3.1.6 <4'
 
 packageExtensions:
   '@hookform/resolvers':
@@ -239,6 +249,20 @@ auditConfig:
     # mdx-loader. No patched release exists on npm yet (advisory lists "Patched: None"); revisit
     # and add an override once image-size ships a fix.
     - GHSA-5p2g-fcmc-qvqq
+    # JUSTIFICATION: GHSA-qxc2-j82w-r537 — arbitrary code execution via faker's `helpers.fake`.
+    # Transitive via docs -> openapi-to-postmanv2 -> postman-collection, which depends on the
+    # deprecated @faker-js/faker@5.5.3. Not overridable: the fix landed in faker 10.5.0 (the
+    # advisory names 10.4.1, which was never published to npm), and faker 8 renamed the modules
+    # postman-collection binds at require time (`faker.address.*` -> `faker.location.*`). Forcing
+    # any >=8 release makes postman-collection throw on import, breaking
+    # `pnpm --dir docs generate:postman-collections`. Upstream has not migrated — the latest
+    # postman-collection (5.3.1) still pins 5.5.3 — so there is no upgrade path today.
+    # Not exploitable here: the advisory requires attacker-controlled input reaching
+    # `helpers.fake`, and postman-collection never calls it (it only binds individual generators
+    # such as `faker.address.city` for dynamic-variable substitution). The code is also
+    # build-time only, run against this repo's own OpenAPI specs. Revisit once postman-collection
+    # upgrades its faker dependency.
+    - GHSA-qxc2-j82w-r537
 
 minimumReleaseAgeExclude:
   - '@thunderid/*'


### PR DESCRIPTION
## Summary

- Resolve 5 high-severity advisories flagged by `pnpm audit` (all transitive via the Docusaurus build chain):
  - **fast-uri** `>=3.1.6 <4`: GHSA-5jgf-p345-68v8 (high, host confusion via skipped IDN canonicalization on scheme-relative references), GHSA-f65p-4m7j-42xc (high, SSRF via malformed IPv6 normalization), GHSA-fph4-wmhf-6fwf (high, SSRF via repeated hostname percent-decoding), GHSA-jqff-g426-hqxp (high, host confusion via percent-encoded scheme normalization). Transitive via `webpack>schema-utils>ajv` (100+ paths), so overridden globally. Constrained to the 3.x line: ajv declares `fast-uri ^3.0.1`, and an open-ended `>=3.1.6` lets the resolver dedupe the edge onto the untested 4.x major.
  - **@faker-js/faker**: GHSA-qxc2-j82w-r537 (high, `helpers.fake` exploitable into arbitrary code execution) added to `auditConfig.ignoreGhsas` rather than overridden. The fix landed in faker 10.5.0 — the advisory names 10.4.1, which was never published to npm — but faker 8 renamed the modules `postman-collection` binds at require time (`faker.address.*` → `faker.location.*`), so forcing any `>=8` release makes it throw on import and breaks `pnpm --dir docs generate:postman-collections`. There is no upgrade path: the latest `postman-collection` (5.3.1) still pins faker `5.5.3`. Not exploitable here — the advisory requires attacker-controlled input reaching `helpers.fake`, which `postman-collection` never calls (it only binds individual generators such as `faker.address.city`), and the code is build-time only, run against this repo's own OpenAPI specs.
- Only `pnpm-workspace.yaml` overrides and `pnpm-lock.yaml` changed — no application code modified.

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm audit` exits 0 (2 remaining `qs` moderates are pre-existing on `main` and out of scope; 3 ignored advisories are the 2 pre-existing `image-size` entries plus the faker entry above, all with justifications in `auditConfig.ignoreGhsas`)
- [x] `pnpm run build:docs` succeeds — exercises the `webpack>schema-utils>ajv>fast-uri` chain
- [x] `pnpm --dir docs generate:postman-collections` succeeds with byte-identical output — exercises the faker path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security audit settings to better manage a known vulnerability advisory.
  * Refined package version constraints to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->