### PR TITLE
[Docs] Add workload identity federation guides

### DIFF
--- a/docs/content/guides/integrations/workload-identity-federation/claude.mdx
+++ b/docs/content/guides/integrations/workload-identity-federation/claude.mdx
@@ -1,0 +1,241 @@
+---
+title: Call the Claude API with a {{ProductName}} Agent Identity
+docType: guide
+sidebar_position: 2
+persona: iam
+description: Federate a {{ProductName}} agent identity to Anthropic using workload identity federation, so an agent trades its own token for Claude API access instead of holding a long-lived API key.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Call the Claude API with a <ProductName /> Agent Identity
+
+Anthropic [workload identity federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation) accepts a signed OIDC token from an external issuer and returns a short-lived Anthropic access token in exchange. Point it at <ProductName /> and your agent reaches the Claude API with the identity it already has. No static API key sits in the agent's environment, no key is shared between agents, and disabling the agent in <ProductName /> ends its Claude access at the next exchange.
+
+This guide explains how to authenticate an agent to the Claude API using workload identity federation. The agent gets an [Agent Token](../../../agents/authentication/agent-own-token) from <ProductName />. Anthropic verifies that token and issues a short-lived access token of its own. The agent sends that access token on its API calls.
+
+See [Workload Identity Federation](../overview) for what federation replaces and how the exchange works, and [Agent Token](../../../agents/authentication/agent-own-token) for how <ProductName /> issues that token and what it carries.
+
+## Prerequisites
+
+- A running <ProductName /> instance. See [Get <ProductName />](../../../../getting-started/get-thunderid).
+- An Anthropic account with access to [Claude Console](https://platform.claude.com/).
+- `curl` and `jq` available in your terminal.
+
+## Create the Agent
+
+1. Sign in to the <ProductName /> Console at `https://localhost:8090/console`.
+2. Navigate to **Agents** → **New Agent**.
+3. Enter an **Agent Name** (for example `research-agent`).
+4. Select an owner for the agent.
+5. Click **Create Agent**.
+6. Note down the **Agent ID**, Anthropic matches on this value.
+7. Record the **Client ID** and **Client Secret**. The secret is shown once.
+8. Open the agent's **Advanced** tab. Under **OAuth 2 Configuration**, set **Default audience (aud)** to `https://api.anthropic.com`, then save.
+
+A new agent has the `client_credentials` grant enabled, so it can already request a token for itself. See [Agent Token](../../../agents/authentication/agent-own-token) on how to get a token.
+
+:::note[The audience is fixed]
+Anthropic verifies the token's `aud` claim against `https://api.anthropic.com`, and that value cannot be changed on the Anthropic side. The agent token has to carry it, so step 8 sets it as the agent's default audience.
+:::
+
+A `client_credentials` request that carries no `resource` parameter now produces a token whose `aud` claim is `https://api.anthropic.com`.
+
+## Configure Federation in the Claude Console
+
+In the [Claude Console](https://platform.claude.com/), navigate to **Organization settings** → **Workload identity**. You register <ProductName /> as an issuer there, then connect the agent to a service account through a federation rule.
+
+### Register <ProductName /> as a Federation Issuer
+
+Anthropic verifies the agent token against a key set it holds for your issuer. It can either fetch that key set from your discovery document or store a copy you paste in. Discovery needs an issuer served over public HTTPS on port 443 with a public DNS hostname, so a <ProductName /> instance on `https://localhost:8090` cannot be discovered and has to supply the key set directly.
+
+
+<Tabs groupId="thunderid-reachability">
+<TabItem value="public" label="Public instance" default>
+1. Click **Register issuer**.
+2. Enter a **Name**, for example `thunderid`.
+3. Set the **Issuer URL** to your <ProductName /> URL.
+4. Choose the **JWKS source**.
+5. Leave the JWKS source on **OIDC discovery**.
+6. Click **Register**.
+
+</TabItem>
+<TabItem value="local" label="Local instance">
+1. Click **Register issuer**.
+2. Enter a **Name**, for example `thunderid`.
+3. Set the **Issuer URL** to your <ProductName /> URL.
+4. Choose the **JWKS source**.
+5. Select **Inline keys**, then paste the <ProductName /> signing keys:
+
+```bash
+curl -sk https://localhost:8090/oauth2/jwks | jq -c .keys
+```
+
+:::warning[Paste the key set again after a key rotation]
+An inline key set is a snapshot. Anthropic performs no discovery against the issuer, so rotating the <ProductName /> signing key invalidates every new token until you paste the new key set.
+:::
+6. Click **Register**.
+
+</TabItem>
+</Tabs>
+
+### Connect the Agent as a Workload
+
+The issuer establishes which issuer Anthropic trusts. A federation rule decides which Anthropic identity a given token may act as, and a service account is the identity it acts as. The **Connect workload** wizard creates both.
+
+1. Click **Connect workload**, then select the issuer you registered from the list.
+2. Give the federation rule a **Name**, for example `research-agent-rule`.
+3. Set the **subject claim** to the **Agent ID**.
+4. Select the **Workspace** the minted tokens act in.
+5. Add claim conditions if the rule should match on more than the subject.
+6. Click **Continue**.
+7. Connect a service account. Select an existing one, or create one by entering a **service account name**.
+8. Click **Apply and continue**.
+
+The wizard then shows a `curl` command that runs the exchange, and listens for it. Its body carries the four values the agent needs at runtime, so record them: the federation rule ID (`fdrl_...`), the service account ID (`svac_...`), your organization ID, and the workspace ID (`wrkspc_...`).
+
+## Run the Flow
+
+### Request the Agent Token
+
+Send a `client_credentials` request with the agent's credentials:
+
+```bash
+TOKEN_RESPONSE=$(curl -X POST https://localhost:8090/oauth2/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -u '<CLIENT_ID>:<CLIENT_SECRET>' \
+  -d 'grant_type=client_credentials')
+
+AGENT_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r .access_token)
+```
+
+You can inspect the claims before you exchange the token if needed. Following three claims decide whether the exchange succeeds:
+
+| Claim | Expected value |
+|---|---|
+| `iss` | The **Issuer URL** on the federation issuer, for example `https://localhost:8090`. |
+| `aud` | `https://api.anthropic.com`, the fixed value Anthropic verifies. Set as the agent's default audience. |
+| `sub` | The **subject claim** on the rule, which is the Agent ID. |
+
+See [Agent Token](../../../agents/authentication/agent-own-token) for a detailed explanation on getting an agent token.
+
+### Exchange the Token at Anthropic
+
+```bash
+ACCESS_TOKEN=$(curl -sS https://api.anthropic.com/v1/oauth/token \
+  -H 'content-type: application/json' \
+  --data '{
+    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    "assertion": "'"$AGENT_TOKEN"'",
+    "federation_rule_id": "<FEDERATION_RULE_ID>",
+    "organization_id": "<ORGANIZATION_ID>",
+    "service_account_id": "<SERVICE_ACCOUNT_ID>",
+    "workspace_id": "<WORKSPACE_ID>"
+  }' | jq -r .access_token)
+```
+
+Anthropic returns a standard OAuth 2.0 token response. The response can include additional fields.
+
+```json
+{
+  "access_token": "sk-ant-oat01-...",
+  "token_type": "Bearer",
+  "expires_in": 600,
+  "scope": "workspace:inference"
+}
+```
+
+Send `workspace_id` only when the rule is enabled for more than one workspace. When you omit it, Anthropic scopes the token to the rule's sole enabled workspace.
+
+:::note[Exchange each agent token once]
+Every <ProductName /> access token carries a `jti` claim, and Anthropic accepts an assertion with a `jti` only once per issuer. Request a fresh agent token for each exchange. A retry that re-sends a token it already presented is rejected, and the [authentication history](https://platform.claude.com/settings/workload-identity-federation?tab=history) records the reason as `jti_reused`.
+:::
+
+### Call the Claude API
+
+```bash
+curl -sS https://api.anthropic.com/v1/messages \
+  -H "authorization: Bearer $ACCESS_TOKEN" \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'content-type: application/json' \
+  --data '{
+    "model": "claude-opus-5",
+    "max_tokens": 1024,
+    "messages": [{"role": "user", "content": "write a 3 word sentence"}]
+  }'
+```
+
+## Use <ProductName /> with the Anthropic SDK
+
+The Anthropic SDKs can run the exchange for you. Supply an identity token provider that fetches the agent token from <ProductName />, and pass the rule, organization, and service account IDs alongside it.
+
+```python
+import os
+
+import requests
+from anthropic import Anthropic, WorkloadIdentityCredentials
+
+TOKEN_ENDPOINT = "https://localhost:8090/oauth2/token"
+
+
+def fetch_agent_token() -> str:
+    response = requests.post(
+        TOKEN_ENDPOINT,
+        data={"grant_type": "client_credentials"},
+        auth=(os.environ["AGENT_CLIENT_ID"], os.environ["AGENT_CLIENT_SECRET"]),
+        timeout=10,
+    )
+    response.raise_for_status()
+    return response.json()["access_token"]
+
+
+client = Anthropic(
+    credentials=WorkloadIdentityCredentials(
+        identity_token_provider=fetch_agent_token,
+        federation_rule_id=os.environ["ANTHROPIC_FEDERATION_RULE_ID"],
+        organization_id=os.environ["ANTHROPIC_ORGANIZATION_ID"],
+        service_account_id=os.environ["ANTHROPIC_SERVICE_ACCOUNT_ID"],
+        workspace_id=os.environ.get("ANTHROPIC_WORKSPACE_ID"),
+    ),
+)
+
+message = client.messages.create(
+    model="claude-opus-5",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "write a 3 word sentence"}],
+)
+
+print(next(block.text for block in message.content if block.type == "text"))
+```
+
+The SDK calls `fetch_agent_token` again whenever the Anthropic access token approaches expiry.
+
+:::note[Trusting the local certificate]
+In a local setup, <ProductName /> serves HTTPS with a self-signed certificate, so you need to trust the certificate in the shell where you run Python by setting `REQUESTS_CA_BUNDLE`. This prevents `requests` from raising an `SSLError` due to certificate verification.
+:::
+
+Store `AGENT_CLIENT_ID` and `AGENT_CLIENT_SECRET` in your secret manager, not in the image or the repository. An agent that must not hold a shared secret at all can authenticate with a signed assertion instead, which changes only how the identity token provider fetches the agent token. See [Agent Authentication](../../../agents/authentication).
+
+## Troubleshooting
+
+Every denied assertion returns the same opaque `401` `authentication_error` with the message `Authentication failed`, so the deny reason lives on the [authentication history page](https://platform.claude.com/settings/workload-identity-federation?tab=history) rather than in the response.
+
+| Symptom | Likely cause |
+|---|---|
+| `invalid_client` from <ProductName /> | Wrong client ID or secret, or the agent has no OAuth configuration. |
+| Deny reason `match_subject_prefix` | The token's `sub` differs from the rule's **subject claim**. Decode the token and compare it against the Agent ID. |
+| The history entry points at the audience | The token's `aud` is not `https://api.anthropic.com`. Check whether you have set the agent's default audience, and that the token request carries no `resource` parameter naming something else. |
+| The history entry points at the issuer or the signature | The token's `iss` does not equal the issuer's **Issuer URL** byte for byte, or the signing key rotated and the inline key set is stale. |
+| Deny reason `jti_reused` | The same agent token was exchanged twice. Request a new one for each exchange. |
+| Deny reason `workspace_id_required` | The rule is enabled for more than one workspace and the exchange named none. Send `workspace_id`. |
+| The exchange fails on the token lifetime | The agent token's `exp` minus `iat` exceeds the issuer's maximum, one hour by default. Lower **Token Validity** on the agent's **Tokens** tab, or raise the maximum on the issuer. |
+| A `401` with no history entry at all | The `federation_rule_id` was not recognized. Confirm it in the Claude Console and that the rule is not archived. |
+| `401` from `api.anthropic.com` | The Anthropic access token expired. Exchange again rather than caching it past `expires_in`. |
+| `403` from `api.anthropic.com` | The rule's OAuth scope is narrower than the call needs, or the service account is not a member of the rule's workspace. |
+
+## Next Steps
+
+- [Agent Token](../../../agents/authentication/agent-own-token)
+- [Agent Authentication](../../../agents/authentication)
+- [Create and Manage Agents](../../../agents/manage-agents)

--- a/docs/content/guides/integrations/workload-identity-federation/openai.mdx
+++ b/docs/content/guides/integrations/workload-identity-federation/openai.mdx
@@ -1,0 +1,229 @@
+---
+title: Call OpenAI APIs with a {{ProductName}} Agent Identity
+docType: guide
+sidebar_position: 1
+persona: iam
+description: Federate a {{ProductName}} agent identity to OpenAI using workload identity federation, so an agent trades its own token for OpenAI access instead of holding a long-lived API key.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Call OpenAI APIs with a <ProductName /> Agent Identity
+
+OpenAI [workload identity federation](https://developers.openai.com/api/docs/guides/workload-identity-federation) accepts a signed token from an external issuer and returns a short-lived OpenAI access token in exchange. Point it at <ProductName /> and your agent reaches the OpenAI API with the identity it already has. No OpenAI API key sits in the agent's environment, no key is shared between agents, and disabling the agent in <ProductName /> ends its OpenAI access at the next exchange.
+
+This guide explains how to authenticate an agent to the OpenAI API using workload identity federation. The agent gets an [Agent Token](../../../agents/authentication/agent-own-token) from <ProductName />. OpenAI verifies that token and issues a short-lived access token of its own. The agent sends that access token on its API calls.
+
+See [Workload Identity Federation](../overview) for what federation replaces and how the exchange works, and [Agent Token](../../../agents/authentication/agent-own-token) for how <ProductName /> issues that token and what it carries.
+
+## Prerequisites
+
+- A running <ProductName /> instance. See [Get <ProductName />](../../../../getting-started/get-thunderid).
+- An OpenAI [developer account](https://platform.openai.com/) with access to Organization Settings.
+- `curl` and `jq` available in your terminal.
+
+## Create the Agent
+
+1. Sign in to the <ProductName /> Console at `https://localhost:8090/console`.
+2. Navigate to **Agents** → **New Agent**.
+3. Enter an **Agent Name** (for example `research-agent`).
+4. Select an owner for the agent.
+5. Click **Create Agent**.
+6. Note down the **Agent ID**, OpenAI matches on this value.
+7. Record the **Client ID** and **Client Secret**. The secret is shown once.
+
+A new agent has the `client_credentials` grant enabled, so it can already request a token for itself. See [Agent Token](../../../agents/authentication/agent-own-token) on how to get a token.
+
+:::note[Setting the audience]
+OpenAI matches the token's `aud` claim against the audience registered on the provider, so the agent token has to carry that value. You can configure a default audience value from the console, under agent's **Advanced** → **OAuth 2 Configuration** → **Default audience (aud)**.
+:::
+
+A `client_credentials` request that carries no `resource` parameter now produces a token whose `aud` claim is the value of default audience (for example `https://api.openai.com`). This is the value you register with OpenAI below.
+
+## Register <ProductName /> as a Workload Identity Provider
+
+OpenAI verifies the agent token against a key set it holds for your issuer. It can either fetch that key set from your discovery document or store a copy you upload. Discovery needs an issuer served over public HTTPS with no custom port, so a <ProductName /> instance on `https://localhost:8090` cannot be discovered and has to upload the key set instead.
+
+<Tabs groupId="thunderid-reachability">
+<TabItem value="public" label="Public instance" default>
+
+1. In the [OpenAI platform dashboard](https://platform.openai.com/), navigate to **Settings** → **Organization settings** → **Security** → **Workload Identity Provider**.
+2. Click **Create identity provider**.
+3. Enter a **Name**, for example **<ProductName />**, and select **OIDC** as the provider type.
+4. Set **Issuer URL** to your <ProductName /> URL, for example `https://id.example.com`. This must equal the `jwt.issuer` value in `deployment.yaml`, which defaults to the server URL.
+5. Set **Audience** to the agent's default audience, `https://api.openai.com`.
+6. Leave the discovery settings untouched. Or you can configure a custom OIDC discovery URL by turning on **Use custom URL for OIDC discovery**.
+7. Click **Create**, then record the provider ID, a string such as `idp_a1B2c3D4e5F6g7H8i9J0kLmN`.
+
+A signing key rotation needs no change on the OpenAI side, because OpenAI refreshes the key set itself when it meets a `kid` it does not hold.
+
+</TabItem>
+<TabItem value="local" label="Local instance">
+
+1. Export the <ProductName /> signing keys. Keep the full response, including the surrounding `keys` array.
+    ```bash
+    curl -sk https://localhost:8090/oauth2/jwks
+    ```
+2. In the [OpenAI platform dashboard](https://platform.openai.com/), navigate to **Settings** → **Organization settings** → **Security** → **Workload Identity Provider**.
+3. Click **Create identity provider**.
+4. Enter a **Name**, for example **<ProductName />**, and select **OIDC** as the provider type.
+5. Set **Issuer URL** to `https://localhost:8090`. This must equal the `jwt.issuer` value in `deployment.yaml`, which defaults to the server URL.
+6. Set **Audience** to the agent's default audience, `https://api.openai.com`.
+7. Turn on **Use uploaded JWKS for token verification**, then paste the JWKS JSON from step 1.
+8. Click **Create**, then record the provider ID, a string such as `idp_a1B2c3D4e5F6g7H8i9J0kLmN`.
+
+:::warning[Re-upload the key set after a key rotation]
+An uploaded JWKS is a snapshot. OpenAI saves this and performs no discovery against the issuer, so rotating the <ProductName /> signing key invalidates new tokens until you upload the new key set.
+:::
+
+</TabItem>
+</Tabs>
+
+## Map the Agent to a Service Account
+
+The provider establishes which issuer OpenAI trusts. A service account mapping decides which OpenAI identity a given token may assume. Match on the `sub` claim: it carries the agent's ID, it is unique to that agent, and it survives a client secret rotation.
+
+1. Open the provider you created, then click on **create mapping**.
+2. Enter a **Name**, for example `mapping-research-agent`.
+3. Under the key value section, Set **Key** to `sub` and use the **Agent ID** as the value. You can add additional claim mappings if needed.
+4. Select the **Project** and the **Service Account** the agent acts as.
+5. Set **Permissions** to the narrowest scope set the agent needs, or leave it unrestricted to inherit the service account's own access.
+6. Save the mapping, then record the service account ID, a string such as `user-Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8`.
+
+Give each agent its own mapping, and keep the values distinct. OpenAI rejects an exchange when more than one enabled mapping matches it.
+
+## Run the Flow
+
+### Request the Agent Token
+
+Send a `client_credentials` request with the agent's credentials:
+
+```bash
+TOKEN_RESPONSE=$(curl -X POST https://localhost:8090/oauth2/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -u '<CLIENT_ID>:<CLIENT_SECRET>' \
+  -d 'grant_type=client_credentials')
+
+AGENT_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r .access_token)
+```
+
+You can inspect the claims before you exchange the token if needed. Following three claims decide whether the exchange succeeds:
+
+| Claim | Expected value |
+|---|---|
+| `iss` | The **Issuer URL** on the provider, for example `https://localhost:8090`. |
+| `aud` | The **Audience** on the provider, which is the agent's default audience. |
+| `sub` | The **Value** on the mapping, which is the Agent ID. |
+
+See [Agent Token](../../../agents/authentication/agent-own-token) for a detailed explanation on getting an agent token.
+
+### Exchange the Token at OpenAI
+
+```bash
+ACCESS_TOKEN=$(curl -s https://auth.openai.com/oauth/token \
+  -H 'content-type: application/json' \
+  --data '{
+    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+    "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    "subject_token": "'"$AGENT_TOKEN"'",
+    "identity_provider_id": "<IDENTITY_PROVIDER_ID>",
+    "service_account_id": "<SERVICE_ACCOUNT_ID>"
+  }' | jq -r .access_token)
+```
+
+OpenAI returns an access token that lasts at most 3600 seconds:
+
+```json
+{
+  "access_token": "<ACCESS_TOKEN>",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
+
+The exchange assumes an existing service account. It never creates a principal, a project, or a workspace membership, so an agent reaches only what you granted that service account beforehand.
+
+### Call the OpenAI API
+
+```bash
+curl -s https://api.openai.com/v1/responses \
+  -H "authorization: Bearer $ACCESS_TOKEN" \
+  -H 'content-type: application/json' \
+  --data '{
+    "model": "gpt-5.4-mini",
+    "input": "write a 3 word sentence",
+    "store": true
+  }'
+```
+
+## Use <ProductName /> with OpenAI SDK
+
+The OpenAI SDKs can run the exchange for you. Supply a subject token provider that fetches the agent token from <ProductName />, and pass the provider ID and service account ID alongside it.
+
+The `workload_identity` option is available in the OpenAI Python SDK from version 2.31.0 onwards, so install `openai>=2.31.0` before you run the example below.
+
+```python
+import os
+
+import requests
+from openai import OpenAI
+from openai.auth import SubjectTokenProvider
+
+TOKEN_ENDPOINT = "https://localhost:8090/oauth2/token"
+
+
+def thunderid_agent_token_provider() -> SubjectTokenProvider:
+    def get_token() -> str:
+        response = requests.post(
+            TOKEN_ENDPOINT,
+            data={"grant_type": "client_credentials"},
+            auth=(os.environ["AGENT_CLIENT_ID"], os.environ["AGENT_CLIENT_SECRET"]),
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()["access_token"]
+
+    return {"token_type": "jwt", "get_token": get_token}
+
+
+client = OpenAI(
+    workload_identity={
+        "identity_provider_id": os.environ["OPENAI_IDENTITY_PROVIDER_ID"],
+        "service_account_id": os.environ["OPENAI_SERVICE_ACCOUNT_ID"],
+        "provider": thunderid_agent_token_provider(),
+    },
+)
+
+response = client.responses.create(
+    model="gpt-5.4-mini",
+    input="write a 3 word sentence",
+)
+
+print(response.output_text)
+```
+
+:::note[Trusting the local certificate]
+In a local setup, <ProductName /> serves HTTPS with a self-signed certificate, so you need to trust the certificate in the shell where you run Python by setting `REQUESTS_CA_BUNDLE`. This prevents `requests` from raising an `SSLError` due to certificate verification.
+:::
+
+Store `AGENT_CLIENT_ID` and `AGENT_CLIENT_SECRET` in your secret manager, not in the image or the repository. An agent that must not hold a shared secret at all can authenticate with a signed assertion instead, which changes only how the subject token provider fetches the agent token. See [Agent Authentication](../../../agents/authentication).
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `invalid_client` from <ProductName /> | Wrong client ID or secret, or the agent has no OAuth configuration. |
+| `invalid_subject_token` from OpenAI | The agent token expired, its `iss` does not match the provider's issuer URL, or the signing key rotated and the uploaded JWKS is stale. |
+| The exchange fails on the audience | The token's `aud` is not the audience on the provider. Check whether you have configured the default audience in <ProductName />. |
+| No mapping matched the exchange | The token's `sub` differs from the **Value** on the mapping. Decode the token and compare it against the Agent ID. |
+| Several mappings matched the exchange | Two enabled mappings on the provider accept the same token. Disable the extra one. |
+| `401` from `api.openai.com` | The OpenAI access token expired. It lasts at most 3600 seconds, so exchange again rather than caching it longer. |
+| `403` from `api.openai.com` | The mapping's permissions are narrower than the call needs, or the service account has no access to the project. |
+
+## Next Steps
+
+- [Agent Token](../../../agents/authentication/agent-own-token)
+- [Agent Authentication](../../../agents/authentication)
+- [Create and Manage Agents](../../../agents/manage-agents)

--- a/docs/content/guides/integrations/workload-identity-federation/overview.mdx
+++ b/docs/content/guides/integrations/workload-identity-federation/overview.mdx
@@ -1,0 +1,67 @@
+---
+title: Workload Identity Federation
+docType: concept
+sidebar_position: 0
+description: A workload presents its {{ProductName}} token to an external platform and receives that platform's own short-lived credential in return, instead of holding a long-lived API key.
+---
+
+# Workload Identity Federation
+
+Workload identity federation lets a workload access a platform without storing a long-lived credential, using a token from an issuer that platform already trusts. The workload presents a signed token from its own identity provider, and the platform returns a short-lived credential of its own.
+
+For <ProductName />, a workload is any confidential client that can use the client credentials grant. That is an [agent](../../../agents), such as an AI assistant, or an [application](../../../applications/manage-applications), such as a backend service. Either one presents the access token it already gets for itself.
+
+Select a platform to get a step-by-step integration guide with <ProductName />.
+
+| Platform | Guide |
+|---|---|
+| OpenAI | [Call OpenAI APIs with a <ProductName /> Agent Identity](../openai) |
+| Anthropic | [Call the Claude API with a <ProductName /> Agent Identity](../claude) |
+
+## What It Replaces
+
+The alternative is a static API key that the platform issues once and you copy into the workload's environment. Such a key:
+
+- Does not expire, so a leaked copy stays valid until somebody notices and rotates it.
+- If multiple workloads share the same key, the platform generally cannot distinguish them from the credential alone.
+- Sits outside the workload's lifecycle, so deleting the agent or application in <ProductName /> leaves its access to the platform intact.
+
+Federation removes this static key. The workload proves who it is to <ProductName /> with the credential it already holds, and every platform credential it receives afterwards is short-lived and traceable to its <ProductName /> identity.
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant W as Workload
+    participant TID as ThunderID
+    participant P as External platform
+    participant API as Platform API
+    W->>TID: client_credentials with client ID and secret
+    TID-->>W: Signed JWT (its own access token)
+    W->>P: Token exchange with signed JWT
+    P->>P: Verify the signature against ThunderID's public keys
+    P->>P: Match the claims against a mapping rule
+    P-->>W: Platform access token (short-lived)
+    W->>API: Request with the access token as a bearer token
+    API-->>W: Response
+```
+
+- **The workload authenticates to <ProductName />.** The [client credentials grant](../../../protocols/oauth-oidc/client-credentials) returns a signed JWT whose `sub` claim is the workload's own ID.
+- **The workload exchanges that token at the platform.** The exchange usually follows [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693), carrying the <ProductName /> token as the subject token.
+- **The platform verifies the token.** It reads <ProductName />'s public keys, either from the JWKS endpoint or from a copy uploaded during setup, then validates the signature and the token claims required by its federation configuration.
+- **The platform resolves one of its own identities.** A mapping rule maps one or more claims, often `sub`, sometimes together with `iss` or other attributes, against values you registered.
+- **The platform issues a short-lived access token.** The token belongs to that account, expires on a lifetime the platform sets, and is narrowed to any permissions the mapping rule restricts it to.
+- **The workload calls the platform's API.** It sends that token as a bearer token, and repeats the exchange once the token expires.
+
+## Reaching Your Public Keys
+
+A platform needs <ProductName />'s public keys to verify a signature, and there are two ways to give it them. It can retrieve the JWKS directly from `/oauth2/jwks`, or discover the JWKS URL from `/.well-known/openid-configuration`. That keeps the keys current through a rotation, but it requires the instance to be reachable over public HTTPS.
+
+Otherwise you upload a copy during setup, which is the option for an instance that runs locally or inside a private network. The copy is a snapshot, so rotating the signing key breaks every exchange until you upload the new key set.
+
+## Related
+
+- [Agent Token](../../../agents/authentication/agent-own-token)
+- [Client Credentials](../../../protocols/oauth-oidc/client-credentials)
+- [Agents](../../../agents)
+- [Manage Applications](../../../applications/manage-applications)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -658,6 +658,30 @@ const sidebars: SidebarsConfig = {
                 {type: 'doc', id: 'guides/integrations/apim-gateways/krakend', label: 'KrakenD'},
               ],
             },
+            {
+              type: 'category',
+              label: 'Workload Identity Federation',
+              collapsed: true,
+              collapsible: true,
+              items: [
+                {
+                  type: 'doc',
+                  id: 'guides/integrations/workload-identity-federation/overview',
+                  label: 'Overview',
+                  key: 'wif-overview',
+                },
+                {
+                  type: 'doc',
+                  id: 'guides/integrations/workload-identity-federation/openai',
+                  label: 'OpenAI',
+                },
+                {
+                  type: 'doc',
+                  id: 'guides/integrations/workload-identity-federation/claude',
+                  label: 'Claude',
+                },
+              ],
+            },
           ],
         },
         {

--- a/docs/versioned_docs/version-v1.0.x/guides/integrations/workload-identity-federation/claude.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/integrations/workload-identity-federation/claude.mdx
@@ -1,0 +1,243 @@
+---
+title: Call the Claude API with a {{ProductName}} Agent Identity
+docType: guide
+sidebar_position: 2
+persona: iam
+description: Federate a {{ProductName}} agent identity to Anthropic using workload identity federation, so an agent trades its own token for Claude API access instead of holding a long-lived API key.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Call the Claude API with a <ProductName /> Agent Identity
+
+Anthropic [workload identity federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation) accepts a signed OIDC token from an external issuer and returns a short-lived Anthropic access token in exchange. Point it at <ProductName /> and your agent reaches the Claude API with the identity it already has. No static API key sits in the agent's environment, no key is shared between agents, and disabling the agent in <ProductName /> ends its Claude access at the next exchange.
+
+This guide explains how to authenticate an agent to the Claude API using workload identity federation. The agent gets an [Agent Token](../../../agents/authentication/agent-own-token) from <ProductName />. Anthropic verifies that token and issues a short-lived access token of its own. The agent sends that access token on its API calls.
+
+See [Workload Identity Federation](../overview) for what federation replaces and how the exchange works, and [Agent Token](../../../agents/authentication/agent-own-token) for how <ProductName /> issues that token and what it carries.
+
+## Prerequisites
+
+- A running <ProductName /> instance. See [Get <ProductName />](../../../../getting-started/get-thunderid).
+- An Anthropic account with access to [Claude Console](https://platform.claude.com/).
+- `curl` and `jq` available in your terminal.
+
+## Create the Agent
+
+1. Sign in to the <ProductName /> Console at `https://localhost:8090/console`.
+2. Navigate to **Agents** → **New Agent**.
+3. Enter an **Agent Name** (for example `research-agent`).
+4. Select an owner for the agent.
+5. Click **Create Agent**.
+6. Note down the **Agent ID**, Anthropic matches on this value.
+7. Record the **Client ID** and **Client Secret**. The secret is shown once.
+8. Open the agent's **Advanced** tab. Under **OAuth 2 Configuration**, set **Default audience (aud)** to `https://api.anthropic.com`, then save.
+
+A new agent has the `client_credentials` grant enabled, so it can already request a token for itself. See [Agent Token](../../../agents/authentication/agent-own-token) on how to get a token.
+
+:::note[The audience is fixed]
+Anthropic verifies the token's `aud` claim against `https://api.anthropic.com`, and that value cannot be changed on the Anthropic side. The agent token has to carry it, so step 8 sets it as the agent's default audience.
+:::
+
+A `client_credentials` request that carries no `resource` parameter now produces a token whose `aud` claim is `https://api.anthropic.com`.
+
+## Configure Federation in the Claude Console
+
+In the [Claude Console](https://platform.claude.com/), navigate to **Organization settings** → **Workload identity**. You register <ProductName /> as an issuer there, then connect the agent to a service account through a federation rule.
+
+### Register <ProductName /> as a Federation Issuer
+
+Anthropic verifies the agent token against a key set it holds for your issuer. It can either fetch that key set from your discovery document or store a copy you paste in. Discovery needs an issuer served over public HTTPS on port 443 with a public DNS hostname, so a <ProductName /> instance on `https://localhost:8090` cannot be discovered and has to supply the key set directly.
+
+
+<Tabs groupId="thunderid-reachability">
+<TabItem value="public" label="Public instance" default>
+1. Click **Register issuer**.
+2. Enter a **Name**, for example `thunderid`.
+3. Set the **Issuer URL** to your <ProductName /> URL.
+4. Choose the **JWKS source**.
+5. Leave the JWKS source on **OIDC discovery**.
+6. Click **Register**.
+
+</TabItem>
+<TabItem value="local" label="Local instance">
+1. Click **Register issuer**.
+2. Enter a **Name**, for example `thunderid`.
+3. Set the **Issuer URL** to your <ProductName /> URL.
+4. Choose the **JWKS source**.
+5. Select **Inline keys**, then paste the <ProductName /> signing keys:
+
+```bash
+curl -sk https://localhost:8090/oauth2/jwks | jq -c .keys
+```
+
+:::warning[Paste the key set again after a key rotation]
+An inline key set is a snapshot. Anthropic performs no discovery against the issuer, so rotating the <ProductName /> signing key invalidates every new token until you paste the new key set.
+:::
+6. Click **Register**.
+
+</TabItem>
+</Tabs>
+
+5. Click **Register**.
+
+### Connect the Agent as a Workload
+
+The issuer establishes which issuer Anthropic trusts. A federation rule decides which Anthropic identity a given token may act as, and a service account is the identity it acts as. The **Connect workload** wizard creates both.
+
+1. Click **Connect workload**, then select the issuer you registered from the list.
+2. Give the federation rule a **Name**, for example `research-agent-rule`.
+3. Set the **subject claim** to the **Agent ID**.
+4. Select the **Workspace** the minted tokens act in.
+5. Add claim conditions if the rule should match on more than the subject.
+6. Click **Continue**.
+7. Connect a service account. Select an existing one, or create one by entering a **service account name**.
+8. Click **Apply and continue**.
+
+The wizard then shows a `curl` command that runs the exchange, and listens for it. Its body carries the four values the agent needs at runtime, so record them: the federation rule ID (`fdrl_...`), the service account ID (`svac_...`), your organization ID, and the workspace ID (`wrkspc_...`).
+
+## Run the Flow
+
+### Request the Agent Token
+
+Send a `client_credentials` request with the agent's credentials:
+
+```bash
+TOKEN_RESPONSE=$(curl -X POST https://localhost:8090/oauth2/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -u '<CLIENT_ID>:<CLIENT_SECRET>' \
+  -d 'grant_type=client_credentials')
+
+AGENT_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r .access_token)
+```
+
+You can inspect the claims before you exchange the token if needed. Following three claims decide whether the exchange succeeds:
+
+| Claim | Expected value |
+|---|---|
+| `iss` | The **Issuer URL** on the federation issuer, for example `https://localhost:8090`. |
+| `aud` | `https://api.anthropic.com`, the fixed value Anthropic verifies. Set as the agent's default audience. |
+| `sub` | The **subject claim** on the rule, which is the Agent ID. |
+
+See [Agent Token](../../../agents/authentication/agent-own-token) for a detailed explanation on getting an agent token.
+
+### Exchange the Token at Anthropic
+
+```bash
+ACCESS_TOKEN=$(curl -sS https://api.anthropic.com/v1/oauth/token \
+  -H 'content-type: application/json' \
+  --data '{
+    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    "assertion": "'"$AGENT_TOKEN"'",
+    "federation_rule_id": "<FEDERATION_RULE_ID>",
+    "organization_id": "<ORGANIZATION_ID>",
+    "service_account_id": "<SERVICE_ACCOUNT_ID>",
+    "workspace_id": "<WORKSPACE_ID>"
+  }' | jq -r .access_token)
+```
+
+Anthropic returns a standard OAuth 2.0 token response. The response can include additional fields.
+
+```json
+{
+  "access_token": "sk-ant-oat01-...",
+  "token_type": "Bearer",
+  "expires_in": 600,
+  "scope": "workspace:inference"
+}
+```
+
+Send `workspace_id` only when the rule is enabled for more than one workspace. When you omit it, Anthropic scopes the token to the rule's sole enabled workspace.
+
+:::note[Exchange each agent token once]
+Every <ProductName /> access token carries a `jti` claim, and Anthropic accepts an assertion with a `jti` only once per issuer. Request a fresh agent token for each exchange. A retry that re-sends a token it already presented is rejected, and the [authentication history](https://platform.claude.com/settings/workload-identity-federation?tab=history) records the reason as `jti_reused`.
+:::
+
+### Call the Claude API
+
+```bash
+curl -sS https://api.anthropic.com/v1/messages \
+  -H "authorization: Bearer $ACCESS_TOKEN" \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'content-type: application/json' \
+  --data '{
+    "model": "claude-opus-5",
+    "max_tokens": 1024,
+    "messages": [{"role": "user", "content": "write a 3 word sentence"}]
+  }'
+```
+
+## Use <ProductName /> with the Anthropic SDK
+
+The Anthropic SDKs can run the exchange for you. Supply an identity token provider that fetches the agent token from <ProductName />, and pass the rule, organization, and service account IDs alongside it.
+
+```python
+import os
+
+import requests
+from anthropic import Anthropic, WorkloadIdentityCredentials
+
+TOKEN_ENDPOINT = "https://localhost:8090/oauth2/token"
+
+
+def fetch_agent_token() -> str:
+    response = requests.post(
+        TOKEN_ENDPOINT,
+        data={"grant_type": "client_credentials"},
+        auth=(os.environ["AGENT_CLIENT_ID"], os.environ["AGENT_CLIENT_SECRET"]),
+        timeout=10,
+    )
+    response.raise_for_status()
+    return response.json()["access_token"]
+
+
+client = Anthropic(
+    credentials=WorkloadIdentityCredentials(
+        identity_token_provider=fetch_agent_token,
+        federation_rule_id=os.environ["ANTHROPIC_FEDERATION_RULE_ID"],
+        organization_id=os.environ["ANTHROPIC_ORGANIZATION_ID"],
+        service_account_id=os.environ["ANTHROPIC_SERVICE_ACCOUNT_ID"],
+        workspace_id=os.environ.get("ANTHROPIC_WORKSPACE_ID"),
+    ),
+)
+
+message = client.messages.create(
+    model="claude-opus-5",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "write a 3 word sentence"}],
+)
+
+print(next(block.text for block in message.content if block.type == "text"))
+```
+
+The SDK calls `fetch_agent_token` again whenever the Anthropic access token approaches expiry.
+
+:::note[Trusting the local certificate]
+In a local setup, <ProductName /> serves HTTPS with a self-signed certificate, so you need to trust the certificate in the shell where you run Python by setting `REQUESTS_CA_BUNDLE`. This prevents `requests` from raising an `SSLError` due to certificate verification.
+:::
+
+Store `AGENT_CLIENT_ID` and `AGENT_CLIENT_SECRET` in your secret manager, not in the image or the repository. An agent that must not hold a shared secret at all can authenticate with a signed assertion instead, which changes only how the identity token provider fetches the agent token. See [Agent Authentication](../../../agents/authentication).
+
+## Troubleshooting
+
+Every denied assertion returns the same opaque `401` `authentication_error` with the message `Authentication failed`, so the deny reason lives on the [authentication history page](https://platform.claude.com/settings/workload-identity-federation?tab=history) rather than in the response.
+
+| Symptom | Likely cause |
+|---|---|
+| `invalid_client` from <ProductName /> | Wrong client ID or secret, or the agent has no OAuth configuration. |
+| Deny reason `match_subject_prefix` | The token's `sub` differs from the rule's **subject claim**. Decode the token and compare it against the Agent ID. |
+| The history entry points at the audience | The token's `aud` is not `https://api.anthropic.com`. Check whether you have set the agent's default audience, and that the token request carries no `resource` parameter naming something else. |
+| The history entry points at the issuer or the signature | The token's `iss` does not equal the issuer's **Issuer URL** byte for byte, or the signing key rotated and the inline key set is stale. |
+| Deny reason `jti_reused` | The same agent token was exchanged twice. Request a new one for each exchange. |
+| Deny reason `workspace_id_required` | The rule is enabled for more than one workspace and the exchange named none. Send `workspace_id`. |
+| The exchange fails on the token lifetime | The agent token's `exp` minus `iat` exceeds the issuer's maximum, one hour by default. Lower **Token Validity** on the agent's **Tokens** tab, or raise the maximum on the issuer. |
+| A `401` with no history entry at all | The `federation_rule_id` was not recognized. Confirm it in the Claude Console and that the rule is not archived. |
+| `401` from `api.anthropic.com` | The Anthropic access token expired. Exchange again rather than caching it past `expires_in`. |
+| `403` from `api.anthropic.com` | The rule's OAuth scope is narrower than the call needs, or the service account is not a member of the rule's workspace. |
+
+## Next Steps
+
+- [Agent Token](../../../agents/authentication/agent-own-token)
+- [Agent Authentication](../../../agents/authentication)
+- [Create and Manage Agents](../../../agents/manage-agents)

--- a/docs/versioned_docs/version-v1.0.x/guides/integrations/workload-identity-federation/openai.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/integrations/workload-identity-federation/openai.mdx
@@ -1,0 +1,229 @@
+---
+title: Call OpenAI APIs with a {{ProductName}} Agent Identity
+docType: guide
+sidebar_position: 1
+persona: iam
+description: Federate a {{ProductName}} agent identity to OpenAI using workload identity federation, so an agent trades its own token for OpenAI access instead of holding a long-lived API key.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Call OpenAI APIs with a <ProductName /> Agent Identity
+
+OpenAI [workload identity federation](https://developers.openai.com/api/docs/guides/workload-identity-federation) accepts a signed token from an external issuer and returns a short-lived OpenAI access token in exchange. Point it at <ProductName /> and your agent reaches the OpenAI API with the identity it already has. No OpenAI API key sits in the agent's environment, no key is shared between agents, and disabling the agent in <ProductName /> ends its OpenAI access at the next exchange.
+
+This guide explains how to authenticate an agent to the OpenAI API using workload identity federation. The agent gets an [Agent Token](../../../agents/authentication/agent-own-token) from <ProductName />. OpenAI verifies that token and issues a short-lived access token of its own. The agent sends that access token on its API calls.
+
+See [Workload Identity Federation](../overview) for what federation replaces and how the exchange works, and [Agent Token](../../../agents/authentication/agent-own-token) for how <ProductName /> issues that token and what it carries.
+
+## Prerequisites
+
+- A running <ProductName /> instance. See [Get <ProductName />](../../../../getting-started/get-thunderid).
+- An OpenAI [developer account](https://platform.openai.com/) with access to Organization Settings.
+- `curl` and `jq` available in your terminal.
+
+## Create the Agent
+
+1. Sign in to the <ProductName /> Console at `https://localhost:8090/console`.
+2. Navigate to **Agents** → **New Agent**.
+3. Enter an **Agent Name** (for example `research-agent`).
+4. Select an owner for the agent.
+5. Click **Create Agent**.
+6. Note down the **Agent ID**, OpenAI matches on this value.
+7. Record the **Client ID** and **Client Secret**. The secret is shown once.
+
+A new agent has the `client_credentials` grant enabled, so it can already request a token for itself. See [Agent Token](../../../agents/authentication/agent-own-token) on how to get a token.
+
+:::note[Setting the audience]
+OpenAI matches the token's `aud` claim against the audience registered on the provider, so the agent token has to carry that value. You can configure a default audience value from the console, under agent's **Advanced** → **OAuth 2 Configuration** → **Default audience (aud)**.
+:::
+
+A `client_credentials` request that carries no `resource` parameter now produces a token whose `aud` claim is the value of default audience (for example `https://api.openai.com`). This is the value you register with OpenAI below.
+
+## Register <ProductName /> as a Workload Identity Provider
+
+OpenAI verifies the agent token against a key set it holds for your issuer. It can either fetch that key set from your discovery document or store a copy you upload. Discovery needs an issuer served over public HTTPS with no custom port, so a <ProductName /> instance on `https://localhost:8090` cannot be discovered and has to upload the key set instead.
+
+<Tabs groupId="thunderid-reachability">
+<TabItem value="public" label="Public instance" default>
+
+1. In the [OpenAI platform dashboard](https://platform.openai.com/), navigate to **Settings** → **Organization settings** → **Security** → **Workload Identity Provider**.
+2. Click **Create identity provider**.
+3. Enter a **Name**, for example **<ProductName />**, and select **OIDC** as the provider type.
+4. Set **Issuer URL** to your <ProductName /> URL, for example `https://id.example.com`. This must equal the `jwt.issuer` value in `deployment.yaml`, which defaults to the server URL.
+5. Set **Audience** to the agent's default audience, `https://api.openai.com`.
+6. Leave the discovery settings untouched. Or you can configure a custom OIDC discovery URL by turning on **Use custom URL for OIDC discovery**.
+7. Click **Create**, then record the provider ID, a string such as `idp_a1B2c3D4e5F6g7H8i9J0kLmN`.
+
+A signing key rotation needs no change on the OpenAI side, because OpenAI refreshes the key set itself when it meets a `kid` it does not hold.
+
+</TabItem>
+<TabItem value="local" label="Local instance">
+
+1. Export the <ProductName /> signing keys. Keep the full response, including the surrounding `keys` array. 
+    ```bash
+    curl -sk https://localhost:8090/oauth2/jwks
+    ```
+2. In the [OpenAI platform dashboard](https://platform.openai.com/), navigate to **Settings** → **Organization settings** → **Security** → **Workload Identity Provider**.
+3. Click **Create identity provider**.
+4. Enter a **Name**, for example **<ProductName />**, and select **OIDC** as the provider type.
+5. Set **Issuer URL** to `https://localhost:8090`. This must equal the `jwt.issuer` value in `deployment.yaml`, which defaults to the server URL.
+6. Set **Audience** to the agent's default audience, `https://api.openai.com`.
+7. Turn on **Use uploaded JWKS for token verification**, then paste the JWKS JSON from step 1.
+8. Click **Create**, then record the provider ID, a string such as `idp_a1B2c3D4e5F6g7H8i9J0kLmN`.
+
+:::warning[Re-upload the key set after a key rotation]
+An uploaded JWKS is a snapshot. OpenAI saves this and performs no discovery against the issuer, so rotating the <ProductName /> signing key invalidates new tokens until you upload the new key set.
+:::
+
+</TabItem>
+</Tabs>
+
+## Map the Agent to a Service Account
+
+The provider establishes which issuer OpenAI trusts. A service account mapping decides which OpenAI identity a given token may assume. Match on the `sub` claim: it carries the agent's ID, it is unique to that agent, and it survives a client secret rotation.
+
+1. Open the provider you created, then click on **create mapping**.
+2. Enter a **Name**, for example `mapping-research-agent`.
+3. Under the key value section, Set **Key** to `sub` and use the **Agent ID** as the value. You can add additional claim mappings if needed.
+4. Select the **Project** and the **Service Account** the agent acts as.
+5. Set **Permissions** to the narrowest scope set the agent needs, or leave it unrestricted to inherit the service account's own access.
+6. Save the mapping, then record the service account ID, a string such as `user-Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8`.
+
+Give each agent its own mapping, and keep the values distinct. OpenAI rejects an exchange when more than one enabled mapping matches it.
+
+## Run the Flow
+
+### Request the Agent Token
+
+Send a `client_credentials` request with the agent's credentials:
+
+```bash
+TOKEN_RESPONSE=$(curl -X POST https://localhost:8090/oauth2/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -u '<CLIENT_ID>:<CLIENT_SECRET>' \
+  -d 'grant_type=client_credentials')
+
+AGENT_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r .access_token)
+```
+
+You can inspect the claims before you exchange the token if needed. Following three claims decide whether the exchange succeeds:
+
+| Claim | Expected value |
+|---|---|
+| `iss` | The **Issuer URL** on the provider, for example `https://localhost:8090`. |
+| `aud` | The **Audience** on the provider, which is the agent's default audience. |
+| `sub` | The **Value** on the mapping, which is the Agent ID. |
+
+See [Agent Token](../../../agents/authentication/agent-own-token) for a detailed explanation on getting an agent token.
+
+### Exchange the Token at OpenAI
+
+```bash
+ACCESS_TOKEN=$(curl -s https://auth.openai.com/oauth/token \
+  -H 'content-type: application/json' \
+  --data '{
+    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+    "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    "subject_token": "'"$AGENT_TOKEN"'",
+    "identity_provider_id": "<IDENTITY_PROVIDER_ID>",
+    "service_account_id": "<SERVICE_ACCOUNT_ID>"
+  }' | jq -r .access_token)
+```
+
+OpenAI returns an access token that lasts at most 3600 seconds:
+
+```json
+{
+  "access_token": "<ACCESS_TOKEN>",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
+
+The exchange assumes an existing service account. It never creates a principal, a project, or a workspace membership, so an agent reaches only what you granted that service account beforehand.
+
+### Call the OpenAI API
+
+```bash
+curl -s https://api.openai.com/v1/responses \
+  -H "authorization: Bearer $ACCESS_TOKEN" \
+  -H 'content-type: application/json' \
+  --data '{
+    "model": "gpt-5.4-mini",
+    "input": "write a 3 word sentence",
+    "store": true
+  }'
+```
+
+## Use <ProductName /> with OpenAI SDK
+
+The OpenAI SDKs can run the exchange for you. Supply a subject token provider that fetches the agent token from <ProductName />, and pass the provider ID and service account ID alongside it.
+
+The `workload_identity` option is available in the OpenAI Python SDK from version 2.31.0 onwards, so install `openai>=2.31.0` before you run the example below.
+
+```python
+import os
+
+import requests
+from openai import OpenAI
+from openai.auth import SubjectTokenProvider
+
+TOKEN_ENDPOINT = "https://localhost:8090/oauth2/token"
+
+
+def thunderid_agent_token_provider() -> SubjectTokenProvider:
+    def get_token() -> str:
+        response = requests.post(
+            TOKEN_ENDPOINT,
+            data={"grant_type": "client_credentials"},
+            auth=(os.environ["AGENT_CLIENT_ID"], os.environ["AGENT_CLIENT_SECRET"]),
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()["access_token"]
+
+    return {"token_type": "jwt", "get_token": get_token}
+
+
+client = OpenAI(
+    workload_identity={
+        "identity_provider_id": os.environ["OPENAI_IDENTITY_PROVIDER_ID"],
+        "service_account_id": os.environ["OPENAI_SERVICE_ACCOUNT_ID"],
+        "provider": thunderid_agent_token_provider(),
+    },
+)
+
+response = client.responses.create(
+    model="gpt-5.4-mini",
+    input="write a 3 word sentence",
+)
+
+print(response.output_text)
+```
+
+:::note[Trusting the local certificate]
+In a local setup, <ProductName /> serves HTTPS with a self-signed certificate, so you need to trust the certificate in the shell where you run Python by setting `REQUESTS_CA_BUNDLE`. This prevents `requests` from raising an `SSLError` due to certificate verification.
+:::
+
+Store `AGENT_CLIENT_ID` and `AGENT_CLIENT_SECRET` in your secret manager, not in the image or the repository. An agent that must not hold a shared secret at all can authenticate with a signed assertion instead, which changes only how the subject token provider fetches the agent token. See [Agent Authentication](../../../agents/authentication).
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `invalid_client` from <ProductName /> | Wrong client ID or secret, or the agent has no OAuth configuration. |
+| `invalid_subject_token` from OpenAI | The agent token expired, its `iss` does not match the provider's issuer URL, or the signing key rotated and the uploaded JWKS is stale. |
+| The exchange fails on the audience | The token's `aud` is not the audience on the provider. Check whether you have configured the default audience in <ProductName />. |
+| No mapping matched the exchange | The token's `sub` differs from the **Value** on the mapping. Decode the token and compare it against the Agent ID. |
+| Several mappings matched the exchange | Two enabled mappings on the provider accept the same token. Disable the extra one. |
+| `401` from `api.openai.com` | The OpenAI access token expired. It lasts at most 3600 seconds, so exchange again rather than caching it longer. |
+| `403` from `api.openai.com` | The mapping's permissions are narrower than the call needs, or the service account has no access to the project. |
+
+## Next Steps
+
+- [Agent Token](../../../agents/authentication/agent-own-token)
+- [Agent Authentication](../../../agents/authentication)
+- [Create and Manage Agents](../../../agents/manage-agents)

--- a/docs/versioned_docs/version-v1.0.x/guides/integrations/workload-identity-federation/overview.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/integrations/workload-identity-federation/overview.mdx
@@ -1,0 +1,67 @@
+---
+title: Workload Identity Federation
+docType: concept
+sidebar_position: 0
+description: A workload presents its {{ProductName}} token to an external platform and receives that platform's own short-lived credential in return, instead of holding a long-lived API key.
+---
+
+# Workload Identity Federation
+
+Workload identity federation lets a workload access a platform without storing a long-lived credential, using a token from an issuer that platform already trusts. The workload presents a signed token from its own identity provider, and the platform returns a short-lived credential of its own.
+
+For <ProductName />, a workload is any confidential client that can use the client credentials grant. That is an [agent](../../../agents), such as an AI assistant, or an [application](../../../applications/manage-applications), such as a backend service. Either one presents the access token it already gets for itself.
+
+Select a platform to get a step-by-step integration guide with <ProductName />.
+
+| Platform | Guide |
+|---|---|
+| OpenAI | [Call OpenAI APIs with a <ProductName /> Agent Identity](../openai) |
+| Anthropic | [Call the Claude API with a <ProductName /> Agent Identity](../claude) |
+
+## What It Replaces
+
+The alternative is a static API key that the platform issues once and you copy into the workload's environment. Such a key:
+
+- Does not expire, so a leaked copy stays valid until somebody notices and rotates it.
+- If multiple workloads share the same key, the platform generally cannot distinguish them from the credential alone.
+- Sits outside the workload's lifecycle, so deleting the agent or application in <ProductName /> leaves its access to the platform intact.
+
+Federation removes this static key. The workload proves who it is to <ProductName /> with the credential it already holds, and every platform credential it receives afterwards is short-lived and traceable to its <ProductName /> identity.
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant W as Workload
+    participant TID as ThunderID
+    participant P as External platform
+    participant API as Platform API
+    W->>TID: client_credentials with client ID and secret
+    TID-->>W: Signed JWT (its own access token)
+    W->>P: Token exchange with signed JWT
+    P->>P: Verify the signature against ThunderID's public keys
+    P->>P: Match the claims against a mapping rule
+    P-->>W: Platform access token (short-lived)
+    W->>API: Request with the access token as a bearer token
+    API-->>W: Response
+```
+
+- **The workload authenticates to <ProductName />.** The [client credentials grant](../../../protocols/oauth-oidc/client-credentials) returns a signed JWT whose `sub` claim is the workload's own ID.
+- **The workload exchanges that token at the platform.** The exchange usually follows [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693), carrying the <ProductName /> token as the subject token.
+- **The platform verifies the token.** It reads <ProductName />'s public keys, either from the JWKS endpoint or from a copy uploaded during setup, then checks the signature and the `iss`, `aud`, and `exp` claims.
+- **The platform resolves one of its own identities.** A mapping rule maps one or more claims, often `sub`, sometimes together with `iss` or other attributes, against values you registered.
+- **The platform issues a short-lived access token.** The token belongs to that account, expires on a lifetime the platform sets, and is narrowed to any permissions the mapping rule restricts it to.
+- **The workload calls the platform's API.** It sends that token as a bearer token, and repeats the exchange once the token expires.
+
+## Reaching Your Public Keys
+
+A platform needs <ProductName />'s public keys to verify a signature, and there are two ways to give it them. It can retrieve the JWKS directly from `/oauth2/jwks`, or discover the JWKS URL from `/.well-known/openid-configuration`. That keeps the keys current through a rotation, but it requires the instance to be reachable over public HTTPS.
+
+Otherwise you upload a copy during setup, which is the option for an instance that runs locally or inside a private network. The copy is a snapshot, so rotating the signing key breaks every exchange until you upload the new key set.
+
+## Related
+
+- [Agent Token](../../../agents/authentication/agent-own-token)
+- [Client Credentials](../../../protocols/oauth-oidc/client-credentials)
+- [Agents](../../../agents)
+- [Manage Applications](../../../applications/manage-applications)

--- a/docs/versioned_sidebars/version-v1.0.x-sidebars.json
+++ b/docs/versioned_sidebars/version-v1.0.x-sidebars.json
@@ -937,6 +937,30 @@
                   "label": "KrakenD"
                 }
               ]
+            },
+            {
+              "type": "category",
+              "label": "Workload Identity Federation",
+              "collapsed": true,
+              "collapsible": true,
+              "items": [
+                {
+                  "type": "doc",
+                  "id": "guides/integrations/workload-identity-federation/overview",
+                  "label": "Overview",
+                  "key": "wif-overview"
+                },
+                {
+                  "type": "doc",
+                  "id": "guides/integrations/workload-identity-federation/openai",
+                  "label": "OpenAI"
+                },
+                {
+                  "type": "doc",
+                  "id": "guides/integrations/workload-identity-federation/claude",
+                  "label": "Claude"
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
### Purpose
Adds documentation for workload identity federation under **Guides → Integrations**, so a workload
(agent or application) can reach an external platform's API using its own ThunderID token instead of
a long-lived, static API key.

Fixes #3812 
Fixes #3813 

Two new pages:

- **Overview** (`guides/integrations/workload-identity-federation/overview`) - a concept page covering
  what federation replaces, the token-exchange flow (with a sequence diagram), and the two ways a
  platform can reach ThunderID's public keys (JWKS discovery vs. an uploaded key set).
- **OpenAI** (`guides/integrations/workload-identity-federation/openai`) - a step-by-step guide for
  registering ThunderID as an OpenAI workload identity provider, creating the agent, setting the
  audience, and exchanging the agent token for a short-lived OpenAI access token.
- **Anthropic** (`guides/integrations/workload-identity-federation/claude.mdx`) - a step-by-step guide for integrating ThunderID with Claude workload identity provider (similar to openAI guide)

### Approach
- New docs live under `docs/content/guides/integrations/workload-identity-federation/`, with the same
  pages mirrored into `docs/versioned_docs/version-v1.0.x/` so they appear in the current released version.
- Sidebar entries added to both `docs/sidebars.ts` and `docs/versioned_sidebars/version-v1.0.x-sidebars.json`
  as a collapsible **Workload Identity Federation** category alongside the existing integration guides.
- The OpenAI guide uses tabs to split setup between a publicly reachable instance (OIDC discovery) and a
  local or private instance (uploaded key set), since OpenAI cannot discover an issuer on `localhost`.
- Docs-only change. No ThunderID-side configuration is required for the OpenAI flow — it reuses the
  existing client credentials grant and agent token.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a Workload Identity Federation overview covering token exchange, short-lived credentials, key discovery, claim mapping, and replacing static API keys.
  - Added OpenAI and Claude integration guides with setup instructions, authentication flows, API usage examples, SDK configuration, local certificate or key handling, and troubleshooting guidance.
  - Added Workload Identity Federation pages to the current and versioned Integrations documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->