### PR TITLE
Scope the provisioning existing-user check to unique attributes

### DIFF
--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
@@ -125,7 +127,7 @@ func (p *provisioningExecutor) Execute(ctx *providers.NodeContext) (*providers.E
 		return execResp, nil
 	}
 
-	identifyingAttrs, credentialAttrs, err := p.getAttributesForProvisioning(ctx)
+	identifyingAttrs, credentialAttrs, uniqueAttrs, err := p.getAttributesForProvisioning(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -136,23 +138,9 @@ func (p *provisioningExecutor) Execute(ctx *providers.NodeContext) (*providers.E
 		return execResp, nil
 	}
 
-	userID, err := p.IdentifyUser(ctx.Context, identifyingAttrs, execResp)
+	userID, err := p.identifyExistingUser(ctx, uniqueAttrs, execResp, logger)
 	if err != nil {
-		logger.Error(ctx.Context, "Failed to identify user", log.Error(err))
-		execResp.Status = providers.ExecFailure
-		execResp.Error = &ErrFailedToIdentifyUser
-		return execResp, nil
-	}
-	if execResp.Status == providers.ExecFailure &&
-		execResp.Error != nil && execResp.Error.Code == ErrAmbiguousUserIdentity.Code &&
-		isCrossOUProvisioningAllowed(ctx) {
-		resolved, err := p.resolveAmbiguousUserForProvisioning(ctx, identifyingAttrs)
-		if err != nil {
-			return nil, err
-		}
-		userID = resolved
-		execResp.Status = ""
-		execResp.Error = nil
+		return nil, err
 	}
 	if execResp.Status == providers.ExecFailure &&
 		(execResp.Error == nil || execResp.Error.Code != ErrUserNotFound.Code) {
@@ -218,6 +206,74 @@ func (p *provisioningExecutor) Execute(ctx *providers.NodeContext) (*providers.E
 	}
 
 	return execResp, nil
+}
+
+// identifyExistingUser returns the user that would conflict with the one about to be provisioned,
+// or nil when there is none. A user this execution already resolved wins over the attribute lookup,
+// which resolves on a broader set and can pick a different user or none.
+func (p *provisioningExecutor) identifyExistingUser(ctx *providers.NodeContext,
+	uniqueAttrs map[string]interface{}, execResp *providers.ExecutorResponse,
+	logger *log.Logger) (*string, error) {
+	if resolvedID := p.GetUserIDFromContext(ctx, execResp, p.authnProvider); resolvedID != "" {
+		return &resolvedID, nil
+	}
+
+	if len(uniqueAttrs) == 0 {
+		logger.Debug(ctx.Context, "No unique attributes to identify an existing user with")
+		return nil, nil
+	}
+
+	// One lookup per attribute: a combined filter is conjunctive, while the store rejects the write
+	// when any single value is taken. Name order keeps the reported conflict stable.
+	for _, attr := range slices.Sorted(maps.Keys(uniqueAttrs)) {
+		filter := map[string]interface{}{attr: uniqueAttrs[attr]}
+		execResp.Status = ""
+		execResp.Error = nil
+
+		userID, err := p.IdentifyUser(ctx.Context, filter, execResp)
+		if err != nil {
+			logger.Error(ctx.Context, "Failed to identify user", log.Error(err))
+			execResp.Status = providers.ExecFailure
+			execResp.Error = &ErrFailedToIdentifyUser
+			return nil, nil
+		}
+
+		if execResp.Status == providers.ExecFailure {
+			code := ""
+			if execResp.Error != nil {
+				code = execResp.Error.Code
+			}
+			switch code {
+			case ErrUserNotFound.Code:
+				// Free; a later unique attribute can still conflict.
+				continue
+			case ErrAmbiguousUserIdentity.Code:
+				if !isCrossOUProvisioningAllowed(ctx) {
+					return nil, nil
+				}
+				resolved, err := p.resolveAmbiguousUserForProvisioning(ctx, filter)
+				if err != nil {
+					return nil, err
+				}
+				execResp.Status = ""
+				execResp.Error = nil
+				if resolved != nil {
+					return resolved, nil
+				}
+				continue
+			default:
+				return nil, nil
+			}
+		}
+
+		if userID != nil && *userID != "" {
+			logger.Debug(ctx.Context, "An existing user already holds a unique attribute value",
+				log.String("attribute", attr))
+			return userID, nil
+		}
+	}
+
+	return nil, nil
 }
 
 // authenticateProvisionedUser authenticates the newly provisioned user and updates the executor response.
@@ -579,24 +635,26 @@ func (p *provisioningExecutor) isAttrSatisfied(ctx *providers.NodeContext, attr 
 }
 
 // getAttributesForProvisioning collects user attributes from context in a single schema pass,
-// returning identifying (non-credential) and credential attributes as separate maps.
-// Schema is the whitelist for both maps.
+// returning identifying (non-credential), credential, and unique attributes as separate maps.
+// Schema is the whitelist for all three maps. uniqueAttrs is the subset of identifyingAttrs the
+// schema declares unique, and is the only set that can identify a conflicting user.
 // Credential values are resolved from non-empty UserInputs then non-empty RuntimeData only.
 // Non-credential values additionally fall back to AuthenticatedUser.Attributes, and are converted
 // from the engine's string representation to the type declared by the schema attribute.
 func (p *provisioningExecutor) getAttributesForProvisioning(
 	ctx *providers.NodeContext,
-) (identifyingAttrs map[string]interface{}, credentialAttrs map[string]interface{}, err error) {
+) (identifyingAttrs, credentialAttrs, uniqueAttrs map[string]interface{}, err error) {
 	schemaAttrs, fetchErr := p.fetchSchemaAttributes(ctx, true, true)
 	if fetchErr != nil {
-		return nil, nil, fetchErr
+		return nil, nil, nil, fetchErr
 	}
 
 	identifyingAttrs = make(map[string]interface{})
 	credentialAttrs = make(map[string]interface{})
+	uniqueAttrs = make(map[string]interface{})
 
 	if len(schemaAttrs) == 0 {
-		return identifyingAttrs, credentialAttrs, nil
+		return identifyingAttrs, credentialAttrs, uniqueAttrs, nil
 	}
 
 	for _, a := range schemaAttrs {
@@ -612,10 +670,15 @@ func (p *provisioningExecutor) getAttributesForProvisioning(
 			} else if runtimeValue, exists := ctx.RuntimeData[a.Attribute]; exists && runtimeValue != "" {
 				identifyingAttrs[a.Attribute] = convertToSchemaType(runtimeValue, a.Type)
 			}
+			if a.Unique {
+				if value, exists := identifyingAttrs[a.Attribute]; exists {
+					uniqueAttrs[a.Attribute] = value
+				}
+			}
 		}
 	}
 
-	return identifyingAttrs, credentialAttrs, nil
+	return identifyingAttrs, credentialAttrs, uniqueAttrs, nil
 }
 
 // createUserInStore provisions a user through the user management provider. The organization unit

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -87,14 +87,27 @@ func (suite *ProvisioningExecutorTestSuite) SetupTest() {
 // expectSchemaForProvisioning sets up the schema service mocks for Execute tests.
 // The (true,true) mock covers both HasRequiredInputs and getAttributesForProvisioning.
 // This version does NOT include credentials - use expectSchemaWithCredentials if needed.
+// Every attribute is marked unique so the existing-user lookup filter matches the full attribute
+// set, keeping these tests focused on Execute's branching. Scoping of that filter to unique
+// attributes is covered separately by TestExecute_NoUniqueAttributes_SkipsIdentify and
+// TestExecute_OnlyUniqueAttributesIdentify.
 func (suite *ProvisioningExecutorTestSuite) expectSchemaForProvisioning() {
 	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
 		model.AttributeFilter{AllowCredential: true, AllowNonCredential: true}).
 		Return([]model.AttributeInfo{
-			{Attribute: "username", Required: false},
-			{Attribute: attributeEmail, Required: false},
-			{Attribute: "sub", Required: false},
+			{Attribute: "username", Required: false, Unique: true},
+			{Attribute: attributeEmail, Required: false, Unique: true},
+			{Attribute: "sub", Required: false, Unique: true},
 		}, nil).Maybe()
+}
+
+// expectNoExistingUserFor mocks the existing-user lookup as finding nothing, one expectation per
+// attribute since each is looked up on its own.
+func (suite *ProvisioningExecutorTestSuite) expectNoExistingUserFor(attrs map[string]interface{}) {
+	for attr, value := range attrs {
+		suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{attr: value}).
+			Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	}
 }
 
 func (suite *ProvisioningExecutorTestSuite) createMockIdentifyingExecutor() providers.Executor {
@@ -126,6 +139,24 @@ func (suite *ProvisioningExecutorTestSuite) createMockProvisioningExecutor() pro
 			}
 			return len(execResp.Inputs) == 0
 		}).Maybe()
+	// Stands in for the embedded base (internal/flow/core/executor.go), which the mocked base
+	// intercepts: a pre-resolved user ID in runtime data wins, then the resolved entity reference.
+	mockExec.On("GetUserIDFromContext", mock.Anything, mock.Anything, mock.Anything).Return(
+		func(ctx *providers.NodeContext, execResp *providers.ExecutorResponse,
+			authnProvider providers.AuthnProviderManager) string {
+			if val, ok := ctx.RuntimeData[userAttributeUserID]; ok && val != "" {
+				return val
+			}
+			if authnProvider == nil || !ctx.AuthUser.IsAuthenticated() {
+				return ""
+			}
+			authUser, entityRef, err := authnProvider.GetEntityReference(ctx.Context, ctx.AuthUser)
+			execResp.AuthUser = authUser
+			if err != nil || entityRef == nil {
+				return ""
+			}
+			return entityRef.EntityID
+		}).Maybe()
 	mockExec.On("GetInputs", mock.Anything).Return([]providers.Input{}).Maybe()
 	mockExec.On(methodGetRequiredInputs, mock.Anything).Return([]providers.Input{}).Maybe()
 	return mockExec
@@ -142,6 +173,88 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_NonRegistrationFlow() {
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+}
+
+// TestExecute_NoUniqueAttributes_SkipsIdentify verifies that a user type declaring no unique
+// attributes provisions without an existing-user lookup. Nothing can conflict, so two users with
+// identical attributes are both legal and the store is the only uniqueness authority.
+func (suite *ProvisioningExecutorTestSuite) TestExecute_NoUniqueAttributes_SkipsIdentify() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		model.AttributeFilter{AllowCredential: true, AllowNonCredential: true}).
+		Return([]model.AttributeInfo{
+			{Attribute: "firstName", Required: true},
+			{Attribute: "lastName", Required: true},
+		}, nil).Maybe()
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			"firstName": "John",
+			"lastName":  "Smith",
+		},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeInputs: []providers.Input{
+			{Identifier: "firstName", Type: "string", Required: true},
+			{Identifier: "lastName", Type: "string", Required: true},
+		},
+	}
+
+	suite.mockUserMgtProvider.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *providers.User) bool {
+		return u.OUID == testOUID && u.Type == testUserType
+	})).Return(&providers.User{
+		ID: testNewUserID, OUID: testOUID, Type: testUserType,
+	}, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	suite.mockEntityProvider.AssertNotCalled(suite.T(), "IdentifyEntity", mock.Anything)
+}
+
+// TestExecute_OnlyUniqueAttributesIdentify verifies the existing-user lookup filters on the unique
+// attribute alone, not on every attribute present. A changed non-unique attribute must not make the
+// lookup miss an existing user.
+func (suite *ProvisioningExecutorTestSuite) TestExecute_OnlyUniqueAttributesIdentify() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		model.AttributeFilter{AllowCredential: true, AllowNonCredential: true}).
+		Return([]model.AttributeInfo{
+			{Attribute: "username", Required: true},
+			{Attribute: attributeEmail, Required: true, Unique: true},
+		}, nil).Maybe()
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			"username":     "renamed",
+			attributeEmail: "existing@example.com",
+		},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeInputs: []providers.Input{
+			{Identifier: "username", Type: "string", Required: true},
+			{Identifier: attributeEmail, Type: "string", Required: true},
+		},
+	}
+
+	existingUserID := testExistingUser123ID
+	suite.mockEntityProvider.On("IdentifyEntity",
+		map[string]interface{}{attributeEmail: "existing@example.com"}).
+		Return(&existingUserID, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), ErrUserAlreadyExists.Code, resp.Error.Code)
+	suite.mockUserMgtProvider.AssertNotCalled(suite.T(), "CreateUser")
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_Success() {
@@ -170,10 +283,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success() {
 		},
 	}
 
-	suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{
-		"username":     "newuser",
-		attributeEmail: "new@example.com",
-	}).Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.expectNoExistingUserFor(attrs)
 
 	createdUser := &providers.User{
 		ID:         testNewUserID,
@@ -202,6 +312,109 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success() {
 	suite.mockGroupService.AssertExpectations(suite.T())
 	suite.mockRoleService.AssertExpectations(suite.T())
 	suite.mockRoleAssignmentService.AssertExpectations(suite.T())
+}
+
+// TestExecute_ResolvedEntityReference_SkipsIdentify verifies a local user resolved by account
+// linking is used as-is, even when a second connection reports a different username.
+func (suite *ProvisioningExecutorTestSuite) TestExecute_ResolvedEntityReference_SkipsIdentify() {
+	suite.expectSchemaForProvisioning()
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		AuthUser:    newAuthenticatedAuthUser(),
+		RuntimeData: map[string]string{
+			common.RuntimeKeyUserEligibleForProvisioning: dataValueTrue,
+			userTypeKey:    testUserType,
+			"username":     "github-login",
+			attributeEmail: "existing@example.com",
+		},
+		NodeInputs: []providers.Input{},
+	}
+
+	suite.mockAuthnProvider.On("GetEntityReference", mock.Anything, mock.Anything).
+		Return(newAuthenticatedAuthUser(), &providers.EntityReference{EntityID: testExistingUser123ID},
+			(*tidcommon.ServiceError)(nil))
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	assert.Nil(suite.T(), resp.Error)
+	suite.mockEntityProvider.AssertNotCalled(suite.T(), "IdentifyEntity", mock.Anything)
+	suite.mockUserMgtProvider.AssertNotCalled(suite.T(), "CreateUser")
+}
+
+// TestExecute_ConflictOnSecondUniqueAttribute verifies each unique attribute is looked up on its
+// own, so a free value does not mask a taken one.
+func (suite *ProvisioningExecutorTestSuite) TestExecute_ConflictOnSecondUniqueAttribute() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		model.AttributeFilter{AllowCredential: true, AllowNonCredential: true}).
+		Return([]model.AttributeInfo{
+			{Attribute: "username", Required: true, Unique: true},
+			{Attribute: attributeEmail, Required: true, Unique: true},
+		}, nil).Maybe()
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			"username":     "existinguser",
+			attributeEmail: "new@example.com",
+		},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeInputs: []providers.Input{
+			{Identifier: "username", Type: "string", Required: true},
+			{Identifier: attributeEmail, Type: "string", Required: true},
+		},
+	}
+
+	suite.mockEntityProvider.On("IdentifyEntity",
+		map[string]interface{}{attributeEmail: "new@example.com"}).
+		Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	existingUserID := testExistingUser123ID
+	suite.mockEntityProvider.On("IdentifyEntity",
+		map[string]interface{}{"username": "existinguser"}).Return(&existingUserID, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), ErrUserAlreadyExists.Code, resp.Error.Code)
+	suite.mockEntityProvider.AssertExpectations(suite.T())
+	suite.mockUserMgtProvider.AssertNotCalled(suite.T(), "CreateUser")
+}
+
+// TestExecute_PreResolvedUserIDInRuntimeData_SkipsIdentify verifies a user ID an earlier node put
+// in runtime data is used without an attribute lookup.
+func (suite *ProvisioningExecutorTestSuite) TestExecute_PreResolvedUserIDInRuntimeData_SkipsIdentify() {
+	suite.expectSchemaForProvisioning()
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			"username":     "newuser",
+			attributeEmail: "new@example.com",
+		},
+		RuntimeData: map[string]string{
+			ouIDKey:             testOUID,
+			userTypeKey:         testUserType,
+			userAttributeUserID: testExistingUser123ID,
+		},
+		NodeInputs: []providers.Input{},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), ErrUserAlreadyExists.Code, resp.Error.Code)
+	suite.mockEntityProvider.AssertNotCalled(suite.T(), "IdentifyEntity", mock.Anything)
+	suite.mockUserMgtProvider.AssertNotCalled(suite.T(), "CreateUser")
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_UserAlreadyExists() {
@@ -393,7 +606,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Con
 		NodeInputs:  []providers.Input{},
 	}
 
-	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.Equal(suite.T(), true, result["active"])
@@ -417,7 +630,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Unp
 		NodeInputs:  []providers.Input{},
 	}
 
-	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "affirmative", result["active"])
 }
@@ -431,7 +644,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 		NodeInputs:  []providers.Input{},
 	}
 
-	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Empty(suite.T(), result)
 }
@@ -453,7 +666,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 		NodeInputs:  []providers.Input{},
 	}
 
-	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.NotContains(suite.T(), result, "userID")
@@ -483,7 +696,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Req
 		NodeInputs: []providers.Input{},
 	}
 
-	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.Equal(suite.T(), "auth@example.com", result[attributeEmail])
@@ -513,7 +726,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Con
 		NodeInputs: []providers.Input{},
 	}
 
-	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	// UserInputs is checked first — wins for email.
 	assert.Equal(suite.T(), "userinput@example.com", result[attributeEmail])
@@ -542,7 +755,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_All
 		NodeInputs: []providers.Input{},
 	}
 
-	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "user@example.com", result[attributeEmail])
 	assert.Equal(suite.T(), "+1234567890", result["phone"],
@@ -574,7 +787,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Opt
 		NodeInputs:  nodeInputs,
 	}
 
-	result, _, _ := exec.getAttributesForProvisioning(ctx)
+	result, _, _, _ := exec.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "user@example.com", result[attributeEmail])
 	assert.Equal(suite.T(), "+1234567890", result["phone"],
@@ -599,7 +812,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Emp
 		NodeInputs: []providers.Input{},
 	}
 
-	_, credentialAttrs, err := suite.executor.getAttributesForProvisioning(ctx)
+	_, credentialAttrs, _, err := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "runtime-secret", credentialAttrs[attributePassword])
@@ -623,7 +836,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Cre
 		NodeInputs: []providers.Input{},
 	}
 
-	_, credentialAttrs, err := suite.executor.getAttributesForProvisioning(ctx)
+	_, credentialAttrs, _, err := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "input-secret", credentialAttrs[attributePassword])
@@ -674,7 +887,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Fil
 		NodeInputs:  nodeInputs,
 	}
 
-	result, _, _ := exec.getAttributesForProvisioning(ctx)
+	result, _, _, _ := exec.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.Equal(suite.T(), "test@example.com", result[attributeEmail])
@@ -708,7 +921,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Fil
 		NodeInputs: nodeInputs,
 	}
 
-	result, _, _ := exec.getAttributesForProvisioning(ctx)
+	result, _, _, _ := exec.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.Equal(suite.T(), "federated@example.com", result[attributeEmail])
@@ -738,7 +951,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Fil
 		NodeInputs: nodeInputs,
 	}
 
-	result, _, _ := exec.getAttributesForProvisioning(ctx)
+	result, _, _, _ := exec.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "userinput@example.com", result[attributeEmail],
 		"UserInputs must win over RuntimeData for the same key")
@@ -811,8 +1024,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_NewUser_NoGroupOrRolePro
 		Attributes: attrsJSON,
 	}
 
-	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(nil,
-		entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.expectNoExistingUserFor(attrs)
 	suite.mockUserMgtProvider.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *providers.User) bool {
 		return u.OUID == testOUID && u.Type == testUserType
 	})).Return(createdUser, nil)
@@ -867,8 +1079,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_UserEligibleForProvision
 		Attributes: attrsJSON,
 	}
 
-	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(nil,
-		entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.expectNoExistingUserFor(attrs)
 	suite.mockUserMgtProvider.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *providers.User) bool {
 		return u.OUID == testOUID && u.Type == testUserType
 	})).Return(createdUser, nil)
@@ -915,8 +1126,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_UserAutoProvisionedFlag_
 		Attributes: attrsJSON,
 	}
 
-	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(nil,
-		entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.expectNoExistingUserFor(attrs)
 	suite.mockUserMgtProvider.On("CreateUser", mock.Anything, mock.Anything).Return(createdUser, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -1072,8 +1282,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFailures() {
 			attrs := map[string]interface{}{
 				"username": "newuser",
 			}
-			suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(nil,
-				entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+			suite.expectNoExistingUserFor(attrs)
 			suite.mockUserMgtProvider.On("CreateUser", mock.Anything, mock.Anything).
 				Return(tt.createdUser, tt.createUserError)
 
@@ -1222,8 +1431,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_GroupAssignmentF
 		},
 	}
 
-	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(nil,
-		entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.expectNoExistingUserFor(attrs)
 
 	createdUser := &providers.User{
 		ID:         testNewUserID,
@@ -1276,8 +1484,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_RoleAssignmentFa
 		},
 	}
 
-	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(nil,
-		entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.expectNoExistingUserFor(attrs)
 
 	createdUser := &providers.User{
 		ID:         testNewUserID,
@@ -1334,8 +1541,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_GroupWithExistingMembers
 		},
 	}
 
-	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(nil,
-		entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.expectNoExistingUserFor(attrs)
 
 	createdUser := &providers.User{
 		ID:         testNewUserID,
@@ -1387,8 +1593,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_AuthFlow_AutoProvisionin
 		},
 	}
 
-	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(nil,
-		entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.expectNoExistingUserFor(attrs)
 
 	createdUser := &providers.User{
 		ID:         "user-provisioned",
@@ -1444,10 +1649,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success_WithGroupAndRole
 		},
 	}
 
-	suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{
-		"username":     "newuser",
-		attributeEmail: "new@example.com",
-	}).Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.expectNoExistingUserFor(attrs)
 
 	createdUser := &providers.User{
 		ID:         testNewUserID,
@@ -1501,8 +1703,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success_WithMultipleGrou
 		},
 	}
 
-	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(nil,
-		entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.expectNoExistingUserFor(attrs)
 
 	createdUser := &providers.User{
 		ID:         testNewUserID,
@@ -2725,7 +2926,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 		NodeInputs: []providers.Input{},
 	}
 
-	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.Equal(suite.T(), "test@example.com", result[attributeEmail])
@@ -2747,7 +2948,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Opt
 		NodeInputs:  []providers.Input{},
 	}
 
-	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "user@example.com", result[attributeEmail])
 	assert.Equal(suite.T(), "+1234567890", result["phone"],
@@ -2765,7 +2966,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 		NodeInputs:  []providers.Input{},
 	}
 
-	result, _, err := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _, err := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Nil(suite.T(), result, "schema service error must return nil map")
 	assert.Error(suite.T(), err, "schema service error must propagate as an error")
@@ -2788,7 +2989,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Opt
 		NodeInputs:  nodeInputs,
 	}
 
-	result, _, err := exec.getAttributesForProvisioning(ctx)
+	result, _, _, err := exec.getAttributesForProvisioning(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "user@example.com", result[attributeEmail])
@@ -3202,7 +3403,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Inc
 		},
 	}
 
-	result, _, err := exec.getAttributesForProvisioning(ctx)
+	result, _, _, err := exec.getAttributesForProvisioning(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "user@example.com", result[attributeEmail])
@@ -3235,7 +3436,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Inc
 		NodeProperties: map[string]interface{}{},
 	}
 
-	result, _, err := exec.getAttributesForProvisioning(ctx)
+	result, _, _, err := exec.getAttributesForProvisioning(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "user@example.com", result[attributeEmail])

--- a/docs/content/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/flows/advanced-configurations.mdx
@@ -1127,6 +1127,8 @@ Creates a new user record in the user store. This executor persists the user's i
 
 **Prompt batching:** If `maxPerPrompt` is set, the executor forwards only that many missing inputs per prompt cycle, cycling through them across multiple flow iterations.
 
+**How existing users are detected:** Before creating the record, the executor checks whether a conflicting user already exists. It matches only on the attributes that the user type schema marks `unique` and that were collected for the new user, so a changed non-unique attribute does not hide an existing account. Credential attributes are never used for this check. When the user type declares no unique attributes, the executor skips the check and creates the record. The user store validates uniqueness on write in every case.
+
 **Cross-OU provisioning:** When `allowCrossOUProvisioning` is set and the user exists in a different OU, the executor creates the user in the target OU instead of failing.
 
 **Executor properties:**

--- a/docs/content/guides/users/user-type-reference.mdx
+++ b/docs/content/guides/users/user-type-reference.mdx
@@ -29,7 +29,7 @@ Modifiers add validation and behavior rules to an attribute. You can combine mul
 | Modifier | Applies To | What It Does | When to Use |
 |----------|------------|--------------|-------------|
 | `required` | All types | The attribute must be provided on creation. <ProductName /> rejects the request if the value is missing. | Fields essential to the user's identity, such as `email` or `username`. |
-| `unique` | `string`, `number` | The value must be unique across all users. <ProductName /> rejects creation or update if a duplicate exists. | Natural identifiers like `username`, `email`, or `employeeId`. |
+| `unique` | `string`, `number` | The value must be unique across all users. <ProductName /> rejects creation or update if a duplicate exists. Provisioning flows also match on these attributes to detect an existing account. | Natural identifiers like `username`, `email`, or `employeeId`. |
 | `credential` | `string`, `number` | <ProductName /> hashes and stores the value securely. Never returned in any API response, even to administrators. | Passwords or other sensitive secrets. |
 | `enum` | `string`, `number` | Restricts the value to a fixed set of allowed options. <ProductName /> rejects any value not in the list. | Controlled vocabularies like a `department` field limited to specific team names. |
 | `regex` | `string` | Validates the value against a regular expression on creation and update. <ProductName /> rejects values that do not match. | Format rules such as email patterns or password complexity requirements. |


### PR DESCRIPTION
### Purpose

Scope the provisioning executor's existing-user check to the attributes the schema declares unique, and stop it from producing false negatives or false positives.

Before this change, `Execute` passed the full set of identifying attributes to `IdentifyUser` as one combined (AND'd) filter. That was wrong in multiple ways:

- A provisioning attempt that changed any non-unique attribute (for example `username` when only `email` is unique) missed the existing user entirely, so the flow fell through to `CreateUser` and surfaced a raw store constraint violation instead of `ErrUserAlreadyExists`.
- A single combined filter can only ever report the *first* attribute it happens to check; if `username` is free but `email` is already taken, an AND'd lookup finds nothing and lets the conflict through to the store.
- A user type declaring no unique attributes still paid for a lookup that could never legitimately match, even though nothing about such a user can conflict.
- A user already resolved earlier in the flow (a pre-linked federated account, or a user ID an earlier node placed in runtime data) was re-looked-up by attributes instead of reused, which can pick a different user than the one already resolved.

### Approach

`getAttributesForProvisioning` returns a third map, `uniqueAttrs`: the subset of identifying attributes whose schema `AttributeInfo.Unique` is set. That map, not the full identifying set, drives the existing-user check.

The identify and cross-OU ambiguity-resolution logic moves out of `Execute` into a new `identifyExistingUser` helper:

1. It first checks `GetUserIDFromContext` (the executor base's existing helper, already used elsewhere for account-linking), which returns a pre-resolved user, either a user ID an earlier node placed in runtime data, or the entity resolved via federated account linking. If found, that user is used as-is and no attribute lookup happens at all.
2. Otherwise, with no unique attributes it returns immediately; nothing can conflict.
3. Otherwise it looks up each unique attribute **individually** (one `IdentifyUser` call per attribute, sorted by name for a stable result) instead of combining them into one AND'd filter. `ErrUserNotFound` on one attribute just means that value is free; the loop continues to the next attribute. The first attribute that resolves to a user (or triggers cross-OU ambiguity resolution) wins; any other error aborts immediately.

Key points:

- Uniqueness is still enforced by the store on create. This lookup exists only to report the conflict before the write, so registration flows can re-prompt rather than fail.
- Credential attributes are never part of `uniqueAttrs` and never checked.
- No change to what gets written: `identifyingAttrs` and `credentialAttrs` still supply the full attribute set for `CreateUser`.

### Related Issues
- Closes #5279
- #5218
- Fixes #4590

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [Provisioning executor: how existing users are detected](docs/content/guides/flows/advanced-configurations.mdx)
    - [User type reference: `unique` modifier](docs/content/guides/users/user-type-reference.mdx)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

New unit tests in `provisioning_executor_test.go`:

- `TestExecute_NoUniqueAttributes_SkipsIdentify` - a user type with no unique attributes provisions without any `IdentifyEntity` call.
- `TestExecute_OnlyUniqueAttributesIdentify` - the lookup filters on the unique attribute alone, so a changed non-unique attribute no longer causes it to miss an existing user.
- `TestExecute_ConflictOnSecondUniqueAttribute` - each unique attribute is looked up on its own; a free first attribute doesn't mask a taken second one.
- `TestExecute_ResolvedEntityReference_SkipsIdentify` - a user already resolved through federated account linking is reused as-is, even if a second connection reports a different username.
- `TestExecute_PreResolvedUserIDInRuntimeData_SkipsIdentify` - a user ID an earlier flow node placed in runtime data is used without an attribute lookup.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
