### PR TITLE
Carry the deployment id on the request context

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -240,12 +240,16 @@ func createHTTPServer(ctx context.Context, logger *log.Logger, cfg *config.Confi
 	securityMiddleware := createSecurityMiddleware(ctx, logger, mux, jwtService, revocationEnforcer)
 
 	// Build the middleware chain with proper execution order.
-	// Request flow: CorrelationID (outermost) -> SecurityHeaders -> AccessLog -> Security -> Route Handler (innermost)
+	// Request flow: CorrelationID (outermost) -> DeploymentID -> SecurityHeaders -> AccessLog ->
+	// Security -> Route Handler (innermost)
 	// Note: Middlewares are wrapped in reverse order - the last added will execute first.
 	// The Gate and Console frontend paths are always excluded from the access log to keep it
 	// focused on API traffic. Additional prefixes can be excluded via log.access.exclude_paths.
 	handler := log.AccessLogHandler(logger, accessLogExcludePaths(cfg.Log.Access.ExcludePaths), securityMiddleware)
 	handler = middleware.SecurityHeadersMiddleware()(handler)
+	// Outside the security layer, so that every request carries the deployment id it acts for by the
+	// time any store is reached.
+	handler = middleware.DeploymentIDMiddleware(handler)
 	handler = middleware.CorrelationIDMiddleware(handler)
 
 	// Build the server address using hostname and port from the configurations.

--- a/backend/internal/cert/store.go
+++ b/backend/internal/cert/store.go
@@ -8,9 +8,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	dbprovider "github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 )
 
 // certificateStoreInterface defines the methods for certificate storage operations.
@@ -26,27 +26,31 @@ type certificateStoreInterface interface {
 
 // certificateStore implements the certificateStoreInterface for managing certificates.
 type certificateStore struct {
-	dbProvider   dbprovider.DBProviderInterface
-	deploymentID string
+	dbProvider dbprovider.DBProviderInterface
 }
 
 // NewCertificateStore creates a new instance of CertificateStore.
 func newCertificateStore() certificateStoreInterface {
 	return &certificateStore{
-		dbProvider:   dbprovider.GetDBProvider(),
-		deploymentID: config.GetServerRuntime().Config.Server.Identifier,
+		dbProvider: dbprovider.GetDBProvider(),
 	}
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (s *certificateStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // GetCertificateByID retrieves a certificate by its ID.
 func (s *certificateStore) GetCertificateByID(ctx context.Context, id string) (*Certificate, error) {
-	return s.getCertificate(ctx, queryGetCertificateByID, id, s.deploymentID)
+	return s.getCertificate(ctx, queryGetCertificateByID, id, s.scope(ctx))
 }
 
 // GetCertificateByReference retrieves a certificate by its reference type and ID.
 func (s *certificateStore) GetCertificateByReference(ctx context.Context, refType CertificateReferenceType,
 	refID string) (*Certificate, error) {
-	return s.getCertificate(ctx, queryGetCertificateByReference, refType, refID, s.deploymentID)
+	return s.getCertificate(ctx, queryGetCertificateByReference, refType, refID, s.scope(ctx))
 }
 
 // getCertificate retrieves a certificate based on a query and its arguments.
@@ -121,7 +125,7 @@ func (s *certificateStore) CreateCertificate(ctx context.Context, cert *Certific
 	}
 
 	rows, err := dbClient.ExecuteContext(ctx, queryInsertCertificate, cert.ID, cert.RefType, cert.RefID, cert.Type,
-		cert.Value, s.deploymentID)
+		cert.Value, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to insert certificate: %w", err)
 	}
@@ -135,14 +139,14 @@ func (s *certificateStore) CreateCertificate(ctx context.Context, cert *Certific
 // UpdateCertificateByID updates a certificate by its ID.
 func (s *certificateStore) UpdateCertificateByID(ctx context.Context, existingCert, updatedCert *Certificate) error {
 	return s.updateCertificate(ctx, queryUpdateCertificateByID, existingCert.ID, updatedCert.Type, updatedCert.Value,
-		s.deploymentID)
+		s.scope(ctx))
 }
 
 // UpdateCertificateByReference updates a certificate by its reference type and ID.
 func (s *certificateStore) UpdateCertificateByReference(ctx context.Context,
 	existingCert, updatedCert *Certificate) error {
 	return s.updateCertificate(ctx, queryUpdateCertificateByReference, existingCert.RefType, existingCert.RefID,
-		updatedCert.Type, updatedCert.Value, s.deploymentID)
+		updatedCert.Type, updatedCert.Value, s.scope(ctx))
 }
 
 // updateCertificate updates a certificate based on a query and its arguments.
@@ -165,13 +169,13 @@ func (s *certificateStore) updateCertificate(ctx context.Context, query dbmodel.
 
 // DeleteCertificateByID deletes a certificate by its ID.
 func (s *certificateStore) DeleteCertificateByID(ctx context.Context, id string) error {
-	return s.deleteCertificate(ctx, queryDeleteCertificateByID, id, s.deploymentID)
+	return s.deleteCertificate(ctx, queryDeleteCertificateByID, id, s.scope(ctx))
 }
 
 // DeleteCertificateByReference deletes a certificate by its reference type and ID.
 func (s *certificateStore) DeleteCertificateByReference(ctx context.Context, refType CertificateReferenceType,
 	refID string) error {
-	return s.deleteCertificate(ctx, queryDeleteCertificateByReference, refType, refID, s.deploymentID)
+	return s.deleteCertificate(ctx, queryDeleteCertificateByReference, refType, refID, s.scope(ctx))
 }
 
 // deleteCertificate deletes a certificate based on a query and its arguments.

--- a/backend/internal/cert/store_test.go
+++ b/backend/internal/cert/store_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 type StoreTestSuite struct {
@@ -27,11 +30,11 @@ func TestStoreTestSuite(t *testing.T) {
 }
 
 func (suite *StoreTestSuite) SetupTest() {
+	loadRuntimeForScope()
 	suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 	suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 	suite.store = &certificateStore{
-		dbProvider:   suite.mockDBProvider,
-		deploymentID: "test-deployment-id",
+		dbProvider: suite.mockDBProvider,
 	}
 }
 
@@ -562,4 +565,14 @@ func (suite *StoreTestSuite) TestDeleteCertificateByReference_NoRowsAffected() {
 	assert.Nil(suite.T(), err)
 	suite.mockDBProvider.AssertExpectations(suite.T())
 	suite.mockDBClient.AssertExpectations(suite.T())
+}
+
+// loadRuntimeForScope loads a server runtime naming the deployment these tests assert on. The store
+// resolves its deployment from the runtime rather than holding one, and other suites in this package
+// reset the runtime, so it is loaded per test rather than once for the package.
+func loadRuntimeForScope() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: "test-deployment-id"},
+	})
 }

--- a/backend/internal/entity/store.go
+++ b/backend/internal/entity/store.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -66,7 +66,6 @@ var getDBProvider = provider.GetDBProvider
 
 // entityDBStore is the database implementation of entityStoreInterface.
 type entityDBStore struct {
-	deploymentID      string
 	indexedAttributes map[string]bool
 	dbProvider        provider.DBProviderInterface
 	logger            *log.Logger
@@ -75,8 +74,6 @@ type entityDBStore struct {
 // newEntityDBStore creates a new instance of entityDBStore.
 // Indexed attributes start empty; consumers must call LoadIndexedAttributes after init.
 func newEntityDBStore() (entityStoreInterface, providers.Transactioner, error) {
-	runtime := config.GetServerRuntime()
-
 	dbProvider := getDBProvider()
 	client, err := dbProvider.GetEntityDBClient()
 	if err != nil {
@@ -88,11 +85,16 @@ func newEntityDBStore() (entityStoreInterface, providers.Transactioner, error) {
 	}
 
 	return &entityDBStore{
-		deploymentID:      runtime.Config.Server.Identifier,
 		indexedAttributes: make(map[string]bool),
 		dbProvider:        dbProvider,
 		logger:            log.GetLogger().With(log.String(log.LoggerKeyComponentName, "EntityStore")),
 	}, transactioner, nil
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (es *entityDBStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // LoadIndexedAttributes merges the given attributes into the indexed set.
@@ -149,7 +151,7 @@ func (es *entityDBStore) CreateEntity(ctx context.Context, entity providers.Enti
 		ctx,
 		QueryCreateEntity,
 		entity.ID,
-		es.deploymentID,
+		es.scope(ctx),
 		string(entity.Category),
 		entity.Type,
 		string(entity.State),
@@ -180,7 +182,7 @@ func (es *entityDBStore) GetEntity(ctx context.Context, id string) (providers.En
 		return providers.Entity{}, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, QueryGetEntityByID, id, es.deploymentID)
+	results, err := dbClient.QueryContext(ctx, QueryGetEntityByID, id, es.scope(ctx))
 	if err != nil {
 		return providers.Entity{}, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -204,7 +206,7 @@ func (es *entityDBStore) GetEntityWithCredentials(ctx context.Context, id string
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, QueryGetEntityWithCredentials, id, es.deploymentID)
+	results, err := dbClient.QueryContext(ctx, QueryGetEntityWithCredentials, id, es.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -251,7 +253,7 @@ func (es *entityDBStore) UpdateEntity(ctx context.Context, entity *providers.Ent
 		ctx,
 		QueryUpdateEntity,
 		entity.ID, entity.OUID, entity.Type,
-		string(entity.State), string(attributes), systemAttrs, time.Now().UTC(), es.deploymentID,
+		string(entity.State), string(attributes), systemAttrs, time.Now().UTC(), es.scope(ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to execute update entity query: %w", err)
@@ -269,7 +271,7 @@ func (es *entityDBStore) UpdateEntity(ctx context.Context, entity *providers.Ent
 		return fmt.Errorf("failed to reload entity for identifier sync: %w", err)
 	}
 
-	_, err = dbClient.ExecuteContext(ctx, QueryDeleteIdentifiersByEntity, entity.ID, es.deploymentID)
+	_, err = dbClient.ExecuteContext(ctx, QueryDeleteIdentifiersByEntity, entity.ID, es.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to delete identifiers: %w", err)
 	}
@@ -290,7 +292,7 @@ func (es *entityDBStore) UpdateAttributes(ctx context.Context, entityID string, 
 	}
 
 	rowsAffected, err := dbClient.ExecuteContext(ctx, QueryUpdateAttributes,
-		entityID, string(attributes), time.Now().UTC(), es.deploymentID)
+		entityID, string(attributes), time.Now().UTC(), es.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute update attributes query: %w", err)
 	}
@@ -300,7 +302,7 @@ func (es *entityDBStore) UpdateAttributes(ctx context.Context, entityID string, 
 	}
 
 	if _, err = dbClient.ExecuteContext(ctx, QueryDeleteAttributeIdentifiersByEntity,
-		entityID, es.deploymentID); err != nil {
+		entityID, es.scope(ctx)); err != nil {
 		return fmt.Errorf("failed to delete attribute identifiers: %w", err)
 	}
 
@@ -320,7 +322,7 @@ func (es *entityDBStore) UpdateSystemAttributes(ctx context.Context, entityID st
 	}
 
 	rowsAffected, err := dbClient.ExecuteContext(ctx, QueryUpdateSystemAttributes,
-		entityID, string(attrs), time.Now().UTC(), es.deploymentID)
+		entityID, string(attrs), time.Now().UTC(), es.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -330,7 +332,7 @@ func (es *entityDBStore) UpdateSystemAttributes(ctx context.Context, entityID st
 	}
 
 	if _, err = dbClient.ExecuteContext(ctx, QueryDeleteSystemIdentifiersByEntity,
-		entityID, es.deploymentID); err != nil {
+		entityID, es.scope(ctx)); err != nil {
 		return fmt.Errorf("failed to delete system identifiers: %w", err)
 	}
 
@@ -350,7 +352,7 @@ func (es *entityDBStore) UpdateCredentials(ctx context.Context, entityID string,
 	}
 
 	rowsAffected, err := dbClient.ExecuteContext(ctx, QueryUpdateCredentials,
-		entityID, string(creds), time.Now().UTC(), es.deploymentID)
+		entityID, string(creds), time.Now().UTC(), es.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -371,7 +373,7 @@ func (es *entityDBStore) UpdateSystemCredentials(ctx context.Context, entityID s
 	}
 
 	rowsAffected, err := dbClient.ExecuteContext(ctx, QueryUpdateSystemCredentials,
-		entityID, string(creds), time.Now().UTC(), es.deploymentID)
+		entityID, string(creds), time.Now().UTC(), es.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -390,7 +392,7 @@ func (es *entityDBStore) DeleteEntity(ctx context.Context, id string) error {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	rowsAffected, err := dbClient.ExecuteContext(ctx, QueryDeleteEntity, id, es.deploymentID)
+	rowsAffected, err := dbClient.ExecuteContext(ctx, QueryDeleteEntity, id, es.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -399,7 +401,7 @@ func (es *entityDBStore) DeleteEntity(ctx context.Context, id string) error {
 		return ErrEntityNotFound
 	}
 
-	if _, err = dbClient.ExecuteContext(ctx, QueryDeleteIdentifiersByEntity, id, es.deploymentID); err != nil {
+	if _, err = dbClient.ExecuteContext(ctx, QueryDeleteIdentifiersByEntity, id, es.scope(ctx)); err != nil {
 		return fmt.Errorf("failed to delete entity identifiers: %w", err)
 	}
 
@@ -411,7 +413,7 @@ func (es *entityDBStore) DeleteEntity(ctx context.Context, id string) error {
 func (es *entityDBStore) syncAttributeIdentifiers(ctx context.Context, entityID string,
 	attributes json.RawMessage, systemAttributes json.RawMessage,
 	indexedAttrs map[string]bool) error {
-	query, args, err := prepareIdentifierQuery(entityID, attributes, systemAttributes, indexedAttrs, es.deploymentID)
+	query, args, err := prepareIdentifierQuery(entityID, attributes, systemAttributes, indexedAttrs, es.scope(ctx))
 	if err != nil {
 		return err
 	}
@@ -443,7 +445,7 @@ func (es *entityDBStore) IdentifyEntity(ctx context.Context,
 	// Fast path: try indexed identifier store first for all lookups.
 	// This covers both schema-indexed attributes (email, username) and
 	// system identifiers without requiring config.
-	identifyQuery, args, err := buildIdentifyQueryFromIdentifiers(filters, es.deploymentID)
+	identifyQuery, args, err := buildIdentifyQueryFromIdentifiers(filters, es.scope(ctx))
 	if err == nil {
 		results, qErr := dbClient.QueryContext(ctx, identifyQuery, args...)
 		if qErr == nil && len(results) == 1 {
@@ -470,14 +472,14 @@ func (es *entityDBStore) IdentifyEntity(ctx context.Context,
 
 	if len(indexedFilters) > 0 && len(nonIndexedFilters) > 0 {
 		// Mixed: identifier table for indexed filters + JSON for non-indexed filters.
-		fallbackQuery, fallbackArgs, err = buildIdentifyQueryHybrid(indexedFilters, nonIndexedFilters, es.deploymentID)
+		fallbackQuery, fallbackArgs, err = buildIdentifyQueryHybrid(indexedFilters, nonIndexedFilters, es.scope(ctx))
 		if err != nil {
 			return nil, fmt.Errorf("failed to build hybrid query: %w", err)
 		}
 	} else {
 		// All-indexed: fast path already tried the identifier table; fall back to JSON search.
 		// All non-indexed: always use JSON search.
-		fallbackQuery, fallbackArgs, err = buildIdentifyQuery(filters, es.deploymentID)
+		fallbackQuery, fallbackArgs, err = buildIdentifyQuery(filters, es.scope(ctx))
 		if err != nil {
 			return nil, fmt.Errorf("failed to build identify query: %w", err)
 		}
@@ -528,7 +530,7 @@ func (es *entityDBStore) SearchEntities(ctx context.Context,
 	}
 
 	searchQuery, args, err := buildEntityListQuery(
-		"", filters, serverconst.MaxPageSize, 0, es.deploymentID)
+		"", filters, serverconst.MaxPageSize, 0, es.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build search query: %w", err)
 	}
@@ -558,7 +560,7 @@ func (es *entityDBStore) GetEntityListCount(ctx context.Context, category string
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	countQuery, args, err := buildEntityCountQuery(category, filters, es.deploymentID)
+	countQuery, args, err := buildEntityCountQuery(category, filters, es.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to build count query: %w", err)
 	}
@@ -574,7 +576,7 @@ func (es *entityDBStore) GetEntityList(ctx context.Context, category string,
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	listQuery, args, err := buildEntityListQuery(category, filters, limit, offset, es.deploymentID)
+	listQuery, args, err := buildEntityListQuery(category, filters, limit, offset, es.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build list query: %w", err)
 	}
@@ -598,7 +600,7 @@ func (es *entityDBStore) GetEntityListCountByOUIDs(ctx context.Context, category
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	countQuery, args, err := buildEntityCountQueryByOUIDs(category, ouIDs, filters, es.deploymentID)
+	countQuery, args, err := buildEntityCountQueryByOUIDs(category, ouIDs, filters, es.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to build count query: %w", err)
 	}
@@ -614,7 +616,7 @@ func (es *entityDBStore) GetEntityListByOUIDs(ctx context.Context, category stri
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	listQuery, args, err := buildEntityListQueryByOUIDs(category, ouIDs, filters, limit, offset, es.deploymentID)
+	listQuery, args, err := buildEntityListQueryByOUIDs(category, ouIDs, filters, limit, offset, es.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build list query: %w", err)
 	}
@@ -638,7 +640,7 @@ func (es *entityDBStore) ValidateEntityIDs(ctx context.Context, entityIDs []stri
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	query, args, err := buildBulkEntityExistsQuery(entityIDs, es.deploymentID)
+	query, args, err := buildBulkEntityExistsQuery(entityIDs, es.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build bulk entity exists query: %w", err)
 	}
@@ -687,7 +689,7 @@ func (es *entityDBStore) GetEntitiesByIDs(ctx context.Context, entityIDs []strin
 		}
 		chunk := entityIDs[start:end]
 
-		query, args, err := buildGetEntitiesByIDsQuery(chunk, es.deploymentID)
+		query, args, err := buildGetEntitiesByIDsQuery(chunk, es.scope(ctx))
 		if err != nil {
 			return nil, fmt.Errorf("failed to build get entities by IDs query: %w", err)
 		}
@@ -723,7 +725,7 @@ func (es *entityDBStore) ValidateEntityIDsInOUs(
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	query, args, err := buildBulkEntityExistsQueryInOUs(entityIDs, ouIDs, es.deploymentID)
+	query, args, err := buildBulkEntityExistsQueryInOUs(entityIDs, ouIDs, es.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build query: %w", err)
 	}
@@ -756,7 +758,7 @@ func (es *entityDBStore) GetGroupCountForEntity(ctx context.Context, entityID st
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	countResults, err := dbClient.QueryContext(ctx, QueryGetGroupCountForEntity, entityID, es.deploymentID)
+	countResults, err := dbClient.QueryContext(ctx, QueryGetGroupCountForEntity, entityID, es.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to get group count for entity: %w", err)
 	}
@@ -780,7 +782,7 @@ func (es *entityDBStore) GetEntityGroups(
 	}
 
 	results, err := dbClient.QueryContext(ctx, QueryGetGroupsForEntity,
-		entityID, limit, offset, es.deploymentID)
+		entityID, limit, offset, es.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get groups for entity: %w", err)
 	}

--- a/backend/internal/entity/store_constants_test.go
+++ b/backend/internal/entity/store_constants_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 type StoreConstantsTestSuite struct {
@@ -274,4 +277,12 @@ func (s *StoreConstantsTestSuite) TestBuildIdentifyQueryHybrid_NonIndexed_UsesCO
 	s.Contains(q.SQLiteQuery, "COALESCE")
 	s.Contains(q.SQLiteQuery, "json_extract(e.ATTRIBUTES, '$.clientId')")
 	s.Contains(q.SQLiteQuery, "json_extract(e.SYSTEM_ATTRIBUTES, '$.clientId')")
+}
+
+// The stores resolve their deployment from the loaded server runtime rather than holding one, so
+// these tests load a runtime naming the id the query assertions below expect.
+func init() {
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: testDeploymentID},
+	})
 }

--- a/backend/internal/entity/store_test.go
+++ b/backend/internal/entity/store_test.go
@@ -35,7 +35,6 @@ func (s *DBStoreTestSuite) SetupTest() {
 	s.provider = providermock.NewDBProviderInterfaceMock(s.T())
 	s.client = providermock.NewDBClientInterfaceMock(s.T())
 	s.store = &entityDBStore{
-		deploymentID:      "dep1",
 		indexedAttributes: map[string]bool{},
 		dbProvider:        s.provider,
 		logger:            log.GetLogger(),

--- a/backend/internal/entitytype/store.go
+++ b/backend/internal/entitytype/store.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -76,8 +76,7 @@ type entityTypeStoreInterface interface {
 
 // entityTypeStore is the default implementation of entityTypeStoreInterface.
 type entityTypeStore struct {
-	dbProvider   provider.DBProviderInterface
-	deploymentID string
+	dbProvider provider.DBProviderInterface
 }
 
 // newEntityTypeStore creates a new instance of entityTypeStore.
@@ -88,9 +87,14 @@ func newEntityTypeStore() (entityTypeStoreInterface, providers.Transactioner, er
 		return nil, nil, err
 	}
 	return &entityTypeStore{
-		dbProvider:   dbProvider,
-		deploymentID: config.GetServerRuntime().Config.Server.Identifier,
+		dbProvider: dbProvider,
 	}, transactioner, nil
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (s *entityTypeStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // GetEntityTypeListCount retrieves the total count of entity types for the given category.
@@ -100,7 +104,7 @@ func (s *entityTypeStore) GetEntityTypeListCount(ctx context.Context, category T
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	countResults, err := dbClient.QueryContext(ctx, queryGetEntityTypeCount, string(category), s.deploymentID)
+	countResults, err := dbClient.QueryContext(ctx, queryGetEntityTypeCount, string(category), s.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute count query: %w", err)
 	}
@@ -127,7 +131,7 @@ func (s *entityTypeStore) GetEntityTypeList(ctx context.Context, category TypeCa
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetEntityTypeList, limit, offset, s.deploymentID, string(category))
+	results, err := dbClient.QueryContext(ctx, queryGetEntityTypeList, limit, offset, s.scope(ctx), string(category))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -164,7 +168,7 @@ func (s *entityTypeStore) GetEntityTypeListByOUIDs(ctx context.Context, category
 	for _, id := range ouIDs {
 		args = append(args, id)
 	}
-	args = append(args, string(category), s.deploymentID, limit, offset)
+	args = append(args, string(category), s.scope(ctx), limit, offset)
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -201,7 +205,7 @@ func (s *entityTypeStore) GetEntityTypeListCountByOUIDs(ctx context.Context, cat
 	for _, id := range ouIDs {
 		args = append(args, id)
 	}
-	args = append(args, string(category), s.deploymentID)
+	args = append(args, string(category), s.scope(ctx))
 
 	countResults, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -242,7 +246,7 @@ func (s *entityTypeStore) CreateEntityType(ctx context.Context, entityType Entit
 		entityType.AllowSelfRegistration,
 		string(entityType.Schema),
 		sysAttrs,
-		s.deploymentID,
+		s.scope(ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create entity type: %w", err)
@@ -259,7 +263,7 @@ func (s *entityTypeStore) GetEntityTypeByID(ctx context.Context, category TypeCa
 		return EntityType{}, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetEntityTypeByID, schemaID, s.deploymentID, string(category))
+	results, err := dbClient.QueryContext(ctx, queryGetEntityTypeByID, schemaID, s.scope(ctx), string(category))
 	if err != nil {
 		return EntityType{}, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -279,7 +283,7 @@ func (s *entityTypeStore) GetEntityTypeByName(ctx context.Context, category Type
 		return EntityType{}, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetEntityTypeByName, name, s.deploymentID, string(category))
+	results, err := dbClient.QueryContext(ctx, queryGetEntityTypeByName, name, s.scope(ctx), string(category))
 	if err != nil {
 		return EntityType{}, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -313,7 +317,7 @@ func (s *entityTypeStore) UpdateEntityTypeByID(ctx context.Context, category Typ
 		string(entityType.Schema),
 		sysAttrs,
 		schemaID,
-		s.deploymentID,
+		s.scope(ctx),
 		string(category),
 	)
 	if err != nil {
@@ -333,7 +337,7 @@ func (s *entityTypeStore) DeleteEntityTypeByID(ctx context.Context, category Typ
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	rowsAffected, err := dbClient.ExecuteContext(ctx, queryDeleteEntityTypeByID, schemaID, s.deploymentID,
+	rowsAffected, err := dbClient.ExecuteContext(ctx, queryDeleteEntityTypeByID, schemaID, s.scope(ctx),
 		string(category))
 	if err != nil {
 		return fmt.Errorf("failed to delete entity type: %w", err)
@@ -370,7 +374,7 @@ func (s *entityTypeStore) GetDisplayAttributesByNames(ctx context.Context, categ
 	for _, name := range names {
 		args = append(args, name)
 	}
-	args = append(args, string(category), s.deploymentID)
+	args = append(args, string(category), s.scope(ctx))
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/backend/internal/entitytype/store_test.go
+++ b/backend/internal/entitytype/store_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	dbMock "github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 type StoreTestSuite struct {
@@ -23,12 +26,12 @@ type StoreTestSuite struct {
 }
 
 func (suite *StoreTestSuite) SetupTest() {
+	loadRuntimeForScope()
 	suite.mockProvider = dbMock.NewDBProviderInterfaceMock(suite.T())
 	suite.mockClient = dbMock.NewDBClientInterfaceMock(suite.T())
 
 	suite.store = &entityTypeStore{
-		dbProvider:   suite.mockProvider,
-		deploymentID: "test-node",
+		dbProvider: suite.mockProvider,
 	}
 }
 
@@ -274,4 +277,14 @@ func (suite *StoreTestSuite) TestGetEntityTypeListCountByOUIDs() {
 			suite.mockClient.AssertExpectations(suite.T())
 		})
 	}
+}
+
+// loadRuntimeForScope loads a server runtime naming the deployment these tests assert on. The store
+// resolves its deployment from the runtime rather than holding one, and other suites in this package
+// reset the runtime, so it is loaded per test rather than once for the package.
+func loadRuntimeForScope() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: "test-node"},
+	})
 }

--- a/backend/internal/group/store.go
+++ b/backend/internal/group/store.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -90,16 +90,20 @@ func resolveTransitiveGroupAncestors(
 
 // groupStore is the default implementation of groupStoreInterface.
 type groupStore struct {
-	dbProvider   provider.DBProviderInterface
-	deploymentID string
+	dbProvider provider.DBProviderInterface
 }
 
 // newGroupStore creates a new instance of groupStore.
 func newGroupStore() groupStoreInterface {
 	return &groupStore{
-		deploymentID: config.GetServerRuntime().Config.Server.Identifier,
-		dbProvider:   provider.GetDBProvider(),
+		dbProvider: provider.GetDBProvider(),
 	}
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (s *groupStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // GetGroupListCount retrieves the total count of root groups.
@@ -109,7 +113,7 @@ func (s *groupStore) GetGroupListCount(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	countResults, err := dbClient.QueryContext(ctx, QueryGetGroupListCount, s.deploymentID)
+	countResults, err := dbClient.QueryContext(ctx, QueryGetGroupListCount, s.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute group list count query: %w", err)
 	}
@@ -130,7 +134,7 @@ func (s *groupStore) GetGroupList(ctx context.Context, limit, offset int) ([]Gro
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	results, err := dbClient.QueryContext(ctx, QueryGetGroupList, limit, offset, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, QueryGetGroupList, limit, offset, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute group list query: %w", err)
 	}
@@ -166,7 +170,7 @@ func (s *groupStore) GetGroupListCountByOUIDs(ctx context.Context, ouIDs []strin
 		return 0, fmt.Errorf("failed to get database client for counter query: %w", err)
 	}
 
-	query, args := buildGetGroupsCountByOUIDsQuery(ouIDs, s.deploymentID)
+	query, args := buildGetGroupsCountByOUIDsQuery(ouIDs, s.scope(ctx))
 
 	var count int
 	countResults, err := dbClient.QueryContext(ctx, query, args...)
@@ -196,7 +200,7 @@ func (s *groupStore) GetGroupListByOUIDs(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client for query: %w", err)
 	}
-	query, args := buildGetGroupsByOUIDsQuery(ouIDs, limit, offset, s.deploymentID)
+	query, args := buildGetGroupsByOUIDsQuery(ouIDs, limit, offset, s.scope(ctx))
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -238,7 +242,7 @@ func (s *groupStore) CreateGroup(ctx context.Context, group GroupDAO) error {
 		group.OUID,
 		group.Name,
 		group.Description,
-		s.deploymentID,
+		s.scope(ctx),
 		now,
 		now,
 	)
@@ -246,7 +250,7 @@ func (s *groupStore) CreateGroup(ctx context.Context, group GroupDAO) error {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
 
-	err = addMembersToGroup(ctx, dbClient, group.ID, group.Members, s.deploymentID)
+	err = addMembersToGroup(ctx, dbClient, group.ID, group.Members, s.scope(ctx))
 	if err != nil {
 		return err
 	}
@@ -261,7 +265,7 @@ func (s *groupStore) GetGroup(ctx context.Context, id string) (GroupDAO, error) 
 		return GroupDAO{}, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, QueryGetGroupByID, id, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, QueryGetGroupByID, id, s.scope(ctx))
 	if err != nil {
 		return GroupDAO{}, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -290,7 +294,7 @@ func (s *groupStore) GetGroupMembers(ctx context.Context, groupID string, limit,
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, QueryGetGroupMembers, groupID, limit, offset, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, QueryGetGroupMembers, groupID, limit, offset, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get group members: %w", err)
 	}
@@ -317,7 +321,7 @@ func (s *groupStore) GetGroupMemberCount(ctx context.Context, groupID string) (i
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	countResults, err := dbClient.QueryContext(ctx, QueryGetGroupMemberCount, groupID, s.deploymentID)
+	countResults, err := dbClient.QueryContext(ctx, QueryGetGroupMemberCount, groupID, s.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to get group member count: %w", err)
 	}
@@ -348,7 +352,7 @@ func (s *groupStore) UpdateGroup(ctx context.Context, group GroupDAO) error {
 		group.Name,
 		group.Description,
 		time.Now().UTC(),
-		s.deploymentID,
+		s.scope(ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
@@ -370,12 +374,12 @@ func (s *groupStore) DeleteGroup(ctx context.Context, id string) error {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	_, err = dbClient.ExecuteContext(ctx, QueryDeleteGroupMembers, id, s.deploymentID)
+	_, err = dbClient.ExecuteContext(ctx, QueryDeleteGroupMembers, id, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to delete group members: %w", err)
 	}
 
-	result, err := dbClient.ExecuteContext(ctx, QueryDeleteGroup, id, s.deploymentID)
+	result, err := dbClient.ExecuteContext(ctx, QueryDeleteGroup, id, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -398,7 +402,7 @@ func (s *groupStore) ValidateGroupIDs(ctx context.Context, groupIDs []string) ([
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	query, args, err := buildBulkGroupExistsQueryFunc(groupIDs, s.deploymentID)
+	query, args, err := buildBulkGroupExistsQueryFunc(groupIDs, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build bulk group exists query: %w", err)
 	}
@@ -434,7 +438,7 @@ func (s *groupStore) CheckGroupNameConflictForCreate(
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	return checkGroupNameConflictForCreate(ctx, dbClient, name, oUID, s.deploymentID)
+	return checkGroupNameConflictForCreate(ctx, dbClient, name, oUID, s.scope(ctx))
 }
 
 // CheckGroupNameConflictForUpdate checks if the new group name conflicts with other groups
@@ -446,7 +450,7 @@ func (s *groupStore) CheckGroupNameConflictForUpdate(
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	return checkGroupNameConflictForUpdate(ctx, dbClient, name, oUID, groupID, s.deploymentID)
+	return checkGroupNameConflictForUpdate(ctx, dbClient, name, oUID, groupID, s.scope(ctx))
 }
 
 // GetGroupsByOrganizationUnitCount retrieves the total count of groups in a specific organization unit.
@@ -457,7 +461,7 @@ func (s *groupStore) GetGroupsByOrganizationUnitCount(ctx context.Context, oUID 
 	}
 
 	countResults, err := dbClient.QueryContext(
-		ctx, QueryGetGroupsByOrganizationUnitCount, oUID, s.deploymentID)
+		ctx, QueryGetGroupsByOrganizationUnitCount, oUID, s.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to get group count by organization unit: %w", err)
 	}
@@ -483,7 +487,7 @@ func (s *groupStore) GetGroupsByOrganizationUnit(
 	}
 
 	results, err := dbClient.QueryContext(
-		ctx, QueryGetGroupsByOrganizationUnit, oUID, limit, offset, s.deploymentID)
+		ctx, QueryGetGroupsByOrganizationUnit, oUID, limit, offset, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get groups by organization unit: %w", err)
 	}
@@ -513,7 +517,7 @@ func (s *groupStore) AddGroupMembers(ctx context.Context, groupID string, member
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	return addMembersToGroup(ctx, dbClient, groupID, members, s.deploymentID)
+	return addMembersToGroup(ctx, dbClient, groupID, members, s.scope(ctx))
 }
 
 // RemoveGroupMembers removes members from a group.
@@ -526,7 +530,7 @@ func (s *groupStore) RemoveGroupMembers(ctx context.Context, groupID string, mem
 	for _, member := range members {
 		_, err := dbClient.ExecuteContext(
 			ctx, QueryDeleteGroupMember,
-			groupID, member.Type, member.ID, s.deploymentID,
+			groupID, member.Type, member.ID, s.scope(ctx),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to remove member from group: %w", err)
@@ -546,7 +550,7 @@ func (s *groupStore) DeleteMembershipsByMember(
 	}
 
 	rowsAffected, err := dbClient.ExecuteContext(
-		ctx, QueryDeleteGroupMembershipsByMember, memberType, memberID, s.deploymentID)
+		ctx, QueryDeleteGroupMembershipsByMember, memberType, memberID, s.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete memberships for member: %w", err)
 	}
@@ -575,7 +579,7 @@ func (s *groupStore) GetGroupsByIDs(ctx context.Context, groupIDs []string) ([]G
 		}
 		chunk := groupIDs[start:end]
 
-		query, args, err := buildGetGroupsByIDsQuery(chunk, s.deploymentID)
+		query, args, err := buildGetGroupsByIDsQuery(chunk, s.scope(ctx))
 		if err != nil {
 			return nil, fmt.Errorf("failed to build get groups by IDs query: %w", err)
 		}
@@ -617,7 +621,7 @@ func (s *groupStore) GetTransitiveGroupsForEntity(
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, QueryGetTransitiveGroupsForMember, entityID, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, QueryGetTransitiveGroupsForMember, entityID, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get transitive groups for entity: %w", err)
 	}
@@ -653,7 +657,7 @@ func (s *groupStore) GetDirectGroupParents(ctx context.Context, groupIDs []strin
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	query, args := buildGetDirectGroupParentsQuery(groupIDs, s.deploymentID)
+	query, args := buildGetDirectGroupParentsQuery(groupIDs, s.scope(ctx))
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get direct group parents: %w", err)

--- a/backend/internal/group/store_test.go
+++ b/backend/internal/group/store_test.go
@@ -16,6 +16,9 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 type GroupStoreTestSuite struct {
@@ -79,7 +82,7 @@ func (suite *GroupStoreTestSuite) runGroupNameConflictTestCases(testCases []grou
 		suite.Run(tc.name, func() {
 			providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
 			dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 
 			if tc.setupDB != nil {
 				tc.setupDB(dbClientMock)
@@ -170,7 +173,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupListCount() {
 		suite.Run(tc.name, func() {
 			providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
 			dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 
 			if tc.setup != nil {
 				tc.setup(providerMock, dbClientMock)
@@ -313,7 +316,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupList() {
 		suite.Run(tc.name, func() {
 			providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
 			dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 
 			if tc.setup != nil {
 				tc.setup(providerMock, dbClientMock)
@@ -487,7 +490,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroup() {
 		suite.Run(tc.name, func() {
 			providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
 			dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 
 			if tc.setup != nil {
 				tc.setup(providerMock, dbClientMock)
@@ -595,7 +598,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupMembers() {
 		suite.Run(tc.name, func() {
 			providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
 			dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 
 			if tc.setup != nil {
 				tc.setup(providerMock, dbClientMock)
@@ -725,7 +728,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupMemberCount() {
 		suite.Run(tc.name, func() {
 			providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
 			dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 
 			if tc.setup != nil {
 				tc.setup(providerMock, dbClientMock)
@@ -868,7 +871,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 			providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
 			dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
 
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 
 			if tc.setup != nil {
 				tc.setup(providerMock, dbClientMock)
@@ -1011,7 +1014,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 			providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
 			dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
 
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 
 			if tc.setup != nil {
 				tc.setup(providerMock, dbClientMock)
@@ -1182,7 +1185,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_ValidateGroupIDs() {
 				tc.setup(providerMock, dbClientMock)
 			}
 
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 			invalid, err := store.ValidateGroupIDs(context.Background(), tc.groupIDs)
 
 			if tc.wantErr != "" {
@@ -1285,7 +1288,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupsByOrganizationUnitCoun
 		suite.Run(tc.name, func() {
 			providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
 			dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 
 			if tc.setup != nil {
 				tc.setup(providerMock, dbClientMock)
@@ -1392,7 +1395,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupsByOrganizationUnit() {
 		suite.Run(tc.name, func() {
 			providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
 			dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 
 			if tc.setup != nil {
 				tc.setup(providerMock, dbClientMock)
@@ -1773,7 +1776,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupsByIDs() {
 				tc.setup(providerMock, dbClientMock)
 			}
 
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 			groups, err := store.GetGroupsByIDs(context.Background(), tc.groupIDs)
 
 			if tc.wantErr != "" {
@@ -1947,7 +1950,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetTransitiveGroupsForEntity() 
 		suite.Run(tc.name, func() {
 			providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
 			dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
-			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			store := &groupStore{dbProvider: providerMock}
 
 			tc.setup(providerMock, dbClientMock)
 
@@ -1974,7 +1977,7 @@ func (suite *GroupStoreTestSuite) TestDeleteMembershipsByMember() {
 		dbClientMock.On("ExecuteContext", mock.Anything, QueryDeleteGroupMembershipsByMember,
 			string(memberTypeEntity), "user-1", testDeploymentID).Return(int64(2), nil).Once()
 
-		store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+		store := &groupStore{dbProvider: providerMock}
 		deleted, err := store.DeleteMembershipsByMember(
 			context.Background(), string(memberTypeEntity), "user-1")
 
@@ -1989,11 +1992,21 @@ func (suite *GroupStoreTestSuite) TestDeleteMembershipsByMember() {
 		dbClientMock.On("ExecuteContext", mock.Anything, QueryDeleteGroupMembershipsByMember,
 			string(memberTypeEntity), "user-1", testDeploymentID).Return(int64(0), errors.New("db error")).Once()
 
-		store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+		store := &groupStore{dbProvider: providerMock}
 		deleted, err := store.DeleteMembershipsByMember(
 			context.Background(), string(memberTypeEntity), "user-1")
 
 		require.Error(suite.T(), err)
 		require.Equal(suite.T(), int64(0), deleted)
+	})
+}
+
+// SetupTest loads a server runtime naming the deployment these tests assert on. The store resolves
+// its deployment from the runtime rather than holding one, and other suites in this package reset
+// the runtime, so it is loaded per test rather than once for the package.
+func (suite *GroupStoreTestSuite) SetupTest() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: testDeploymentID},
 	})
 }

--- a/backend/internal/idp/store.go
+++ b/backend/internal/idp/store.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 
 	"github.com/thunder-id/thunderid/internal/system/cmodels"
-	"github.com/thunder-id/thunderid/internal/system/config"
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -32,8 +32,7 @@ type idpStoreInterface interface {
 
 // idpStore is the default implementation of IDPStoreInterface.
 type idpStore struct {
-	dbProvider   provider.DBProviderInterface
-	deploymentID string
+	dbProvider provider.DBProviderInterface
 }
 
 // newIDPStore creates a new instance of IDPStore.
@@ -48,9 +47,14 @@ func newIDPStore() (idpStoreInterface, providers.Transactioner, error) {
 		return nil, nil, err
 	}
 	return &idpStore{
-		dbProvider:   dbProvider,
-		deploymentID: config.GetServerRuntime().Config.Server.Identifier,
+		dbProvider: dbProvider,
 	}, transactioner, nil
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (s *idpStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // CreateIdentityProvider handles the IdP creation in the database.
@@ -75,7 +79,7 @@ func (s *idpStore) CreateIdentityProvider(ctx context.Context, idp providers.IDP
 
 	_, err = dbClient.ExecuteContext(ctx,
 		queryCreateIdentityProvider, idp.ID, idp.Name, idp.Description, idp.Type, propertiesJSON,
-		attributeConfigurationJSON, s.deploymentID,
+		attributeConfigurationJSON, s.scope(ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
@@ -91,7 +95,7 @@ func (s *idpStore) GetIdentityProviderList(ctx context.Context) ([]BasicIDPDTO, 
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetIdentityProviderList, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetIdentityProviderList, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -118,7 +122,7 @@ func (s *idpStore) GetIdentityProviderListCount(ctx context.Context) (int, error
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetIdentityProviderListCount, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetIdentityProviderListCount, s.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -163,7 +167,7 @@ func (s *idpStore) GetIdentityProvidersByProperty(ctx context.Context,
 	}
 
 	results, err := dbClient.QueryContext(ctx, queryGetIdentityProvidersByProperty,
-		propertyKey, propertyValue, s.deploymentID)
+		propertyKey, propertyValue, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -217,7 +221,7 @@ func (s *idpStore) getIDP(ctx context.Context, query dbmodel.DBQuery, identifier
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, query, identifier, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, query, identifier, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -293,7 +297,7 @@ func (s *idpStore) UpdateIdentityProvider(ctx context.Context, idp *providers.ID
 
 	// Update the IDP in the database
 	_, err = dbClient.ExecuteContext(ctx, queryUpdateIdentityProviderByID, idp.ID, idp.Name,
-		idp.Description, idp.Type, propertiesJSON, attributeConfigurationJSON, s.deploymentID)
+		idp.Description, idp.Type, propertiesJSON, attributeConfigurationJSON, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -310,7 +314,7 @@ func (s *idpStore) DeleteIdentityProvider(ctx context.Context, id string) error 
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	rowsAffected, err := dbClient.ExecuteContext(ctx, queryDeleteIdentityProviderByID, id, s.deploymentID)
+	rowsAffected, err := dbClient.ExecuteContext(ctx, queryDeleteIdentityProviderByID, id, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}

--- a/backend/internal/idp/store_test.go
+++ b/backend/internal/idp/store_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 const testDeploymentID = "test-deployment-id"
@@ -32,6 +34,7 @@ func TestIDPStoreTestSuite(t *testing.T) {
 
 func (s *IDPStoreTestSuite) SetupTest() {
 	testConfig := &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: testDeploymentID},
 		Database: config.DatabaseConfig{
 			Config: config.DataSource{
 				Type:   "sqlite",
@@ -43,14 +46,16 @@ func (s *IDPStoreTestSuite) SetupTest() {
 			},
 		},
 	}
+	// The store resolves its deployment from the runtime rather than holding one, and other suites in
+	// this package reset the runtime, so load it per test.
+	config.ResetServerRuntime()
 	_ = config.InitializeServerRuntime("test", testConfig)
 
 	s.mockDBProvider = &providermock.DBProviderInterfaceMock{}
 	s.mockDBClient = &providermock.DBClientInterfaceMock{}
 
 	s.store = &idpStore{
-		dbProvider:   s.mockDBProvider,
-		deploymentID: testDeploymentID,
+		dbProvider: s.mockDBProvider,
 	}
 }
 

--- a/backend/internal/inboundclient/store.go
+++ b/backend/internal/inboundclient/store.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 
 	inboundmodel "github.com/thunder-id/thunderid/internal/inboundclient/model"
-	"github.com/thunder-id/thunderid/internal/system/config"
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/utils"
@@ -56,8 +56,7 @@ type inboundClientStoreInterface interface {
 
 // store implements inboundClientStoreInterface using the configured config database.
 type store struct {
-	dbProvider   provider.DBProviderInterface
-	deploymentID string
+	dbProvider provider.DBProviderInterface
 }
 
 // getDBProvider is a package-level indirection to allow test override.
@@ -76,14 +75,15 @@ func newStore() (inboundClientStoreInterface, providers.Transactioner, error) {
 		return nil, nil, err
 	}
 
-	deploymentID := config.GetServerRuntime().Config.Server.Identifier
+	// Table verification runs at start-up, outside any request, so this resolves to the configured
+	// identifier.
+	deploymentID := deployment.Resolve(context.Background())
 	if _, err := client.QueryContext(context.Background(), queryGetInboundClientCount, deploymentID); err != nil {
 		return nil, nil, fmt.Errorf("failed to verify inbound client table: %w", err)
 	}
 
 	return &store{
-		dbProvider:   dbProvider,
-		deploymentID: deploymentID,
+		dbProvider: dbProvider,
 	}, transactioner, nil
 }
 
@@ -133,6 +133,12 @@ func marshalInboundClient(c inboundmodel.InboundClient) (
 		recoveryFlowID, signOutFlowID, registrationFlowID, themeID, layoutID, nil
 }
 
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (st *store) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
+}
+
 // CreateInboundClient creates a new inbound client entry.
 func (st *store) CreateInboundClient(ctx context.Context, client inboundmodel.InboundClient) error {
 	dbClient, err := st.dbProvider.GetConfigDBClient()
@@ -149,7 +155,7 @@ func (st *store) CreateInboundClient(ctx context.Context, client inboundmodel.In
 	_, err = dbClient.ExecuteContext(ctx, queryCreateInboundClient,
 		client.ID, client.AuthFlowID, registrationFlowID, isRegEnabledStr,
 		recoveryFlowID, isRecoveryEnabledStr, signOutFlowID,
-		themeID, layoutID, propsBytes, st.deploymentID)
+		themeID, layoutID, propsBytes, st.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to insert inbound client: %w", err)
 	}
@@ -170,7 +176,7 @@ func (st *store) CreateOAuthProfile(ctx context.Context, entityID string,
 		return err
 	}
 
-	_, err = dbClient.ExecuteContext(ctx, queryCreateOAuthProfile, entityID, profileJSON, st.deploymentID)
+	_, err = dbClient.ExecuteContext(ctx, queryCreateOAuthProfile, entityID, profileJSON, st.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to insert OAuth profile: %w", err)
 	}
@@ -184,7 +190,7 @@ func (st *store) GetInboundClientByEntityID(ctx context.Context, entityID string
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetInboundClientByEntityID, entityID, st.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetInboundClientByEntityID, entityID, st.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -201,7 +207,7 @@ func (st *store) GetOAuthProfileByEntityID(ctx context.Context, entityID string)
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetOAuthProfileByEntityID, entityID, st.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetOAuthProfileByEntityID, entityID, st.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -218,7 +224,7 @@ func (st *store) GetInboundClientList(ctx context.Context, limit int) ([]provide
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetInboundClientList, st.deploymentID, limit)
+	results, err := dbClient.QueryContext(ctx, queryGetInboundClientList, st.scope(ctx), limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -239,7 +245,7 @@ func (st *store) GetInboundClientList(ctx context.Context, limit int) ([]provide
 // cannot reference a resource type it has no column for.
 func (st *store) GetEntityIDsByReference(
 	ctx context.Context, refType, refID string, limit, offset int) ([]string, int, error) {
-	countQuery, listQuery, filterArgs, ok := referenceQueries(refType, refID, st.deploymentID)
+	countQuery, listQuery, filterArgs, ok := referenceQueries(refType, refID, st.scope(ctx))
 	if !ok {
 		return []string{}, 0, nil
 	}
@@ -319,7 +325,7 @@ func (st *store) GetTotalInboundClientCount(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetInboundClientCount, st.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetInboundClientCount, st.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -349,7 +355,7 @@ func (st *store) UpdateInboundClient(ctx context.Context, client inboundmodel.In
 	rowsAffected, err := dbClient.ExecuteContext(ctx, queryUpdateInboundClientByEntityID,
 		client.ID, client.AuthFlowID, registrationFlowID, isRegEnabledStr,
 		recoveryFlowID, isRecoveryEnabledStr, signOutFlowID,
-		themeID, layoutID, propsBytes, st.deploymentID)
+		themeID, layoutID, propsBytes, st.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to update inbound client: %w", err)
 	}
@@ -374,7 +380,7 @@ func (st *store) UpdateOAuthProfile(ctx context.Context, entityID string,
 	}
 
 	rowsAffected, err := dbClient.ExecuteContext(ctx, queryUpdateOAuthProfileByEntityID,
-		entityID, profileJSON, st.deploymentID)
+		entityID, profileJSON, st.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to update OAuth profile: %w", err)
 	}
@@ -404,7 +410,7 @@ func (st *store) DeleteInboundClient(ctx context.Context, entityID string) error
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	_, err = dbClient.ExecuteContext(ctx, queryDeleteInboundClientByEntityID, entityID, st.deploymentID)
+	_, err = dbClient.ExecuteContext(ctx, queryDeleteInboundClientByEntityID, entityID, st.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to delete inbound client: %w", err)
 	}
@@ -418,7 +424,7 @@ func (st *store) DeleteOAuthProfile(ctx context.Context, entityID string) error 
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	_, err = dbClient.ExecuteContext(ctx, queryDeleteOAuthProfileByEntityID, entityID, st.deploymentID)
+	_, err = dbClient.ExecuteContext(ctx, queryDeleteOAuthProfileByEntityID, entityID, st.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to delete OAuth profile: %w", err)
 	}
@@ -432,7 +438,7 @@ func (st *store) InboundClientExists(ctx context.Context, entityID string) (bool
 		return false, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryCheckInboundClientExistsByEntityID, entityID, st.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryCheckInboundClientExistsByEntityID, entityID, st.scope(ctx))
 	if err != nil {
 		return false, fmt.Errorf("failed to execute existence check query: %w", err)
 	}

--- a/backend/internal/inboundclient/store_test.go
+++ b/backend/internal/inboundclient/store_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 const (
@@ -44,12 +46,12 @@ func TestInboundClientStoreTestSuite(t *testing.T) {
 }
 
 func (suite *InboundClientStoreTestSuite) SetupTest() {
+	loadRuntimeForScope()
 	_ = config.InitializeServerRuntime("test", &config.Config{})
 	suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 	suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 	suite.store = &store{
-		dbProvider:   suite.mockDBProvider,
-		deploymentID: testServerID,
+		dbProvider: suite.mockDBProvider,
 	}
 }
 
@@ -882,4 +884,14 @@ func (suite *InboundClientStoreTestSuite) TestSubjectAttribute_RoundTrip() {
 	suite.NoError(err)
 	suite.Require().NotNil(result)
 	suite.Equal(mapping, result.SubjectAttribute)
+}
+
+// loadRuntimeForScope loads a server runtime naming the deployment these tests assert on. The store
+// resolves its deployment from the runtime rather than holding one, and other suites in this package
+// reset the runtime, so it is loaded per test rather than once for the package.
+func loadRuntimeForScope() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: testServerID},
+	})
 }

--- a/backend/internal/notification/store.go
+++ b/backend/internal/notification/store.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/notification/common"
 	"github.com/thunder-id/thunderid/internal/system/cmodels"
-	"github.com/thunder-id/thunderid/internal/system/config"
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -36,8 +36,7 @@ type notificationStoreInterface interface {
 
 // notificationStore is the implementation of notificationStoreInterface.
 type notificationStore struct {
-	dbProvider   provider.DBProviderInterface
-	deploymentID string
+	dbProvider provider.DBProviderInterface
 }
 
 // newNotificationStore returns a new instance of notificationStoreInterface.
@@ -52,10 +51,15 @@ func newNotificationStore() (notificationStoreInterface, providers.Transactioner
 		return nil, nil, fmt.Errorf("failed to get transactioner: %w", err)
 	}
 	store := &notificationStore{
-		dbProvider:   dbProvider,
-		deploymentID: config.GetServerRuntime().Config.Server.Identifier,
+		dbProvider: dbProvider,
 	}
 	return store, tx, nil
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (s *notificationStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // createSender creates a new notification sender.
@@ -75,7 +79,7 @@ func (s *notificationStore) createSender(ctx context.Context, sender common.Noti
 	}
 
 	_, err = dbClient.ExecuteContext(ctx, queryCreateNotificationSender, sender.Name, sender.ID,
-		sender.Description, string(sender.Type), string(sender.Provider), propertiesJSON, s.deploymentID)
+		sender.Description, string(sender.Type), string(sender.Provider), propertiesJSON, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -85,7 +89,7 @@ func (s *notificationStore) createSender(ctx context.Context, sender common.Noti
 
 // listSenders retrieves all notification senders.
 func (s *notificationStore) listSenders(ctx context.Context) ([]common.NotificationSenderDTO, error) {
-	return s.listSendersWithQuery(ctx, queryGetAllNotificationSenders, s.deploymentID)
+	return s.listSendersWithQuery(ctx, queryGetAllNotificationSenders, s.scope(ctx))
 }
 
 // listSendersByType retrieves all notification senders of the given type (e.g. only
@@ -94,7 +98,7 @@ func (s *notificationStore) listSenders(ctx context.Context) ([]common.Notificat
 func (s *notificationStore) listSendersByType(
 	ctx context.Context, senderType common.NotificationSenderType,
 ) ([]common.NotificationSenderDTO, error) {
-	return s.listSendersWithQuery(ctx, queryGetNotificationSendersByType, string(senderType), s.deploymentID)
+	return s.listSendersWithQuery(ctx, queryGetNotificationSendersByType, string(senderType), s.scope(ctx))
 }
 
 // listSendersWithQuery runs the given query and builds the resulting notification senders,
@@ -162,7 +166,7 @@ func (s *notificationStore) getSender(ctx context.Context, query dbmodel.DBQuery
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, query, identifier, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, query, identifier, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -216,7 +220,7 @@ func (s *notificationStore) updateSender(ctx context.Context, id string, sender 
 	}
 
 	_, err = dbClient.ExecuteContext(ctx, queryUpdateNotificationSender, sender.Name, sender.Description,
-		string(sender.Provider), propertiesJSON, id, string(sender.Type), s.deploymentID)
+		string(sender.Provider), propertiesJSON, id, string(sender.Type), s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -233,7 +237,7 @@ func (s *notificationStore) deleteSender(ctx context.Context, id string) error {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	rowsAffected, err := dbClient.ExecuteContext(ctx, queryDeleteNotificationSender, id, s.deploymentID)
+	rowsAffected, err := dbClient.ExecuteContext(ctx, queryDeleteNotificationSender, id, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute delete query: %w", err)
 	}

--- a/backend/internal/notification/store_test.go
+++ b/backend/internal/notification/store_test.go
@@ -54,11 +54,11 @@ func (suite *StoreTestSuite) SetupSuite() {
 }
 
 func (suite *StoreTestSuite) SetupTest() {
+	loadRuntimeForScope()
 	suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 	suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 	suite.store = &notificationStore{
-		dbProvider:   suite.mockDBProvider,
-		deploymentID: testDeploymentID,
+		dbProvider: suite.mockDBProvider,
 	}
 }
 
@@ -561,9 +561,7 @@ func (suite *StoreTestSuite) TestDeleteSender_ExecuteError() {
 }
 
 func (suite *StoreTestSuite) TestBuildSenderFromResultRow_WithError() {
-	s := &notificationStore{
-		deploymentID: testDeploymentID,
-	}
+	s := &notificationStore{}
 
 	// missing sender_id
 	row := map[string]interface{}{"name": "n1", "description": "d1", "type": "message", "provider": "p"}
@@ -578,9 +576,7 @@ func (suite *StoreTestSuite) TestBuildSenderFromResultRow_WithError() {
 }
 
 func (suite *StoreTestSuite) TestBuildSenderFromResultRow_MissingFields() {
-	s := &notificationStore{
-		deploymentID: testDeploymentID,
-	}
+	s := &notificationStore{}
 
 	// missing name
 	row := map[string]interface{}{"id": "s1", "description": "d1", "type": "message", "provider": "p"}
@@ -608,9 +604,7 @@ func (suite *StoreTestSuite) TestBuildSenderFromResultRow_MissingFields() {
 }
 
 func (suite *StoreTestSuite) TestBuildSenderFromResultRow() {
-	s := &notificationStore{
-		deploymentID: testSenderID,
-	}
+	s := &notificationStore{}
 	row := map[string]interface{}{
 		"id":          "sid",
 		"name":        "name",
@@ -623,4 +617,14 @@ func (suite *StoreTestSuite) TestBuildSenderFromResultRow() {
 	suite.NotNil(sender)
 	suite.Equal("sid", sender.ID)
 	suite.Equal("name", sender.Name)
+}
+
+// loadRuntimeForScope loads a server runtime naming the deployment these tests assert on. The store
+// resolves its deployment from the runtime rather than holding one, and other suites in this package
+// reset the runtime, so it is loaded per test rather than once for the package.
+func loadRuntimeForScope() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: testDeploymentID},
+	})
 }

--- a/backend/internal/ou/store.go
+++ b/backend/internal/ou/store.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
 	"github.com/thunder-id/thunderid/internal/system/log"
@@ -49,8 +49,7 @@ var getDBProvider = provider.GetDBProvider
 
 // organizationUnitStore is the default implementation of organizationUnitStoreInterface.
 type organizationUnitStore struct {
-	dbProvider   provider.DBProviderInterface
-	deploymentID string
+	dbProvider provider.DBProviderInterface
 }
 
 // newOrganizationUnitStore creates a new instance of organizationUnitStore.
@@ -61,9 +60,14 @@ func newOrganizationUnitStore() (organizationUnitStoreInterface, providers.Trans
 		return nil, nil, err
 	}
 	return &organizationUnitStore{
-		dbProvider:   dbProvider,
-		deploymentID: config.GetServerRuntime().Config.Server.Identifier,
+		dbProvider: dbProvider,
 	}, transactioner, nil
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (s *organizationUnitStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // GetOrganizationUnitListCount retrieves the total count of organization units.
@@ -79,7 +83,7 @@ func (s *organizationUnitStore) GetOrganizationUnitListCount(
 	if err != nil {
 		return 0, fmt.Errorf("failed to build count query: %w", err)
 	}
-	args := append([]interface{}{s.deploymentID}, filterArgs...)
+	args := append([]interface{}{s.scope(ctx)}, filterArgs...)
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -111,7 +115,7 @@ func (s *organizationUnitStore) GetOrganizationUnitList(
 	if err != nil {
 		return nil, fmt.Errorf("failed to build list query: %w", err)
 	}
-	args := append([]interface{}{limit, offset, s.deploymentID}, filterArgs...)
+	args := append([]interface{}{limit, offset, s.scope(ctx)}, filterArgs...)
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -148,7 +152,7 @@ func (s *organizationUnitStore) GetOrganizationUnitsByIDs(
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	args = append(args, s.deploymentID)
+	args = append(args, s.scope(ctx))
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -188,7 +192,7 @@ func (s *organizationUnitStore) CreateOrganizationUnit(ctx context.Context, ou p
 		ou.Name,
 		ou.Description,
 		string(ouMetadataBytes),
-		s.deploymentID,
+		s.scope(ctx),
 		ou.CreatedAt,
 		ou.UpdatedAt,
 	)
@@ -209,7 +213,7 @@ func (s *organizationUnitStore) GetOrganizationUnit(
 		return providers.OrganizationUnit{}, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetOrganizationUnitByID, id, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetOrganizationUnitByID, id, s.scope(ctx))
 	if err != nil {
 		return providers.OrganizationUnit{}, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -238,9 +242,9 @@ func (s *organizationUnitStore) GetOrganizationUnitByHandle(
 
 	var results []map[string]interface{}
 	if parent == nil {
-		results, err = dbClient.QueryContext(ctx, queryGetRootOrganizationUnitByHandle, handle, s.deploymentID)
+		results, err = dbClient.QueryContext(ctx, queryGetRootOrganizationUnitByHandle, handle, s.scope(ctx))
 	} else {
-		results, err = dbClient.QueryContext(ctx, queryGetOrganizationUnitByHandle, handle, *parent, s.deploymentID)
+		results, err = dbClient.QueryContext(ctx, queryGetOrganizationUnitByHandle, handle, *parent, s.scope(ctx))
 	}
 	if err != nil {
 		return providers.OrganizationUnit{}, fmt.Errorf("failed to execute query for handle %s: %w", handle, err)
@@ -308,9 +312,9 @@ func (s *organizationUnitStore) getOrganizationUnitByHandleWithClient(
 	var err error
 
 	if parent == nil {
-		results, err = dbClient.QueryContext(ctx, queryGetRootOrganizationUnitByHandle, handle, s.deploymentID)
+		results, err = dbClient.QueryContext(ctx, queryGetRootOrganizationUnitByHandle, handle, s.scope(ctx))
 	} else {
-		results, err = dbClient.QueryContext(ctx, queryGetOrganizationUnitByHandle, handle, *parent, s.deploymentID)
+		results, err = dbClient.QueryContext(ctx, queryGetOrganizationUnitByHandle, handle, *parent, s.scope(ctx))
 	}
 	if err != nil {
 		return providers.OrganizationUnit{}, fmt.Errorf("failed to execute query for handle %s: %w", handle, err)
@@ -339,7 +343,7 @@ func (s *organizationUnitStore) IsOrganizationUnitExists(ctx context.Context, id
 		return false, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryCheckOrganizationUnitExists, id, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryCheckOrganizationUnitExists, id, s.scope(ctx))
 	if err != nil {
 		return false, fmt.Errorf("failed to execute existence check query: %w", err)
 	}
@@ -385,7 +389,7 @@ func (s *organizationUnitStore) UpdateOrganizationUnit(ctx context.Context, ou p
 		ou.Description,
 		string(ouMetadataBytes),
 		ou.UpdatedAt,
-		s.deploymentID,
+		s.scope(ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
@@ -401,7 +405,7 @@ func (s *organizationUnitStore) DeleteOrganizationUnit(ctx context.Context, id s
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	_, err = dbClient.ExecuteContext(ctx, queryDeleteOrganizationUnit, id, s.deploymentID)
+	_, err = dbClient.ExecuteContext(ctx, queryDeleteOrganizationUnit, id, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -422,7 +426,7 @@ func (s *organizationUnitStore) GetOrganizationUnitChildrenCount(
 	if err != nil {
 		return 0, fmt.Errorf("failed to build count query: %w", err)
 	}
-	args := append([]interface{}{parentID, s.deploymentID}, filterArgs...)
+	args := append([]interface{}{parentID, s.scope(ctx)}, filterArgs...)
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -455,7 +459,7 @@ func (s *organizationUnitStore) GetOrganizationUnitChildrenList(ctx context.Cont
 	if err != nil {
 		return nil, fmt.Errorf("failed to build list query: %w", err)
 	}
-	args := append([]interface{}{parentID, limit, offset, s.deploymentID}, filterArgs...)
+	args := append([]interface{}{parentID, limit, offset, s.scope(ctx)}, filterArgs...)
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -483,7 +487,7 @@ func (s *organizationUnitStore) CheckOrganizationUnitNameConflict(
 		queryCheckOrganizationUnitNameConflictRoot,
 		name,
 		parentID,
-		s.deploymentID,
+		s.scope(ctx),
 	)
 }
 
@@ -496,7 +500,7 @@ func (s *organizationUnitStore) CheckOrganizationUnitHandleConflict(
 		queryCheckOrganizationUnitHandleConflictRoot,
 		handle,
 		parentID,
-		s.deploymentID,
+		s.scope(ctx),
 	)
 }
 

--- a/backend/internal/ou/store_test.go
+++ b/backend/internal/ou/store_test.go
@@ -19,6 +19,9 @@ import (
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 const testDeploymentID = "test-deployment-id"
@@ -35,11 +38,11 @@ func TestOrganizationUnitStoreTestSuite(t *testing.T) {
 }
 
 func (suite *OrganizationUnitStoreTestSuite) SetupTest() {
+	loadRuntimeForScope()
 	suite.providerMock = providermock.NewDBProviderInterfaceMock(suite.T())
 	suite.dbClientMock = providermock.NewDBClientInterfaceMock(suite.T())
 	suite.store = &organizationUnitStore{
-		dbProvider:   suite.providerMock,
-		deploymentID: testDeploymentID,
+		dbProvider: suite.providerMock,
 	}
 }
 
@@ -2431,5 +2434,15 @@ func TestBuildChildrenOUListQuery(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported operator")
+	})
+}
+
+// loadRuntimeForScope loads a server runtime naming the deployment these tests assert on. The store
+// resolves its deployment from the runtime rather than holding one, and other suites in this package
+// reset the runtime, so it is loaded per test rather than once for the package.
+func loadRuntimeForScope() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: testDeploymentID},
 	})
 }

--- a/backend/internal/resource/init_test.go
+++ b/backend/internal/resource/init_test.go
@@ -333,7 +333,6 @@ func (suite *InitTestSuite) TestNewResourceStore() {
 	resStore, ok := store.(*resourceStore)
 	suite.True(ok)
 	suite.NotNil(resStore.dbProvider)
-	suite.Equal("test-deployment", resStore.deploymentID)
 }
 
 // TestRegisterRoutes_AllOPTIONSRoutes tests that all OPTIONS routes return NoContent

--- a/backend/internal/resource/store.go
+++ b/backend/internal/resource/store.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
@@ -67,8 +67,7 @@ type resourceStoreInterface interface {
 
 // resourceStore is the default implementation of resourceStoreInterface.
 type resourceStore struct {
-	dbProvider   provider.DBProviderInterface
-	deploymentID string
+	dbProvider provider.DBProviderInterface
 }
 
 // resourceServerProperties represents the JSON structure of PROPERTIES column.
@@ -89,9 +88,14 @@ func newResourceStore() (resourceStoreInterface, providers.Transactioner, error)
 		return nil, nil, err
 	}
 	return &resourceStore{
-		dbProvider:   dbProvider,
-		deploymentID: config.GetServerRuntime().Config.Server.Identifier,
+		dbProvider: dbProvider,
 	}, transactioner, nil
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (s *resourceStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // CreateResourceServer creates a new resource server in the database.
@@ -107,7 +111,7 @@ func (s *resourceStore) CreateResourceServer(ctx context.Context, id string, rs 
 			resolveNullableString(rs.Identifier),
 			resolveNullableString(string(rs.Type)),
 			buildPropertiesJSON(rs),
-			s.deploymentID,
+			s.scope(ctx),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create resource server: %w", err)
@@ -121,7 +125,7 @@ func (s *resourceStore) CreateResourceServer(ctx context.Context, id string, rs 
 func (s *resourceStore) GetResourceServer(ctx context.Context, id string) (providers.ResourceServer, error) {
 	var rs providers.ResourceServer
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		results, err := dbClient.QueryContext(ctx, queryGetResourceServerByID, id, s.deploymentID)
+		results, err := dbClient.QueryContext(ctx, queryGetResourceServerByID, id, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to get resource server: %w", err)
 		}
@@ -143,7 +147,7 @@ func (s *resourceStore) GetResourceServerList(
 ) ([]providers.ResourceServer, error) {
 	var resourceServers []providers.ResourceServer
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		results, err := dbClient.QueryContext(ctx, queryGetResourceServerList, limit, offset, s.deploymentID)
+		results, err := dbClient.QueryContext(ctx, queryGetResourceServerList, limit, offset, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to get resource server list: %w", err)
 		}
@@ -169,7 +173,7 @@ func (s *resourceStore) GetResourceServerList(
 func (s *resourceStore) GetResourceServerListCount(ctx context.Context) (int, error) {
 	var count int
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		results, err := dbClient.QueryContext(ctx, queryGetResourceServerListCount, s.deploymentID)
+		results, err := dbClient.QueryContext(ctx, queryGetResourceServerListCount, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to get resource server count: %w", err)
 		}
@@ -193,7 +197,7 @@ func (s *resourceStore) UpdateResourceServer(ctx context.Context, id string, rs 
 			resolveNullableString(string(rs.Type)),
 			buildPropertiesJSON(rs),
 			id,
-			s.deploymentID,
+			s.scope(ctx),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to update resource server: %w", err)
@@ -206,7 +210,7 @@ func (s *resourceStore) UpdateResourceServer(ctx context.Context, id string, rs 
 // DeleteResourceServer deletes a resource server.
 func (s *resourceStore) DeleteResourceServer(ctx context.Context, id string) error {
 	return s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		_, err := dbClient.ExecuteContext(ctx, queryDeleteResourceServer, id, s.deploymentID)
+		_, err := dbClient.ExecuteContext(ctx, queryDeleteResourceServer, id, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to delete resource server: %w", err)
 		}
@@ -219,7 +223,7 @@ func (s *resourceStore) DeleteResourceServer(ctx context.Context, id string) err
 func (s *resourceStore) CheckResourceServerNameExists(ctx context.Context, name string) (bool, error) {
 	var exists bool
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		results, err := dbClient.QueryContext(ctx, queryCheckResourceServerNameExists, name, s.deploymentID)
+		results, err := dbClient.QueryContext(ctx, queryCheckResourceServerNameExists, name, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to check resource server name: %w", err)
 		}
@@ -234,7 +238,7 @@ func (s *resourceStore) CheckResourceServerNameExists(ctx context.Context, name 
 func (s *resourceStore) CheckResourceServerIdentifierExists(ctx context.Context, identifier string) (bool, error) {
 	var exists bool
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		results, err := dbClient.QueryContext(ctx, queryCheckResourceServerIdentifierExists, identifier, s.deploymentID)
+		results, err := dbClient.QueryContext(ctx, queryCheckResourceServerIdentifierExists, identifier, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to check resource server identifier: %w", err)
 		}
@@ -252,7 +256,7 @@ func (s *resourceStore) GetResourceServerByIdentifier(
 ) (providers.ResourceServer, error) {
 	var rs providers.ResourceServer
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		results, err := dbClient.QueryContext(ctx, queryGetResourceServerByIdentifier, identifier, s.deploymentID)
+		results, err := dbClient.QueryContext(ctx, queryGetResourceServerByIdentifier, identifier, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to get resource server by identifier: %w", err)
 		}
@@ -272,7 +276,7 @@ func (s *resourceStore) CheckResourceServerHasDependencies(ctx context.Context, 
 	var hasDeps bool
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
 		results, err := dbClient.QueryContext(
-			ctx, queryCheckResourceServerHasDependencies, resServerID, s.deploymentID,
+			ctx, queryCheckResourceServerHasDependencies, resServerID, s.scope(ctx),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to check dependencies: %w", err)
@@ -312,7 +316,7 @@ func (s *resourceStore) CreateResource(
 			res.Permission,  // $6: PERMISSION
 			"{}",            // $7: PROPERTIES (empty JSON).
 			parentID,        // $8: PARENT_RESOURCE_ID (UUID FK or NULL)
-			s.deploymentID,  // $9: DEPLOYMENT_ID
+			s.scope(ctx),    // $9: DEPLOYMENT_ID
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create resource: %w", err)
@@ -326,7 +330,7 @@ func (s *resourceStore) CreateResource(
 func (s *resourceStore) GetResource(ctx context.Context, id string, resServerID string) (providers.Resource, error) {
 	var res providers.Resource
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		results, err := dbClient.QueryContext(ctx, queryGetResourceByID, id, resServerID, s.deploymentID)
+		results, err := dbClient.QueryContext(ctx, queryGetResourceByID, id, resServerID, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to get resource: %w", err)
 		}
@@ -348,7 +352,7 @@ func (s *resourceStore) GetResourceList(
 	var resources []providers.Resource
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
 		results, err := dbClient.QueryContext(
-			ctx, queryGetResourceList, resServerID, limit, offset, s.deploymentID,
+			ctx, queryGetResourceList, resServerID, limit, offset, s.scope(ctx),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to get resource list: %w", err)
@@ -384,12 +388,12 @@ func (s *resourceStore) GetResourceListByParent(
 		if parentID == nil {
 			results, err = dbClient.QueryContext(
 				ctx,
-				queryGetResourceListByNullParent, resServerID, limit, offset, s.deploymentID,
+				queryGetResourceListByNullParent, resServerID, limit, offset, s.scope(ctx),
 			)
 		} else {
 			results, err = dbClient.QueryContext(
 				ctx,
-				queryGetResourceListByParent, resServerID, *parentID, limit, offset, s.deploymentID,
+				queryGetResourceListByParent, resServerID, *parentID, limit, offset, s.scope(ctx),
 			)
 		}
 
@@ -418,7 +422,7 @@ func (s *resourceStore) GetResourceListByParent(
 func (s *resourceStore) GetResourceListCount(ctx context.Context, resServerID string) (int, error) {
 	var count int
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		results, err := dbClient.QueryContext(ctx, queryGetResourceListCount, resServerID, s.deploymentID)
+		results, err := dbClient.QueryContext(ctx, queryGetResourceListCount, resServerID, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to get resource count: %w", err)
 		}
@@ -440,12 +444,12 @@ func (s *resourceStore) GetResourceListCountByParent(
 		// Treat nil parent ID as top-level resources
 		if parentID == nil {
 			results, err = dbClient.QueryContext(
-				ctx, queryGetResourceListCountByNullParent, resServerID, s.deploymentID,
+				ctx, queryGetResourceListCountByNullParent, resServerID, s.scope(ctx),
 			)
 		} else {
 			results, err = dbClient.QueryContext(
 				ctx,
-				queryGetResourceListCountByParent, resServerID, *parentID, s.deploymentID)
+				queryGetResourceListCountByParent, resServerID, *parentID, s.scope(ctx))
 		}
 
 		if err != nil {
@@ -474,7 +478,7 @@ func (s *resourceStore) UpdateResource(
 			"{}",            // $3: PROPERTIES (empty JSON).
 			id,              // $4: RESOURCE_ID
 			resServerID,     // $5: RESOURCE_SERVER_ID (UUID FK)
-			s.deploymentID,  // $6: DEPLOYMENT_ID
+			s.scope(ctx),    // $6: DEPLOYMENT_ID
 		)
 		if err != nil {
 			return fmt.Errorf("failed to update resource: %w", err)
@@ -495,7 +499,7 @@ func (s *resourceStore) UpdateResourcePermission(
 			permission,
 			id,
 			resServerID,
-			s.deploymentID,
+			s.scope(ctx),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to update resource permission: %w", err)
@@ -507,7 +511,7 @@ func (s *resourceStore) UpdateResourcePermission(
 // DeleteResource deletes a resource.
 func (s *resourceStore) DeleteResource(ctx context.Context, id string, resServerID string) error {
 	return s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		_, err := dbClient.ExecuteContext(ctx, queryDeleteResource, id, resServerID, s.deploymentID)
+		_, err := dbClient.ExecuteContext(ctx, queryDeleteResource, id, resServerID, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to delete resource: %w", err)
 		}
@@ -528,13 +532,13 @@ func (s *resourceStore) CheckResourceHandleExists(
 		if parentID == nil {
 			results, err = dbClient.QueryContext(
 				ctx,
-				queryCheckResourceHandleExistsUnderNullParent, resServerID, handle, s.deploymentID,
+				queryCheckResourceHandleExistsUnderNullParent, resServerID, handle, s.scope(ctx),
 			)
 		} else {
 			results, err = dbClient.QueryContext(
 				ctx,
 				queryCheckResourceHandleExistsUnderParent, resServerID, handle, *parentID,
-				s.deploymentID,
+				s.scope(ctx),
 			)
 		}
 
@@ -552,7 +556,7 @@ func (s *resourceStore) CheckResourceHandleExists(
 func (s *resourceStore) CheckResourceHasDependencies(ctx context.Context, resID string) (bool, error) {
 	var hasDeps bool
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		results, err := dbClient.QueryContext(ctx, queryCheckResourceHasDependencies, resID, s.deploymentID)
+		results, err := dbClient.QueryContext(ctx, queryCheckResourceHasDependencies, resID, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to check dependencies: %w", err)
 		}
@@ -568,7 +572,7 @@ func (s *resourceStore) CheckCircularDependency(ctx context.Context, resourceID,
 	var hasCircular bool
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
 		results, err := dbClient.QueryContext(
-			ctx, queryCheckCircularDependency, newParentID, resourceID, s.deploymentID,
+			ctx, queryCheckCircularDependency, newParentID, resourceID, s.scope(ctx),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to check circular dependency: %w", err)
@@ -602,7 +606,7 @@ func (s *resourceStore) CreateAction(
 			action.Description,                // $6: DESCRIPTION
 			action.Permission,                 // $7: PERMISSION
 			buildActionPropertiesJSON(action), // $8: PROPERTIES (NULL when kind empty).
-			s.deploymentID,                    // $9: DEPLOYMENT_ID
+			s.scope(ctx),                      // $9: DEPLOYMENT_ID
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create action: %w", err)
@@ -622,7 +626,7 @@ func (s *resourceStore) GetAction(
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
 		// Single unified query handles both resource server and resource level via nullable parameter
 		results, err := dbClient.QueryContext(
-			ctx, queryGetActionByID, id, resServerID, resID, s.deploymentID,
+			ctx, queryGetActionByID, id, resServerID, resID, s.scope(ctx),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to get action: %w", err)
@@ -650,12 +654,12 @@ func (s *resourceStore) GetActionList(
 		if kind != "" {
 			results, err = dbClient.QueryContext(
 				ctx, queryGetActionListByKind, resServerID, resID, limit, offset,
-				string(kind), s.deploymentID,
+				string(kind), s.scope(ctx),
 			)
 		} else {
 			results, err = dbClient.QueryContext(
 				ctx, queryGetActionList, resServerID, resID, limit, offset,
-				s.deploymentID,
+				s.scope(ctx),
 			)
 		}
 		if err != nil {
@@ -689,11 +693,11 @@ func (s *resourceStore) GetActionListCount(
 		var err error
 		if kind != "" {
 			results, err = dbClient.QueryContext(
-				ctx, queryGetActionListCountByKind, resServerID, resID, string(kind), s.deploymentID,
+				ctx, queryGetActionListCountByKind, resServerID, resID, string(kind), s.scope(ctx),
 			)
 		} else {
 			results, err = dbClient.QueryContext(
-				ctx, queryGetActionListCount, resServerID, resID, s.deploymentID,
+				ctx, queryGetActionListCount, resServerID, resID, s.scope(ctx),
 			)
 		}
 		if err != nil {
@@ -721,7 +725,7 @@ func (s *resourceStore) UpdateAction(
 			id,                                // $4: ACTION_ID
 			resServerID,                       // $5: RESOURCE_SERVER_ID (UUID FK)
 			resID,                             // $6: RESOURCE_ID (UUID FK or NULL)
-			s.deploymentID,                    // $7: DEPLOYMENT_ID
+			s.scope(ctx),                      // $7: DEPLOYMENT_ID
 		)
 		if err != nil {
 			return fmt.Errorf("failed to update action: %w", err)
@@ -739,11 +743,11 @@ func (s *resourceStore) UpdateActionPermission(
 		_, err := dbClient.ExecuteContext(
 			ctx,
 			queryUpdateActionPermission,
-			permission,     // $1: PERMISSION
-			id,             // $2: ACTION_ID
-			resServerID,    // $3: RESOURCE_SERVER_ID
-			resID,          // $4: RESOURCE_ID (nullable)
-			s.deploymentID, // $5: DEPLOYMENT_ID
+			permission,   // $1: PERMISSION
+			id,           // $2: ACTION_ID
+			resServerID,  // $3: RESOURCE_SERVER_ID
+			resID,        // $4: RESOURCE_ID (nullable)
+			s.scope(ctx), // $5: DEPLOYMENT_ID
 		)
 		if err != nil {
 			return fmt.Errorf("failed to update action permission: %w", err)
@@ -760,10 +764,10 @@ func (s *resourceStore) DeleteAction(
 		_, err := dbClient.ExecuteContext(
 			ctx,
 			queryDeleteAction,
-			id,             // $1: ACTION_ID
-			resServerID,    // $2: RESOURCE_SERVER_ID (UUID FK)
-			resID,          // $3: RESOURCE_ID (UUID FK or NULL)
-			s.deploymentID, // $4: DEPLOYMENT_ID
+			id,           // $1: ACTION_ID
+			resServerID,  // $2: RESOURCE_SERVER_ID (UUID FK)
+			resID,        // $3: RESOURCE_ID (UUID FK or NULL)
+			s.scope(ctx), // $4: DEPLOYMENT_ID
 		)
 		if err != nil {
 			return fmt.Errorf("failed to delete action: %w", err)
@@ -780,7 +784,7 @@ func (s *resourceStore) IsActionExist(
 	var exists bool
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
 		results, err := dbClient.QueryContext(
-			ctx, queryCheckActionExists, id, resServerID, resID, s.deploymentID,
+			ctx, queryCheckActionExists, id, resServerID, resID, s.scope(ctx),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to check action existence: %w", err)
@@ -801,7 +805,7 @@ func (s *resourceStore) CheckActionHandleExists(
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
 		results, err := dbClient.QueryContext(
 			ctx,
-			queryCheckActionHandleExists, resServerID, resID, handle, s.deploymentID,
+			queryCheckActionHandleExists, resServerID, resID, handle, s.scope(ctx),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to check action handle: %w", err)
@@ -837,7 +841,7 @@ func (s *resourceStore) ValidatePermissions(
 			ctx,
 			queryValidatePermissions,
 			resServerID,
-			s.deploymentID,
+			s.scope(ctx),
 			string(permissionsJSON),
 		)
 		if err != nil {

--- a/backend/internal/resource/store_test.go
+++ b/backend/internal/resource/store_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 var (
@@ -42,11 +45,11 @@ func TestResourceStoreTestSuite(t *testing.T) {
 
 // SetupTest sets up the test suite.
 func (suite *ResourceStoreTestSuite) SetupTest() {
+	loadRuntimeForScope()
 	suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 	suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 	suite.store = &resourceStore{
-		dbProvider:   suite.mockDBProvider,
-		deploymentID: "test-deployment",
+		dbProvider: suite.mockDBProvider,
 	}
 }
 
@@ -152,8 +155,7 @@ func (suite *ResourceStoreTestSuite) TestCreateResourceServer() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -253,8 +255,7 @@ func (suite *ResourceStoreTestSuite) TestGetResourceServer() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -371,8 +372,7 @@ func (suite *ResourceStoreTestSuite) TestGetResourceServerList() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -437,8 +437,7 @@ func (suite *ResourceStoreTestSuite) TestGetResourceServerListCount() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -518,8 +517,7 @@ func (suite *ResourceStoreTestSuite) TestUpdateResourceServer() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -581,8 +579,7 @@ func (suite *ResourceStoreTestSuite) TestDeleteResourceServer() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -663,8 +660,7 @@ func (suite *ResourceStoreTestSuite) TestCheckResourceServerNameExists() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -697,8 +693,7 @@ func (suite *ResourceStoreTestSuite) runBoolCheckTest(
 		suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 		suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 		suite.store = &resourceStore{
-			dbProvider:   suite.mockDBProvider,
-			deploymentID: "test-deployment",
+			dbProvider: suite.mockDBProvider,
 		}
 
 		setupMocks()
@@ -921,8 +916,7 @@ func (suite *ResourceStoreTestSuite) TestCreateResource() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.parentID)
@@ -1008,8 +1002,7 @@ func (suite *ResourceStoreTestSuite) TestGetResource() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1138,8 +1131,7 @@ func (suite *ResourceStoreTestSuite) TestGetResourceList() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1252,8 +1244,7 @@ func (suite *ResourceStoreTestSuite) TestGetResourceListByParent() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.parentID)
@@ -1321,8 +1312,7 @@ func (suite *ResourceStoreTestSuite) TestGetResourceListCount() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1400,8 +1390,7 @@ func (suite *ResourceStoreTestSuite) TestGetResourceListCountByParent() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.parentID)
@@ -1489,8 +1478,7 @@ func (suite *ResourceStoreTestSuite) TestUpdateResource() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1555,8 +1543,7 @@ func (suite *ResourceStoreTestSuite) TestDeleteResource() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1656,8 +1643,7 @@ func (suite *ResourceStoreTestSuite) TestCheckResourceHandleExists() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.parentID)
@@ -1733,8 +1719,7 @@ func (suite *ResourceStoreTestSuite) TestCheckResourceHasDependencies() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1812,8 +1797,7 @@ func (suite *ResourceStoreTestSuite) TestCheckCircularDependency() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1938,8 +1922,7 @@ func (suite *ResourceStoreTestSuite) TestCreateAction() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.resourceID)
@@ -2060,8 +2043,7 @@ func (suite *ResourceStoreTestSuite) TestGetAction() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.resourceID)
@@ -2259,8 +2241,7 @@ func (suite *ResourceStoreTestSuite) TestGetActionList() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.resourceID, tc.limit, tc.offset)
@@ -2397,8 +2378,7 @@ func (suite *ResourceStoreTestSuite) TestGetActionListCount() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.resourceID)
@@ -2516,8 +2496,7 @@ func (suite *ResourceStoreTestSuite) TestUpdateAction() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.resourceID)
@@ -2629,8 +2608,7 @@ func (suite *ResourceStoreTestSuite) TestDeleteAction() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.resourceID)
@@ -2738,8 +2716,7 @@ func (suite *ResourceStoreTestSuite) TestIsActionExist() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.resourceID)
@@ -2848,8 +2825,7 @@ func (suite *ResourceStoreTestSuite) TestCheckActionHandleExists() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks(tc.resourceID)
@@ -3772,8 +3748,7 @@ func (suite *ResourceStoreTestSuite) TestValidatePermissions() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &resourceStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: "test-deployment",
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -3871,4 +3846,14 @@ func (suite *ResourceStoreTestSuite) TestBuildPropertiesJSONFunction() {
 			suite.NotNil(result)
 		})
 	}
+}
+
+// loadRuntimeForScope loads a server runtime naming the deployment these tests assert on. The store
+// resolves its deployment from the runtime rather than holding one, and other suites in this package
+// reset the runtime, so it is loaded per test rather than once for the package.
+func loadRuntimeForScope() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: "test-deployment"},
+	})
 }

--- a/backend/internal/role/store.go
+++ b/backend/internal/role/store.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -64,8 +64,7 @@ type roleStoreInterface interface {
 
 // roleStore is the default implementation of roleStoreInterface.
 type roleStore struct {
-	dbProvider   provider.DBProviderInterface
-	deploymentID string
+	dbProvider provider.DBProviderInterface
 }
 
 // newRoleStore creates a new instance of roleStore.
@@ -80,9 +79,14 @@ func newRoleStore() (roleStoreInterface, providers.Transactioner, error) {
 		return nil, nil, err
 	}
 	return &roleStore{
-		dbProvider:   dbProvider,
-		deploymentID: config.GetServerRuntime().Config.Server.Identifier,
+		dbProvider: dbProvider,
 	}, transactioner, nil
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (s *roleStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // GetRoleListCount retrieves the total count of roles.
@@ -92,7 +96,7 @@ func (s *roleStore) GetRoleListCount(ctx context.Context) (int, error) {
 		return 0, err
 	}
 
-	countResults, err := dbClient.QueryContext(ctx, queryGetRoleListCount, s.deploymentID)
+	countResults, err := dbClient.QueryContext(ctx, queryGetRoleListCount, s.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute count query: %w", err)
 	}
@@ -107,7 +111,7 @@ func (s *roleStore) GetRoleList(ctx context.Context, limit, offset int) ([]Role,
 		return nil, err
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetRoleList, limit, offset, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetRoleList, limit, offset, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute role list query: %w", err)
 	}
@@ -131,7 +135,7 @@ func (s *roleStore) GetRoleListCountByOUID(ctx context.Context, ouID string) (in
 		return 0, err
 	}
 
-	countResults, err := dbClient.QueryContext(ctx, queryGetRoleListCountByOUID, ouID, s.deploymentID)
+	countResults, err := dbClient.QueryContext(ctx, queryGetRoleListCountByOUID, ouID, s.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute count query: %w", err)
 	}
@@ -146,7 +150,7 @@ func (s *roleStore) GetRoleListByOUID(ctx context.Context, ouID string, limit, o
 		return nil, err
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetRoleListByOUID, ouID, limit, offset, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetRoleListByOUID, ouID, limit, offset, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute role list query: %w", err)
 	}
@@ -176,17 +180,17 @@ func (s *roleStore) CreateRole(ctx context.Context, id string, role RoleCreation
 		role.OUID,
 		role.Name,
 		role.Description,
-		s.deploymentID,
+		s.scope(ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
 
-	if err := addPermissionsToRole(ctx, dbClient, id, role.Permissions, s.deploymentID); err != nil {
+	if err := addPermissionsToRole(ctx, dbClient, id, role.Permissions, s.scope(ctx)); err != nil {
 		return err
 	}
 
-	if err := addAssignmentsToRole(ctx, dbClient, id, role.Assignments, s.deploymentID); err != nil {
+	if err := addAssignmentsToRole(ctx, dbClient, id, role.Assignments, s.scope(ctx)); err != nil {
 		return err
 	}
 
@@ -200,7 +204,7 @@ func (s *roleStore) GetRole(ctx context.Context, id string) (RoleWithPermissions
 		return RoleWithPermissions{}, err
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetRoleByID, id, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetRoleByID, id, s.scope(ctx))
 	if err != nil {
 		return RoleWithPermissions{}, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -240,7 +244,7 @@ func (s *roleStore) IsRoleExist(ctx context.Context, id string) (bool, error) {
 		return false, err
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryCheckRoleExists, id, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryCheckRoleExists, id, s.scope(ctx))
 	if err != nil {
 		return false, fmt.Errorf("failed to check role existence: %w", err)
 	}
@@ -255,7 +259,7 @@ func (s *roleStore) GetRoleAssignments(ctx context.Context, id string, limit, of
 		return nil, err
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetRoleAssignments, id, limit, offset, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetRoleAssignments, id, limit, offset, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get role assignments: %w", err)
 	}
@@ -273,7 +277,7 @@ func (s *roleStore) GetRoleAssignmentsByType(
 	}
 
 	results, err := dbClient.QueryContext(
-		ctx, queryGetRoleAssignmentsByType, id, limit, offset, s.deploymentID, assigneeType)
+		ctx, queryGetRoleAssignmentsByType, id, limit, offset, s.scope(ctx), assigneeType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get role assignments: %w", err)
 	}
@@ -309,7 +313,7 @@ func (s *roleStore) GetRoleAssignmentsCount(ctx context.Context, id string) (int
 		return 0, err
 	}
 
-	countResults, err := dbClient.QueryContext(ctx, queryGetRoleAssignmentsCount, id, s.deploymentID)
+	countResults, err := dbClient.QueryContext(ctx, queryGetRoleAssignmentsCount, id, s.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to get role assignments count: %w", err)
 	}
@@ -325,7 +329,7 @@ func (s *roleStore) GetRoleAssignmentsCountByType(ctx context.Context, id string
 	}
 
 	countResults, err := dbClient.QueryContext(
-		ctx, queryGetRoleAssignmentsCountByType, id, s.deploymentID, assigneeType)
+		ctx, queryGetRoleAssignmentsCountByType, id, s.scope(ctx), assigneeType)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get role assignments count: %w", err)
 	}
@@ -346,7 +350,7 @@ func (s *roleStore) UpdateRole(ctx context.Context, id string, role RoleUpdateDe
 		role.Name,
 		role.Description,
 		id,
-		s.deploymentID,
+		s.scope(ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
@@ -356,7 +360,7 @@ func (s *roleStore) UpdateRole(ctx context.Context, id string, role RoleUpdateDe
 		return ErrRoleNotFound
 	}
 
-	if err := updateRolePermissions(ctx, dbClient, id, role.Permissions, s.deploymentID); err != nil {
+	if err := updateRolePermissions(ctx, dbClient, id, role.Permissions, s.scope(ctx)); err != nil {
 		return err
 	}
 
@@ -372,7 +376,7 @@ func (s *roleStore) DeleteRole(ctx context.Context, id string) error {
 		return err
 	}
 
-	rowsAffected, err := dbClient.ExecuteContext(ctx, queryDeleteRole, id, s.deploymentID)
+	rowsAffected, err := dbClient.ExecuteContext(ctx, queryDeleteRole, id, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -391,7 +395,7 @@ func (s *roleStore) DeleteAssignmentsByRoleID(ctx context.Context, id string) er
 		return err
 	}
 
-	_, err = dbClient.ExecuteContext(ctx, queryDeleteAllRoleAssignments, id, s.deploymentID)
+	_, err = dbClient.ExecuteContext(ctx, queryDeleteAllRoleAssignments, id, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to delete assignments for role: %w", err)
 	}
@@ -408,7 +412,7 @@ func (s *roleStore) DeleteAssignmentsByAssignee(
 	}
 
 	rowsAffected, err := dbClient.ExecuteContext(
-		ctx, queryDeleteRoleAssignmentsByAssignee, assigneeType, assigneeID, s.deploymentID)
+		ctx, queryDeleteRoleAssignmentsByAssignee, assigneeType, assigneeID, s.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete assignments for assignee: %w", err)
 	}
@@ -423,7 +427,7 @@ func (s *roleStore) GetReferencedPermissions(ctx context.Context) ([]ResourcePer
 		return nil, err
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetReferencedPermissions, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetReferencedPermissions, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get referenced permissions: %w", err)
 	}
@@ -453,7 +457,7 @@ func (s *roleStore) DeleteRolePermission(
 	}
 
 	rowsAffected, err := dbClient.ExecuteContext(
-		ctx, queryDeleteRolePermissionByValue, resourceServerID, permission, s.deploymentID)
+		ctx, queryDeleteRolePermissionByValue, resourceServerID, permission, s.scope(ctx))
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete role permission: %w", err)
 	}
@@ -467,7 +471,7 @@ func (s *roleStore) AddAssignments(ctx context.Context, id string, assignments [
 		return err
 	}
 
-	return addAssignmentsToRole(ctx, dbClient, id, assignments, s.deploymentID)
+	return addAssignmentsToRole(ctx, dbClient, id, assignments, s.scope(ctx))
 }
 
 // RemoveAssignments removes assignments from a role.
@@ -479,7 +483,7 @@ func (s *roleStore) RemoveAssignments(ctx context.Context, id string, assignment
 
 	for _, assignment := range assignments {
 		_, err := dbClient.ExecuteContext(
-			ctx, queryDeleteRoleAssignmentsByIDs, id, assignment.Type, assignment.ID, s.deploymentID)
+			ctx, queryDeleteRoleAssignmentsByIDs, id, assignment.Type, assignment.ID, s.scope(ctx))
 		if err != nil {
 			return fmt.Errorf("failed to remove assignment from role: %w", err)
 		}
@@ -490,7 +494,7 @@ func (s *roleStore) RemoveAssignments(ctx context.Context, id string, assignment
 // getRolePermissions retrieves all permissions for a role.
 func (s *roleStore) getRolePermissions(
 	ctx context.Context, dbClient provider.DBClientInterface, id string) ([]ResourcePermissions, error) {
-	results, err := dbClient.QueryContext(ctx, queryGetRolePermissions, id, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetRolePermissions, id, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get role permissions: %w", err)
 	}
@@ -611,7 +615,7 @@ func (s *roleStore) CheckRoleNameExists(ctx context.Context, ouID, name string) 
 		return false, err
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryCheckRoleNameExists, ouID, name, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryCheckRoleNameExists, ouID, name, s.scope(ctx))
 	if err != nil {
 		return false, fmt.Errorf("failed to check role name existence: %w", err)
 	}
@@ -629,7 +633,7 @@ func (s *roleStore) CheckRoleNameExistsExcludingID(
 	}
 
 	results, err := dbClient.QueryContext(
-		ctx, queryCheckRoleNameExistsExcludingID, ouID, name, excludeRoleID, s.deploymentID)
+		ctx, queryCheckRoleNameExistsExcludingID, ouID, name, excludeRoleID, s.scope(ctx))
 	if err != nil {
 		return false, fmt.Errorf("failed to check role name existence: %w", err)
 	}
@@ -657,7 +661,7 @@ func (s *roleStore) GetAllPermissionsForAssignees(
 		groupIDs = []string{}
 	}
 
-	query, args := buildAllPermissionsForAssigneesQuery(entityID, groupIDs, s.deploymentID)
+	query, args := buildAllPermissionsForAssigneesQuery(entityID, groupIDs, s.scope(ctx))
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -699,7 +703,7 @@ func (s *roleStore) GetAuthorizedPermissionsByResourceServer(
 
 	// Build dynamic query based on provided parameters
 	query, args := buildAuthorizedPermissionsQuery(
-		entityID, groupIDs, resourceServerID, requestedPermissions, s.deploymentID)
+		entityID, groupIDs, resourceServerID, requestedPermissions, s.scope(ctx))
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -729,7 +733,7 @@ func (s *roleStore) GetUserRoles(
 		groupIDs = []string{}
 	}
 
-	query, args := buildUserRolesQuery(entityID, groupIDs, s.deploymentID)
+	query, args := buildUserRolesQuery(entityID, groupIDs, s.scope(ctx))
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -767,7 +771,7 @@ func (s *roleStore) GetEntityRoleIDs(
 		return nil, err
 	}
 
-	query, args := buildEntityRoleIDsQuery(entityID, groupIDs, s.deploymentID)
+	query, args := buildEntityRoleIDsQuery(entityID, groupIDs, s.scope(ctx))
 
 	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/backend/internal/role/store_test.go
+++ b/backend/internal/role/store_test.go
@@ -14,6 +14,9 @@ import (
 
 	"github.com/thunder-id/thunderid/tests/mocks/database/modelmock"
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 const testDeploymentID = "test-deployment-id"
@@ -50,12 +53,12 @@ func TestRoleStoreTestSuite(t *testing.T) {
 
 // SetupTest sets up the test suite.
 func (suite *RoleStoreTestSuite) SetupTest() {
+	loadRuntimeForScope()
 	suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 	suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 	suite.mockTx = modelmock.NewTxInterfaceMock(suite.T())
 	suite.store = &roleStore{
-		dbProvider:   suite.mockDBProvider,
-		deploymentID: testDeploymentID,
+		dbProvider: suite.mockDBProvider,
 	}
 }
 
@@ -111,8 +114,7 @@ func (suite *RoleStoreTestSuite) TestGetRoleListCount() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -211,8 +213,7 @@ func (suite *RoleStoreTestSuite) TestGetRoleList() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -290,8 +291,7 @@ func (suite *RoleStoreTestSuite) TestGetRoleListCountByOUID() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -390,8 +390,7 @@ func (suite *RoleStoreTestSuite) TestGetRoleListByOUID() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -568,8 +567,7 @@ func (suite *RoleStoreTestSuite) TestCreateRole() {
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.mockTx = modelmock.NewTxInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -777,8 +775,7 @@ func (suite *RoleStoreTestSuite) TestGetRole() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -872,8 +869,7 @@ func (suite *RoleStoreTestSuite) TestIsRoleExist() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -974,8 +970,7 @@ func (suite *RoleStoreTestSuite) TestDeleteRole() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1137,8 +1132,7 @@ func (suite *RoleStoreTestSuite) TestUpdateRole() {
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.mockTx = modelmock.NewTxInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1212,8 +1206,7 @@ func (suite *RoleStoreTestSuite) TestAddAssignments() {
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.mockTx = modelmock.NewTxInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1287,8 +1280,7 @@ func (suite *RoleStoreTestSuite) TestRemoveAssignments() {
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.mockTx = modelmock.NewTxInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1378,8 +1370,7 @@ func (suite *RoleStoreTestSuite) TestCheckRoleNameExists() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -1470,8 +1461,7 @@ func (suite *RoleStoreTestSuite) TestCheckRoleNameExistsExcludingID() {
 			suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 			suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 			suite.store = &roleStore{
-				dbProvider:   suite.mockDBProvider,
-				deploymentID: testDeploymentID,
+				dbProvider: suite.mockDBProvider,
 			}
 
 			tc.setupMocks()
@@ -2205,5 +2195,15 @@ func (suite *RoleStoreTestSuite) TestDeleteRolePermission() {
 
 		suite.Error(err)
 		suite.Equal(int64(0), deleted)
+	})
+}
+
+// loadRuntimeForScope loads a server runtime naming the deployment these tests assert on. The store
+// resolves its deployment from the runtime rather than holding one, and other suites in this package
+// reset the runtime, so it is loaded per test rather than once for the package.
+func loadRuntimeForScope() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: testDeploymentID},
 	})
 }

--- a/backend/internal/serverconfig/store.go
+++ b/backend/internal/serverconfig/store.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 )
 
 // serverConfigStoreInterface is the unified store contract. A read returns the section's layers; each
@@ -22,16 +22,20 @@ type serverConfigStoreInterface interface {
 
 // serverConfigStore is the database-backed (writable) store.
 type serverConfigStore struct {
-	dbProvider   provider.DBProviderInterface
-	deploymentID string
+	dbProvider provider.DBProviderInterface
 }
 
 // newServerConfigStore creates a new instance of serverConfigStore.
 func newServerConfigStore() serverConfigStoreInterface {
 	return &serverConfigStore{
-		dbProvider:   provider.GetDBProvider(),
-		deploymentID: config.GetServerRuntime().Config.Server.Identifier,
+		dbProvider: provider.GetDBProvider(),
 	}
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (s *serverConfigStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // getDBClient is a helper method to get the database client.
@@ -50,7 +54,7 @@ func (s *serverConfigStore) GetServerConfig(ctx context.Context, name ConfigName
 		return storeLayers{}, err
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetServerConfigByName, string(name), s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetServerConfigByName, string(name), s.scope(ctx))
 	if err != nil {
 		return storeLayers{}, fmt.Errorf("failed to get server config: %w", err)
 	}
@@ -73,7 +77,7 @@ func (s *serverConfigStore) UpsertServerConfig(ctx context.Context, cfg ServerCo
 	}
 
 	_, err = dbClient.ExecuteContext(ctx, queryUpsertServerConfig, string(cfg.Name), string(cfg.Value),
-		s.deploymentID)
+		s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to upsert server config: %w", err)
 	}

--- a/backend/internal/serverconfig/store_test.go
+++ b/backend/internal/serverconfig/store_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 const testDeploymentID = "test-deployment-id"
@@ -30,10 +33,11 @@ func TestStoreTestSuite(t *testing.T) {
 }
 
 func (suite *StoreTestSuite) SetupTest() {
+	loadRuntimeForScope()
 	suite.ctx = context.Background()
 	suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 	suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
-	suite.store = &serverConfigStore{dbProvider: suite.mockDBProvider, deploymentID: testDeploymentID}
+	suite.store = &serverConfigStore{dbProvider: suite.mockDBProvider}
 }
 
 func (suite *StoreTestSuite) expectDBClient() {
@@ -134,4 +138,14 @@ func (suite *StoreTestSuite) TestUpsertServerConfig_Error() {
 func (suite *StoreTestSuite) TestUpsertServerConfig_DBClientError() {
 	suite.expectDBClientError()
 	suite.Error(suite.store.UpsertServerConfig(suite.ctx, ServerConfig{Name: ConfigNameCORS, Value: corsValue}))
+}
+
+// loadRuntimeForScope loads a server runtime naming the deployment these tests assert on. The store
+// resolves its deployment from the runtime rather than holding one, and other suites in this package
+// reset the runtime, so it is loaded per test rather than once for the package.
+func loadRuntimeForScope() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: testDeploymentID},
+	})
 }

--- a/backend/internal/system/deployment/deployment.go
+++ b/backend/internal/system/deployment/deployment.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package deployment carries the per-request deployment identifier used to scope persistence.
+//
+// The id partitions every stored resource by the DEPLOYMENT_ID column. It is put on the request
+// context at the edge, so a store reads it from one place rather than reaching for configuration.
+// This server holds one deployment, so that id is the configured identifier.
+package deployment
+
+import (
+	"context"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+)
+
+// ctxKey is the private context key under which the per-request deployment id is stored.
+type ctxKey struct{}
+
+// WithID returns a context carrying the given deployment id. An empty id is ignored so callers can
+// pass an unconditionally-extracted claim without having to branch on its presence.
+func WithID(ctx context.Context, id string) context.Context {
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKey{}, id)
+}
+
+// fromContext returns the deployment id carried by the context, if any.
+func fromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(ctxKey{}).(string)
+	return id, ok && id != ""
+}
+
+// Resolve returns the deployment id a store should scope by for this request.
+//
+// The id is put on the context at the edge, so a request always carries one and that is what a
+// store scopes by. Contexts that never passed through the edge, such as start-up tasks, background
+// jobs and command line tooling, fall back to the configured identifier, which this package reads
+// so that a store does not have to reach for configuration itself.
+//
+// The fallback is empty until the server runtime is loaded, which is the correct answer that early:
+// there is no deployment to name yet.
+func Resolve(ctx context.Context) string {
+	if id, ok := fromContext(ctx); ok {
+		return id
+	}
+	if !config.IsServerRuntimeInitialized() {
+		return ""
+	}
+	return config.GetServerRuntime().Config.Server.Identifier
+}

--- a/backend/internal/system/deployment/deployment_test.go
+++ b/backend/internal/system/deployment/deployment_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
+)
+
+// The edge puts the id on the context, so a request always carries one. The fallback is for the
+// contexts that never reach the edge: start-up tasks, background jobs and command line tooling.
+const (
+	requestDeployment    = "acme"
+	configuredDeployment = "configured-deployment"
+)
+
+// withConfiguredRuntime loads a server runtime naming configuredDeployment and resets it afterwards,
+// so a test that needs the fallback does not leave the singleton set for the tests that need it
+// absent.
+func withConfiguredRuntime(t *testing.T) {
+	t.Helper()
+	config.ResetServerRuntime()
+	cfg := &config.Config{Server: engineconfig.ServerConfig{Identifier: configuredDeployment}}
+	if err := config.InitializeServerRuntime("", cfg); err != nil {
+		t.Fatalf("failed to initialize the server runtime: %v", err)
+	}
+	t.Cleanup(config.ResetServerRuntime)
+}
+
+func TestResolve_PrefersTheDeploymentTheRequestNames(t *testing.T) {
+	withConfiguredRuntime(t)
+
+	ctx := WithID(context.Background(), requestDeployment)
+	if got := Resolve(ctx); got != requestDeployment {
+		t.Fatalf("expected the id the request carries, got %q", got)
+	}
+}
+
+func TestResolve_FallsBackToTheConfiguredIdentifier(t *testing.T) {
+	withConfiguredRuntime(t)
+
+	if got := Resolve(context.Background()); got != configuredDeployment {
+		t.Fatalf("expected the configured identifier for a context that carries no id, got %q", got)
+	}
+}
+
+// Before the runtime is loaded there is no deployment to name, so resolving reports none rather
+// than inventing one.
+func TestResolve_IsEmptyBeforeTheRuntimeIsLoaded(t *testing.T) {
+	config.ResetServerRuntime()
+	t.Cleanup(config.ResetServerRuntime)
+
+	if got := Resolve(context.Background()); got != "" {
+		t.Fatalf("expected no deployment before the runtime is loaded, got %q", got)
+	}
+}
+
+// An empty id is ignored so a caller can pass an unconditionally-extracted claim without branching
+// on whether it was present.
+func TestWithID_EmptyIsIgnored(t *testing.T) {
+	withConfiguredRuntime(t)
+
+	ctx := WithID(context.Background(), "")
+	if got := Resolve(ctx); got != configuredDeployment {
+		t.Fatalf("expected the fallback for an empty id, got %q", got)
+	}
+}

--- a/backend/internal/system/middleware/deploymentid.go
+++ b/backend/internal/system/middleware/deploymentid.go
@@ -1,0 +1,43 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
+)
+
+// DeploymentIDMiddleware puts the deployment id this request acts for on its context, so that the
+// stores below read it from one place instead of each reaching for the configuration themselves.
+//
+// It runs for every request, so a store can rely on the context carrying an id and treat a context
+// without one as what it is: a background operation rather than a request.
+func DeploymentIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if id := deploymentIDForRequest(r); id != "" {
+			r = r.WithContext(deployment.WithID(r.Context(), id))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// deploymentIDForRequest returns the deployment id a request acts for.
+//
+// This server holds one deployment, so every request acts for the configured identifier. It is a
+// function of the request rather than a constant because that is the single point a build serving
+// more than one deployment changes: it derives the id per request instead, and everything
+// downstream is unaffected, because everything downstream already reads the id from the context.
+//
+// Whatever a multi-deployment build derives it from has to be something the caller cannot choose.
+// A request header is not: it is attacker controlled, so honoring one would let any caller name
+// another deployment and read its rows. The id has to come from something already authenticated,
+// such as a verified claim in the caller's token.
+var deploymentIDForRequest = func(_ *http.Request) string {
+	if !config.IsServerRuntimeInitialized() {
+		return ""
+	}
+	return config.GetServerRuntime().Config.Server.Identifier
+}

--- a/backend/internal/system/middleware/deploymentid_test.go
+++ b/backend/internal/system/middleware/deploymentid_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/thunder-id/thunderid/internal/system/deployment"
+)
+
+// The point of the middleware is that a handler, and every store below it, can read the id from the
+// context instead of reaching for the configuration.
+func TestDeploymentIDMiddlewarePutsTheIDOnTheContext(t *testing.T) {
+	original := deploymentIDForRequest
+	deploymentIDForRequest = func(*http.Request) string { return "acme" }
+	t.Cleanup(func() { deploymentIDForRequest = original })
+
+	var seen string
+	var carried bool
+	handler := DeploymentIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = deployment.Resolve(r.Context())
+		carried = seen != ""
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/anything", nil))
+
+	if !carried || seen != "acme" {
+		t.Fatalf("expected the request to carry acme, got (%q, %v)", seen, carried)
+	}
+}
+
+// With no identifier configured, the context is left alone rather than carrying an empty id, so a
+// store falls back to its own configured value exactly as it did before.
+func TestDeploymentIDMiddlewareLeavesTheContextAloneWithoutAnIdentifier(t *testing.T) {
+	original := deploymentIDForRequest
+	deploymentIDForRequest = func(*http.Request) string { return "" }
+	t.Cleanup(func() { deploymentIDForRequest = original })
+
+	var carried bool
+	handler := DeploymentIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		carried = deployment.Resolve(r.Context()) != ""
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/anything", nil))
+
+	if carried {
+		t.Fatal("expected no deployment id on the context when none is configured")
+	}
+}

--- a/backend/internal/vc/credential/store.go
+++ b/backend/internal/vc/credential/store.go
@@ -8,9 +8,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 )
 
 // credentialStoreInterface persists managed credential configurations in configdb.
@@ -26,16 +26,20 @@ type credentialStoreInterface interface {
 }
 
 type credentialStore struct {
-	dbProvider   provider.DBProviderInterface
-	deploymentID string
+	dbProvider provider.DBProviderInterface
 }
 
 // newCredentialStore returns a configdb-backed credential-configuration store.
 func newCredentialStore() credentialStoreInterface {
 	return &credentialStore{
-		dbProvider:   provider.GetDBProvider(),
-		deploymentID: config.GetServerRuntime().Config.Server.Identifier,
+		dbProvider: provider.GetDBProvider(),
 	}
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (s *credentialStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // CreateCredentialConfiguration persists a new credential configuration in the database.
@@ -50,7 +54,7 @@ func (s *credentialStore) CreateCredentialConfiguration(ctx context.Context, dto
 	}
 	_, err = dbClient.ExecuteContext(ctx, queryCreateConfiguration,
 		dto.ID, dto.Handle, dto.OUID, dto.Name, dto.Description, dto.Format, dto.VCT, claimsJSON, displayJSON,
-		nullableInt(dto.ValiditySeconds), s.deploymentID)
+		nullableInt(dto.ValiditySeconds), s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to create credential configuration: %w", err)
 	}
@@ -79,7 +83,7 @@ func (s *credentialStore) getOne(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	results, err := dbClient.QueryContext(ctx, query, identifier, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, query, identifier, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query credential configuration: %w", err)
 	}
@@ -95,7 +99,7 @@ func (s *credentialStore) ListCredentialConfigurations(ctx context.Context) ([]C
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	results, err := dbClient.QueryContext(ctx, queryListConfigurations, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryListConfigurations, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list credential configurations: %w", err)
 	}
@@ -118,7 +122,7 @@ func (s *credentialStore) ListCredentialConfigurationSummaries(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	results, err := dbClient.QueryContext(ctx, queryListConfigurationSummaries, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryListConfigurationSummaries, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list credential configuration summaries: %w", err)
 	}
@@ -149,7 +153,7 @@ func (s *credentialStore) UpdateCredentialConfiguration(ctx context.Context, dto
 	}
 	_, err = dbClient.ExecuteContext(ctx, queryUpdateConfiguration,
 		dto.ID, dto.Handle, dto.OUID, dto.Name, dto.Description, dto.Format, dto.VCT, claimsJSON, displayJSON,
-		nullableInt(dto.ValiditySeconds), s.deploymentID)
+		nullableInt(dto.ValiditySeconds), s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to update credential configuration: %w", err)
 	}
@@ -162,7 +166,7 @@ func (s *credentialStore) DeleteCredentialConfiguration(ctx context.Context, id 
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	if _, err := dbClient.ExecuteContext(ctx, queryDeleteConfiguration, id, s.deploymentID); err != nil {
+	if _, err := dbClient.ExecuteContext(ctx, queryDeleteConfiguration, id, s.scope(ctx)); err != nil {
 		return fmt.Errorf("failed to delete credential configuration: %w", err)
 	}
 	return nil

--- a/backend/internal/vc/credential/store_test.go
+++ b/backend/internal/vc/credential/store_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 const testDeploymentID = "test-deployment-id"
@@ -29,11 +32,11 @@ func TestCredentialStoreTestSuite(t *testing.T) {
 }
 
 func (suite *CredentialStoreTestSuite) SetupTest() {
+	loadRuntimeForScope()
 	suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 	suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 	suite.store = &credentialStore{
-		dbProvider:   suite.mockDBProvider,
-		deploymentID: testDeploymentID,
+		dbProvider: suite.mockDBProvider,
 	}
 }
 
@@ -41,8 +44,7 @@ func (suite *CredentialStoreTestSuite) refreshMocks() {
 	suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 	suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 	suite.store = &credentialStore{
-		dbProvider:   suite.mockDBProvider,
-		deploymentID: testDeploymentID,
+		dbProvider: suite.mockDBProvider,
 	}
 }
 
@@ -624,4 +626,14 @@ func (suite *CredentialStoreTestSuite) TestIsDeclarative() {
 	isDeclarative, err := suite.store.IsCredentialConfigurationDeclarative(context.Background(), "any-id")
 	suite.NoError(err)
 	suite.False(isDeclarative)
+}
+
+// loadRuntimeForScope loads a server runtime naming the deployment these tests assert on. The store
+// resolves its deployment from the runtime rather than holding one, and other suites in this package
+// reset the runtime, so it is loaded per test rather than once for the package.
+func loadRuntimeForScope() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: testDeploymentID},
+	})
 }

--- a/backend/internal/vc/presentation/store.go
+++ b/backend/internal/vc/presentation/store.go
@@ -9,9 +9,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
 )
 
 // ErrNotFound is the store-level not-found sentinel.
@@ -38,16 +38,20 @@ type definitionStoreInterface interface {
 }
 
 type definitionStore struct {
-	dbProvider   provider.DBProviderInterface
-	deploymentID string
+	dbProvider provider.DBProviderInterface
 }
 
 // newDefinitionStore returns a configdb-backed presentation-definition store.
 func newDefinitionStore() definitionStoreInterface {
 	return &definitionStore{
-		dbProvider:   provider.GetDBProvider(),
-		deploymentID: config.GetServerRuntime().Config.Server.Identifier,
+		dbProvider: provider.GetDBProvider(),
 	}
+}
+
+// scope returns the deployment id this request acts for, falling back to the configured
+// identifier for a context that never passed through the edge.
+func (s *definitionStore) scope(ctx context.Context) string {
+	return deployment.Resolve(ctx)
 }
 
 // CreatePresentationDefinition inserts a new presentation definition into the config database.
@@ -66,7 +70,7 @@ func (s *definitionStore) CreatePresentationDefinition(ctx context.Context, dto 
 	}
 	_, err = dbClient.ExecuteContext(ctx, queryCreateDefinition,
 		dto.ID, dto.Handle, dto.OUID, dto.Name, dto.Description, dto.VCT, dto.Format, claimsJSON,
-		nullableBool(dto.EnforceTrustedIssuer), authoritiesJSON, s.deploymentID)
+		nullableBool(dto.EnforceTrustedIssuer), authoritiesJSON, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to create presentation definition: %w", err)
 	}
@@ -95,7 +99,7 @@ func (s *definitionStore) getOne(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	results, err := dbClient.QueryContext(ctx, query, identifier, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, query, identifier, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query presentation definition: %w", err)
 	}
@@ -111,7 +115,7 @@ func (s *definitionStore) ListPresentationDefinitions(ctx context.Context) ([]Pr
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	results, err := dbClient.QueryContext(ctx, queryListDefinitions, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryListDefinitions, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list presentation definitions: %w", err)
 	}
@@ -134,7 +138,7 @@ func (s *definitionStore) ListPresentationDefinitionSummaries(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	results, err := dbClient.QueryContext(ctx, queryListDefinitionSummaries, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryListDefinitionSummaries, s.scope(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list presentation definition summaries: %w", err)
 	}
@@ -168,7 +172,7 @@ func (s *definitionStore) UpdatePresentationDefinition(ctx context.Context, dto 
 	}
 	_, err = dbClient.ExecuteContext(ctx, queryUpdateDefinition,
 		dto.ID, dto.Handle, dto.OUID, dto.Name, dto.Description, dto.VCT, dto.Format, claimsJSON,
-		nullableBool(dto.EnforceTrustedIssuer), authoritiesJSON, s.deploymentID)
+		nullableBool(dto.EnforceTrustedIssuer), authoritiesJSON, s.scope(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to update presentation definition: %w", err)
 	}
@@ -181,7 +185,7 @@ func (s *definitionStore) DeletePresentationDefinition(ctx context.Context, id s
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	if _, err := dbClient.ExecuteContext(ctx, queryDeleteDefinition, id, s.deploymentID); err != nil {
+	if _, err := dbClient.ExecuteContext(ctx, queryDeleteDefinition, id, s.scope(ctx)); err != nil {
 		return fmt.Errorf("failed to delete presentation definition: %w", err)
 	}
 	return nil

--- a/backend/internal/vc/presentation/store_test.go
+++ b/backend/internal/vc/presentation/store_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
 const testDeploymentID = "test-deployment-id"
@@ -29,11 +32,11 @@ func TestDefinitionStoreTestSuite(t *testing.T) {
 }
 
 func (suite *DefinitionStoreTestSuite) SetupTest() {
+	loadRuntimeForScope()
 	suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 	suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 	suite.store = &definitionStore{
-		dbProvider:   suite.mockDBProvider,
-		deploymentID: testDeploymentID,
+		dbProvider: suite.mockDBProvider,
 	}
 }
 
@@ -41,8 +44,7 @@ func (suite *DefinitionStoreTestSuite) refreshMocks() {
 	suite.mockDBProvider = providermock.NewDBProviderInterfaceMock(suite.T())
 	suite.mockDBClient = providermock.NewDBClientInterfaceMock(suite.T())
 	suite.store = &definitionStore{
-		dbProvider:   suite.mockDBProvider,
-		deploymentID: testDeploymentID,
+		dbProvider: suite.mockDBProvider,
 	}
 }
 
@@ -631,4 +633,14 @@ func (suite *DefinitionStoreTestSuite) TestBuildDefinitionDTOFromRowMalformedTru
 	got, err := buildDefinitionDTOFromRow(row)
 	suite.Error(err)
 	suite.Nil(got)
+}
+
+// loadRuntimeForScope loads a server runtime naming the deployment these tests assert on. The store
+// resolves its deployment from the runtime rather than holding one, and other suites in this package
+// reset the runtime, so it is loaded per test rather than once for the package.
+func loadRuntimeForScope() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		Server: engineconfig.ServerConfig{Identifier: testDeploymentID},
+	})
 }

--- a/docs/content/deployment/configuration.mdx
+++ b/docs/content/deployment/configuration.mdx
@@ -34,7 +34,9 @@ Controls the <ProductName /> server's network settings and identity.
 | `server.port` | `8090` | Port the server listens on |
 | `server.http_only` | `false` | If `true`, disables HTTPS and uses HTTP only (not recommended for production) |
 | `server.public_url` | _(derived from server hostname, port and protocol)_ | The public URL clients use to reach the server, if it differs from the bind address. Derived when unset. |
-| `server.identifier` | `default-deployment` | Unique identifier for this deployment instance |
+| `server.identifier` | `default-deployment` | Unique identifier for this deployment instance. Every stored resource is scoped by it, so changing it on a server that already holds data hides that data rather than renaming it. |
+
+Resources are stored against this identifier, so it is fixed for the life of a deployment's data.
 
 When `server.public_url` is set, the `gate_client` settings below default to the corresponding hostname, port, and protocol from that URL. Most deployments only need to configure the server section.
 


### PR DESCRIPTION
## Purpose
Every store that scopes by the deployment id read it from configuration once, at construction. That works for a server holding one deployment, but it means a request cannot be served for any other, and the id is decided in as many places as there are stores.

## Goals
Decide a request's deployment id once, at the edge, and have the stores read it from there.

## Approach
- `DeploymentIDMiddleware` runs for every request and puts the deployment id on its context. It sits just inside the correlation id middleware and outside the security layer, so anything reached during the request already has it.
- The configuration stores resolve the id per request through a small `scope(ctx)` helper, rather than holding it as a field captured at construction.
- `deployment.Resolve` prefers the context and falls back to the store's configured identifier. The fallback covers one case: contexts that never passed through the edge, such as start-up tasks, background jobs and command line tooling.

Behaviour is unchanged. This server holds one deployment, so the context always carries the configured identifier, which is the value the stores read before.

### Stores converted
cert, entity, entitytype, group, idp, inboundclient, notification, ou, resource, role, serverconfig, vc/credential and vc/presentation. 188 call sites.

### Stores not converted
The layout, theme and translation stores keep the configured identifier for now. Their methods take no `context.Context` at all, so converting them means changing their interfaces and every caller. That is a separate change and follows in its own PR.

### Deriving the id from a token is deliberately not here
Nothing in this repository serves more than one deployment, so a token claim reader would be a code path this product never takes. The seam is one function, `deploymentIDForRequest`. A build that serves many deployments derives the id per request there and changes nothing else, because everything downstream already reads the context.

## User stories
As a maintainer I can see in one place where a request's deployment id comes from, rather than in every store that scopes by it.

## Release note
The deployment id is placed on the request context at the edge, and the configuration stores read it from there.

## Documentation
N/A, no user-facing change. The reasoning sits in the comments on the middleware and on `Resolve`.

## Training
N/A

## Tests
New middleware tests cover the id reaching a handler's context, and the context being left alone when no identifier is configured. Package tests cover the context winning over the fallback, and the fallback applying to a context that carries none.

`make lint_backend` reports 0 issues, the full unit suite passes, and the full integration suite passes against a fresh build: 50 suites, 0 failures.

## Related PRs
None. This was previously part of #5189, which stacked it on two unrelated changes; that PR is closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Requests now carry deployment-specific context for consistent data scoping.
  * Persisted resources use the deployment associated with each request, with a configured fallback when unavailable.
  * Deployment identifiers can be used to derive organization identifiers.
  * Requests without an assigned deployment continue using the configured deployment scope.

* **Documentation**
  * Clarified that deployment identifiers scope stored resources and changing one does not rename existing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->