### PR TITLE
Prepare branch for the pinned-commit release builder

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -1,3 +1,5 @@
+# Callers check out the test sources. The action must never check out a ref of its own.
+# A checkout here would replace the workspace mid-job and test a different commit than the build.
 name: Run Integration Tests
 description: Runs integration tests against a specific database type (sqlite, postgres, or redis)
 inputs:
@@ -12,13 +14,23 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: 📥 Checkout Code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
     - name: ⚙️ Set up Go Environment
       uses: ./.github/actions/setup-go
 
+    # Some callers stage the distribution themselves. Skip the download instead of refetching.
+    - name: 🔍 Check for a Staged Distribution
+      id: staged_distribution
+      shell: bash
+      run: |
+        if ls target/dist/*.zip >/dev/null 2>&1; then
+          echo "✅ Using the distribution already staged in target/dist"
+          echo "present=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "present=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: 📥 Download Built Distribution
+      if: steps.staged_distribution.outputs.present != 'true'
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: product-distribution

--- a/.github/docker/Dockerfile.release
+++ b/.github/docker/Dockerfile.release
@@ -1,0 +1,63 @@
+# Copyright 2026 The ThunderID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Built by .github/workflows/release-builder.yml from the published distribution
+# instead of from source. The build context is a directory of Linux archives.
+# Keep the runtime stage in sync with ./Dockerfile.
+
+# Unpack the target architecture's archive, on the build platform to avoid emulation.
+FROM --platform=$BUILDPLATFORM alpine:3.19 AS dist
+
+ARG TARGETARCH
+
+RUN apk add --no-cache unzip
+
+WORKDIR /dist
+
+COPY thunderid-*-linux-*.zip ./
+
+RUN set -eux; \
+    case "$TARGETARCH" in \
+      amd64) archive_arch=x64 ;; \
+      arm64) archive_arch=arm64 ;; \
+      *) echo "unsupported target architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    archive="$(ls thunderid-*-linux-"$archive_arch".zip)"; \
+    unzip -q "$archive" -d /extracted; \
+    mkdir -p /opt/thunderid; \
+    cp -r /extracted/thunderid-*/. /opt/thunderid/
+
+# ./Dockerfile edits these before compiling; here the archive is already packaged.
+RUN sed -i 's/hostname: "localhost"/hostname: "0.0.0.0"/' /opt/thunderid/deployment.yaml && \
+    sed -i '/hostname: "0.0.0.0"/a\  public_url: "https://localhost:8090"' /opt/thunderid/deployment.yaml
+
+# Security material (TLS/JWT/AES keys) is not baked into the image; the setup step generates it per deployment.
+
+# Runtime stage
+FROM alpine:3.19
+
+RUN apk add --no-cache \
+    ca-certificates \
+    lsof \
+    sqlite \
+    bash \
+    curl \
+    openssl \
+    unzip
+
+RUN addgroup -S thunderid -g 10001 && adduser -S thunderid -u 10001 -G thunderid
+
+WORKDIR /opt/thunderid
+
+COPY --from=dist --chown=thunderid:thunderid /opt/thunderid /opt/thunderid
+
+RUN chmod +x thunderid start.sh setup.sh scripts/init_script.sh && \
+    (find bootstrap -name "*.sh" -type f -exec chmod +x {} \; 2>/dev/null || true)
+
+EXPOSE 8090
+
+USER thunderid
+
+ENV BACKEND_PORT=8090
+
+CMD ["./start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Product Docker Image
+# Built from source for `make docker-build*`. The release pipeline uses
+# .github/docker/Dockerfile.release. Keep the runtime stages in sync.
 # Build stage - compile the Go binary and build frontend for the target architecture
 FROM golang:1.26-alpine3.23 AS builder
 


### PR DESCRIPTION
### Purpose

The release builder is being reworked so a release can be built and verified from any branch (#4981). It pins the source branch to a single immutable commit and checks that same commit out in every job, which means the files it reads at release time come from the branch being released rather than from the branch the workflow was dispatched from.

The files in this PR are read that way, so they have to be correct here before a release can be cut from this branch. This PR brings them in ahead of the workflow change on `main`.

The integration test action also fixes a live bug on this branch. It checks out a ref of its own, which replaces `$GITHUB_WORKSPACE` in the middle of the job and discards whatever the caller had checked out. On this branch the release builder checks out `RELEASE_BRANCH` and the action then reverts the workspace to the dispatched ref, so the integration suite can run against different sources than the ones the distribution under test was built from.

### Approach

Removed the `actions/checkout` step from `.github/actions/run-integration-tests`. Composite actions resolve out of `$GITHUB_WORKSPACE`, so a checkout inside one can silently swap the tree the rest of the job runs against. All three callers on this branch (`pr-builder.yml`, `postgres-tests.yml` and `release-builder.yml`) already check out the sources themselves before invoking the action, so nothing changes on the calling side.

Added a guard so the action skips its artifact download when the caller has already staged a distribution in `target/dist`. 

Added `.github/docker/Dockerfile.release`, which assembles the container image by unzipping the already published Linux archives instead of recompiling the product inside `docker buildx`. Extraction happens on `$BUILDPLATFORM` to avoid QEMU emulation, and the two `deployment.yaml` edits are applied to the packaged file rather than to the source tree.

The root `Dockerfile` is functionally unchanged and still builds from source for `make docker-build*`. It gains a comment naming the release Dockerfile, because the two share a runtime stage that has to be kept in sync.

### Related Issues
-  #4981 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
