### PR TITLE
Add current password validation to self-service credential updates

### DIFF
--- a/api/user.yaml
+++ b/api/user.yaml
@@ -1347,8 +1347,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateSelfUserRequest'
+              $ref: '#/components/schemas/UpdateSelfCredentialsRequest'
             example:
+              currentPassword: "0ldP@ssword!"
               attributes:
                 password: "n3wP@ssword!"
       responses:
@@ -1371,6 +1372,16 @@ paths:
                     description:
                       key: "error.userservice.missing_credentials_description"
                       defaultValue: "At least one credential field must be provided"
+                unsupported-credential-type:
+                  summary: A credential type other than password was supplied
+                  value:
+                    code: "USR-1024"
+                    message:
+                      key: "error.userservice.invalid_credential"
+                      defaultValue: "Invalid request format"
+                    description:
+                      key: "error.userservice.invalid_credential_description"
+                      defaultValue: "Invalid credential fields in request"
         "401":
           description: Unauthorized - missing or invalid authentication token
           content:
@@ -1385,6 +1396,20 @@ paths:
                 description:
                   key: "error.unauthorized_description"
                   defaultValue: "Authentication is required to access this resource"
+        "403":
+          description: Forbidden - the supplied current password is incorrect
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "USR-1029"
+                message:
+                  key: "error.userservice.invalid_current_password"
+                  defaultValue: "Invalid current password"
+                description:
+                  key: "error.userservice.invalid_current_password_description"
+                  defaultValue: "The provided current password is incorrect"
         "404":
           description: Authenticated user not found
           content:
@@ -2190,6 +2215,27 @@ components:
           type: object
           description: "User attributes"
           additionalProperties: true
+
+    UpdateSelfCredentialsRequest:
+      type: object
+      required: [attributes]
+      properties:
+        currentPassword:
+          type: string
+          format: password
+          description: "The user's existing password, verified before the write. Required once the account has a password. Omit it for a first-time set, on an account with no password yet."
+          example: "0ldP@ssword!"
+        attributes:
+          type: object
+          description: "Credential attributes to write. Only `password` is accepted here; other types are rejected with 400 USR-1024."
+          required: [password]
+          properties:
+            password:
+              type: string
+              format: password
+              description: "The new password to set."
+              example: "n3wP@ssword!"
+          additionalProperties: false
 
     UpdateUserCredentialsRequest:
       type: object

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -1073,6 +1073,8 @@ var defaultMessages = map[string]string{
 	"error.userservice.handle_path_required_description": "Handle path is required for this operation",
 	"error.userservice.invalid_credential": "Invalid request format",
 	"error.userservice.invalid_credential_description": "Invalid credential fields in request",
+	"error.userservice.invalid_current_password": "Invalid current password",
+	"error.userservice.invalid_current_password_description": "The provided current password is incorrect",
 	"error.userservice.invalid_filter_parameter": "Invalid filter parameter",
 	"error.userservice.invalid_filter_parameter_description": "The filter format is invalid",
 	"error.userservice.invalid_handle_path": "Invalid handle path",

--- a/backend/internal/user/UserServiceInterface_mock_test.go
+++ b/backend/internal/user/UserServiceInterface_mock_test.go
@@ -826,6 +826,77 @@ func (_c *UserServiceInterfaceMock_SetDependencyRegistry_Call) RunAndReturn(run 
 	return _c
 }
 
+// UpdateSelfUserPassword provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) UpdateSelfUserPassword(ctx context.Context, userID string, currentPassword string, credentials json.RawMessage) *common.ServiceError {
+	ret := _mock.Called(ctx, userID, currentPassword, credentials)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateSelfUserPassword")
+	}
+
+	var r0 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, json.RawMessage) *common.ServiceError); ok {
+		r0 = returnFunc(ctx, userID, currentPassword, credentials)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.ServiceError)
+		}
+	}
+	return r0
+}
+
+// UserServiceInterfaceMock_UpdateSelfUserPassword_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateSelfUserPassword'
+type UserServiceInterfaceMock_UpdateSelfUserPassword_Call struct {
+	*mock.Call
+}
+
+// UpdateSelfUserPassword is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+//   - currentPassword string
+//   - credentials json.RawMessage
+func (_e *UserServiceInterfaceMock_Expecter) UpdateSelfUserPassword(ctx interface{}, userID interface{}, currentPassword interface{}, credentials interface{}) *UserServiceInterfaceMock_UpdateSelfUserPassword_Call {
+	return &UserServiceInterfaceMock_UpdateSelfUserPassword_Call{Call: _e.mock.On("UpdateSelfUserPassword", ctx, userID, currentPassword, credentials)}
+}
+
+func (_c *UserServiceInterfaceMock_UpdateSelfUserPassword_Call) Run(run func(ctx context.Context, userID string, currentPassword string, credentials json.RawMessage)) *UserServiceInterfaceMock_UpdateSelfUserPassword_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 json.RawMessage
+		if args[3] != nil {
+			arg3 = args[3].(json.RawMessage)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_UpdateSelfUserPassword_Call) Return(serviceError *common.ServiceError) *UserServiceInterfaceMock_UpdateSelfUserPassword_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_UpdateSelfUserPassword_Call) RunAndReturn(run func(ctx context.Context, userID string, currentPassword string, credentials json.RawMessage) *common.ServiceError) *UserServiceInterfaceMock_UpdateSelfUserPassword_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateUser provides a mock function for the type UserServiceInterfaceMock
 func (_mock *UserServiceInterfaceMock) UpdateUser(ctx context.Context, userID string, user *providers.User) (*providers.User, *common.ServiceError) {
 	ret := _mock.Called(ctx, userID, user)

--- a/backend/internal/user/constants.go
+++ b/backend/internal/user/constants.go
@@ -14,6 +14,11 @@ const (
 	CredentialTypePasskey CredentialType = "passkey"
 )
 
+// CredentialTypePassword is the schema-defined password credential. It is not system-managed, but
+// it is named here because it acts as the account-level proof of ownership when a user changes
+// their own credentials.
+const CredentialTypePassword CredentialType = "password"
+
 // systemManagedCredentialTypes defines credential types that are managed by the system,
 // not through user types. These may support multiple values per user.
 var systemManagedCredentialTypes = []CredentialType{

--- a/backend/internal/user/error_constants.go
+++ b/backend/internal/user/error_constants.go
@@ -141,6 +141,20 @@ var (
 			DefaultValue: "At least one identifying attribute must be provided",
 		},
 	}
+	// ErrorInvalidCurrentPassword is returned when the authenticated user's supplied current
+	// password does not match the stored credential.
+	ErrorInvalidCurrentPassword = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "USR-1029",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.userservice.invalid_current_password",
+			DefaultValue: "Invalid current password",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key:          "error.userservice.invalid_current_password_description",
+			DefaultValue: "The provided current password is incorrect",
+		},
+	}
 	// ErrorMissingCredentials is the error returned when credentials are missing.
 	ErrorMissingCredentials = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -459,7 +459,7 @@ func (uh *userHandler) HandleSelfUserCredentialUpdateRequest(w http.ResponseWrit
 		return
 	}
 
-	updateRequest, err := sysutils.DecodeJSONBody[UpdateSelfUserRequest](r)
+	updateRequest, err := sysutils.DecodeJSONBody[UpdateSelfCredentialsRequest](r)
 	if err != nil {
 		var valErr *sysutils.ValidationError
 		if errors.As(err, &valErr) {
@@ -479,7 +479,8 @@ func (uh *userHandler) HandleSelfUserCredentialUpdateRequest(w http.ResponseWrit
 		return
 	}
 
-	if svcErr := uh.userService.UpdateUserCredentials(ctx, userID, updateRequest.Attributes); svcErr != nil {
+	if svcErr := uh.userService.UpdateSelfUserPassword(
+		ctx, userID, updateRequest.CurrentPassword, updateRequest.Attributes); svcErr != nil {
 		handleError(ctx, w, svcErr)
 		return
 	}
@@ -578,7 +579,8 @@ func handleError(ctx context.Context, w http.ResponseWriter, svcErr *tidcommon.S
 			statusCode = http.StatusBadRequest
 		case ErrorAuthenticationFailed.Code:
 			statusCode = http.StatusUnauthorized
-		case tidcommon.ErrorUnauthorized.Code:
+		case tidcommon.ErrorUnauthorized.Code,
+			ErrorInvalidCurrentPassword.Code:
 			statusCode = http.StatusForbidden
 		default:
 			statusCode = http.StatusBadRequest

--- a/backend/internal/user/handler_test.go
+++ b/backend/internal/user/handler_test.go
@@ -145,7 +145,7 @@ func TestHandleSelfUserCredentialUpdateRequest_Success(t *testing.T) {
 
 	mockSvc := NewUserServiceInterfaceMock(t)
 	credentialsJSON := json.RawMessage(`{"password":[{"value":"Secret123!"}]}`)
-	mockSvc.On("UpdateUserCredentials", mock.Anything, userID, credentialsJSON).Return(nil)
+	mockSvc.On("UpdateSelfUserPassword", mock.Anything, userID, "", credentialsJSON).Return(nil)
 
 	handler := newUserHandler(mockSvc)
 	req := httptest.NewRequest(http.MethodPost, "/users/me/update-credentials",
@@ -165,7 +165,7 @@ func TestHandleSelfUserCredentialUpdateRequest_StringValue(t *testing.T) {
 
 	mockSvc := NewUserServiceInterfaceMock(t)
 	credentialsJSON := json.RawMessage(`{"password":"plaintext-password"}`)
-	mockSvc.On("UpdateUserCredentials", mock.Anything, userID, credentialsJSON).Return(nil)
+	mockSvc.On("UpdateSelfUserPassword", mock.Anything, userID, "", credentialsJSON).Return(nil)
 
 	handler := newUserHandler(mockSvc)
 	req := httptest.NewRequest(http.MethodPost, "/users/me/update-credentials",
@@ -241,7 +241,7 @@ func TestHandleSelfUserCredentialUpdateRequest_ErrorCases(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockSvc := NewUserServiceInterfaceMock(t)
-			mockSvc.On("UpdateUserCredentials", mock.Anything, userID, tc.mockJSON).Return(tc.mockError)
+			mockSvc.On("UpdateSelfUserPassword", mock.Anything, userID, "", tc.mockJSON).Return(tc.mockError)
 
 			handler := newUserHandler(mockSvc)
 			req := httptest.NewRequest(http.MethodPost, "/users/me/update-credentials",
@@ -267,7 +267,7 @@ func TestHandleSelfUserCredentialUpdateRequest_MultipleCredentialTypes(t *testin
 	mockSvc := NewUserServiceInterfaceMock(t)
 	// Test that multiple credential types are updated in a single atomic call
 	credentialsJSON := json.RawMessage(`{"password":"new-password","pin":"1234"}`)
-	mockSvc.On("UpdateUserCredentials", mock.Anything, userID, credentialsJSON).Return(nil)
+	mockSvc.On("UpdateSelfUserPassword", mock.Anything, userID, "", credentialsJSON).Return(nil)
 
 	handler := newUserHandler(mockSvc)
 	req := httptest.NewRequest(http.MethodPost, "/users/me/update-credentials",
@@ -279,8 +279,8 @@ func TestHandleSelfUserCredentialUpdateRequest_MultipleCredentialTypes(t *testin
 
 	require.Equal(t, http.StatusNoContent, rr.Code)
 	require.Equal(t, 0, rr.Body.Len())
-	// Verify that UpdateUserCredentials was called exactly once with all credentials
-	mockSvc.AssertNumberOfCalls(t, "UpdateUserCredentials", 1)
+	// Verify that UpdateSelfUserPassword was called exactly once with all credentials
+	mockSvc.AssertNumberOfCalls(t, "UpdateSelfUserPassword", 1)
 }
 
 func TestHandleUserCredentialUpdateRequest_Success(t *testing.T) {
@@ -1341,4 +1341,79 @@ func TestHandleSelfUserMetadataGetRequest_ServiceError(t *testing.T) {
 	handler.HandleSelfUserMetadataGetRequest(rr, req)
 
 	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Self credential update – current-password plumbing
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleSelfUserCredentialUpdateRequest_ForwardsCurrentPassword(t *testing.T) {
+	userID := testUserID789
+	authCtx := security.NewSecurityContextForTest(userID, "", "", nil, nil)
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	credentialsJSON := json.RawMessage(`{"password":"n3wP@ssword!"}`)
+	mockSvc.
+		On("UpdateSelfUserPassword", mock.Anything, userID, "0ldP@ssword!", credentialsJSON).
+		Return(nil)
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPost, "/users/me/update-credentials",
+		bytes.NewBufferString(`{"currentPassword":"0ldP@ssword!","attributes":{"password":"n3wP@ssword!"}}`))
+	req = req.WithContext(security.WithSecurityContextTest(req.Context(), authCtx))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserCredentialUpdateRequest(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code)
+	mockSvc.AssertNumberOfCalls(t, "UpdateSelfUserPassword", 1)
+}
+
+func TestHandleSelfUserCredentialUpdateRequest_InvalidCurrentPasswordReturns403(t *testing.T) {
+	userID := testUserID789
+	authCtx := security.NewSecurityContextForTest(userID, "", "", nil, nil)
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	mockSvc.
+		On("UpdateSelfUserPassword", mock.Anything, userID, "wrong", mock.Anything).
+		Return(&ErrorInvalidCurrentPassword)
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPost, "/users/me/update-credentials",
+		bytes.NewBufferString(`{"currentPassword":"wrong","attributes":{"password":"n3wP@ssword!"}}`))
+	req = req.WithContext(security.WithSecurityContextTest(req.Context(), authCtx))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserCredentialUpdateRequest(rr, req)
+
+	// 403 is what the SDK maps onto the current-password field, distinct from 401's
+	// "re-authenticate" meaning, so the status matters.
+	require.Equal(t, http.StatusForbidden, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, ErrorInvalidCurrentPassword.Code, errResp.Code)
+}
+
+// Guards the console's admin reset flow: it must keep calling UpdateUserCredentials, never the
+// verifying self variant, since an admin can't know the target user's current password.
+func TestHandleUserCredentialUpdateRequest_DoesNotRequireCurrentPassword(t *testing.T) {
+	userID := testUserID789
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	credentialsJSON := json.RawMessage(`{"password":"admin-reset-password"}`)
+	mockSvc.On("UpdateUserCredentials", mock.Anything, userID, credentialsJSON).Return(nil)
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPost, "/users/"+userID+"/update-credentials",
+		bytes.NewBufferString(`{"credentials":{"password":"admin-reset-password"}}`))
+	req.SetPathValue("id", userID)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserCredentialUpdateRequest(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code)
+	mockSvc.AssertNumberOfCalls(t, "UpdateUserCredentials", 1)
+	mockSvc.AssertNotCalled(t, "UpdateSelfUserPassword",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }

--- a/backend/internal/user/model.go
+++ b/backend/internal/user/model.go
@@ -70,6 +70,14 @@ type UpdateSelfUserRequest struct {
 	Attributes json.RawMessage `json:"attributes,omitempty"`
 }
 
+// UpdateSelfCredentialsRequest represents the request body for the authenticated user changing
+// their own credentials. CurrentPassword is a sibling of Attributes, not a member of it, since the
+// entity layer only accepts schema-declared credential keys inside Attributes.
+type UpdateSelfCredentialsRequest struct {
+	CurrentPassword string          `json:"currentPassword,omitempty"`
+	Attributes      json.RawMessage `json:"attributes,omitempty"`
+}
+
 // UpdateUserCredentialsRequest represents the request body for updating user credentials by an admin.
 type UpdateUserCredentialsRequest struct {
 	Credentials json.RawMessage `json:"credentials,omitempty"`

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -47,6 +47,8 @@ type UserServiceInterface interface {
 	GetUserMetadata(ctx context.Context, userID string) (*entitytype.EntityType, *tidcommon.ServiceError)
 	UpdateUserCredentials(ctx context.Context, userID string,
 		credentials json.RawMessage) *tidcommon.ServiceError
+	UpdateSelfUserPassword(ctx context.Context, userID string, currentPassword string,
+		credentials json.RawMessage) *tidcommon.ServiceError
 	DeleteUser(ctx context.Context, userID string) *tidcommon.ServiceError
 	ValidateDeleteUser(ctx context.Context, userID string) *tidcommon.ServiceError
 	ResolveUserOUHandle(ctx context.Context, user *providers.User) *tidcommon.ServiceError
@@ -685,6 +687,86 @@ func (us *userService) UpdateUserAttributes(
 
 	logger.Debug(ctx, "Successfully updated user attributes", log.MaskedString(log.LoggerKeyUserID, userID))
 	return &existingUser, nil
+}
+
+// UpdateSelfUserPassword updates the authenticated user's own password after verifying their
+// current one. Kept separate from UpdateUserCredentials (the admin reset path), since an admin
+// can't supply the target's current password.
+// A user with no password stored yet is treated as a first-time set.
+func (us *userService) UpdateSelfUserPassword(
+	ctx context.Context,
+	userID string,
+	currentPassword string,
+	credentials json.RawMessage,
+) *tidcommon.ServiceError {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+
+	if strings.TrimSpace(userID) == "" {
+		return &ErrorAuthenticationFailed
+	}
+
+	if svcErr := validateSelfCredentialPayload(credentials); svcErr != nil {
+		return svcErr
+	}
+
+	stored, err := us.entityService.GetCredentialsByType(ctx, userID, string(CredentialTypePassword))
+	if err != nil {
+		if errors.Is(err, entity.ErrEntityNotFound) {
+			return &ErrorUserNotFound
+		}
+		return logErrorAndReturnServerError(ctx, logger, "Failed to read stored credentials", err,
+			log.MaskedString(log.LoggerKeyUserID, userID))
+	}
+
+	if len(stored) > 0 {
+		if strings.TrimSpace(currentPassword) == "" {
+			return &ErrorInvalidCurrentPassword
+		}
+
+		_, authErr := us.entityService.AuthenticateEntityByID(
+			ctx, userID, map[string]interface{}{string(CredentialTypePassword): currentPassword})
+		if authErr != nil {
+			switch {
+			case errors.Is(authErr, entity.ErrAuthenticationFailed):
+				logger.Debug(ctx, "Current password verification failed",
+					log.MaskedString(log.LoggerKeyUserID, userID))
+				return &ErrorInvalidCurrentPassword
+			case errors.Is(authErr, entity.ErrEntityNotFound):
+				return &ErrorUserNotFound
+			default:
+				return logErrorAndReturnServerError(ctx, logger, "Failed to verify current password", authErr,
+					log.MaskedString(log.LoggerKeyUserID, userID))
+			}
+		}
+	}
+
+	return us.UpdateUserCredentials(ctx, userID, credentials)
+}
+
+// validateSelfCredentialPayload restricts a self-service credential write to the password.
+// Rejecting anything else is checked before the stored password is read, so an invalid payload
+// costs no lookup and reveals nothing about whether the account has a password set.
+func validateSelfCredentialPayload(credentials json.RawMessage) *tidcommon.ServiceError {
+	if len(credentials) == 0 {
+		return &ErrorMissingCredentials
+	}
+
+	var credentialsMap map[string]json.RawMessage
+	if err := json.Unmarshal(credentials, &credentialsMap); err != nil {
+		return &ErrorInvalidRequestFormat
+	}
+
+	if len(credentialsMap) == 0 {
+		return &ErrorMissingCredentials
+	}
+
+	for credType := range credentialsMap {
+		if CredentialType(credType) != CredentialTypePassword {
+			return &ErrorInvalidCredential
+		}
+	}
+
+	return nil
 }
 
 // UpdateUserCredentials updates schema-defined credentials for a user.

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -3923,3 +3923,286 @@ func TestGetUserMetadata_GetEntityTypeSchemaError(t *testing.T) {
 	require.NotNil(t, svcErr)
 	require.Equal(t, entitytype.ErrorEntityTypeNotFound.Code, svcErr.Code)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UpdateSelfUserPassword – current-password verification
+// ─────────────────────────────────────────────────────────────────────────────
+
+// storedPasswordCredential returns a stored credential value standing in for a hashed password.
+// The hash is never inspected: AuthenticateEntityByID is mocked, so only its presence matters.
+func storedPasswordCredential() []entitypkg.StoredCredential {
+	return []entitypkg.StoredCredential{{Value: "hashed-current-password"}}
+}
+
+func TestUserService_UpdateSelfUserPassword_RejectsMissingUserID(t *testing.T) {
+	service := &userService{}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), "", "0ldP@ss", json.RawMessage(`{"password":"n3wP@ss"}`))
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorAuthenticationFailed, *err)
+}
+
+func TestUserService_UpdateSelfUserPassword_RejectsWrongCurrentPassword(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.
+		On("GetCredentialsByType", mock.Anything, svcTestUserID1, "password").
+		Return(storedPasswordCredential(), nil).
+		Once()
+	entityMock.
+		On("AuthenticateEntityByID", mock.Anything, svcTestUserID1,
+			map[string]interface{}{"password": "wrong-password"}).
+		Return(nil, entitypkg.ErrAuthenticationFailed).
+		Once()
+
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "wrong-password", json.RawMessage(`{"password":"n3wP@ss"}`))
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorInvalidCurrentPassword, *err)
+	// The write must not be attempted when verification fails.
+	entityMock.AssertNotCalled(t, "UpdateCredentials", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUserService_UpdateSelfUserPassword_RejectsEmptyCurrentPasswordWhenOneIsSet(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.
+		On("GetCredentialsByType", mock.Anything, svcTestUserID1, "password").
+		Return(storedPasswordCredential(), nil).
+		Once()
+
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "   ", json.RawMessage(`{"password":"n3wP@ss"}`))
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorInvalidCurrentPassword, *err)
+	// Verification is skipped entirely when nothing was supplied.
+	entityMock.AssertNotCalled(t, "AuthenticateEntityByID",
+		mock.Anything, mock.Anything, mock.Anything)
+	entityMock.AssertNotCalled(t, "UpdateCredentials", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUserService_UpdateSelfUserPassword_WritesWhenCurrentPasswordMatches(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.On("IsEntityDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	entityMock.
+		On("GetCredentialsByType", mock.Anything, svcTestUserID1, "password").
+		Return(storedPasswordCredential(), nil).
+		Once()
+	entityMock.
+		On("AuthenticateEntityByID", mock.Anything, svcTestUserID1,
+			map[string]interface{}{"password": "0ldP@ss"}).
+		Return(&entitypkg.AuthenticateResult{EntityID: svcTestUserID1}, nil).
+		Once()
+	entityMock.
+		On("GetEntity", mock.Anything, svcTestUserID1).
+		Return(&providers.Entity{
+			Category: providers.EntityCategoryUser, ID: svcTestUserID1, Type: "Person",
+		}, nil).
+		Once()
+	entityMock.
+		On("UpdateCredentials", mock.Anything, svcTestUserID1, mock.Anything).
+		Return(nil).
+		Once()
+
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "0ldP@ss", json.RawMessage(`{"password":"n3wP@ss"}`))
+
+	require.Nil(t, err)
+	entityMock.AssertNumberOfCalls(t, "UpdateCredentials", 1)
+}
+
+func TestUserService_UpdateSelfUserPassword_AllowsFirstTimeSetWithoutStoredPassword(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.On("IsEntityDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	entityMock.
+		On("GetCredentialsByType", mock.Anything, svcTestUserID1, "password").
+		Return([]entitypkg.StoredCredential{}, nil).
+		Once()
+	entityMock.
+		On("GetEntity", mock.Anything, svcTestUserID1).
+		Return(&providers.Entity{
+			Category: providers.EntityCategoryUser, ID: svcTestUserID1, Type: "Person",
+		}, nil).
+		Once()
+	entityMock.
+		On("UpdateCredentials", mock.Anything, svcTestUserID1, mock.Anything).
+		Return(nil).
+		Once()
+
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "", json.RawMessage(`{"password":"n3wP@ss"}`))
+
+	require.Nil(t, err)
+	// Nothing to prove yet, so verification must not run.
+	entityMock.AssertNotCalled(t, "AuthenticateEntityByID",
+		mock.Anything, mock.Anything, mock.Anything)
+	entityMock.AssertNumberOfCalls(t, "UpdateCredentials", 1)
+}
+
+func TestUserService_UpdateSelfUserPassword_RejectsNonPasswordCredentialTypes(t *testing.T) {
+	// UpdateUserCredentials accepts any schema-declared credential, so the self-service path has to
+	// narrow the payload itself. Proving the password must not authorize writing something else.
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "0ldP@ssword!", json.RawMessage(`{"pin":"4321"}`))
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorInvalidCredential, *err)
+	entityMock.AssertNotCalled(t, "GetCredentialsByType", mock.Anything, mock.Anything, mock.Anything)
+	entityMock.AssertNotCalled(t, "UpdateCredentials", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUserService_UpdateSelfUserPassword_RejectsPasswordMixedWithAnotherCredentialType(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "0ldP@ssword!",
+		json.RawMessage(`{"password":"n3wP@ssword!","pin":"4321"}`))
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorInvalidCredential, *err)
+	entityMock.AssertNotCalled(t, "UpdateCredentials", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUserService_UpdateSelfUserPassword_RejectsNonPasswordCredentialWithNoProofSupplied(t *testing.T) {
+	// The first-time-set branch skips verification entirely. Without the payload restriction that
+	// branch would write any schema credential on the access token alone, which is the takeover
+	// path this endpoint exists to close.
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "", json.RawMessage(`{"pin":"4321"}`))
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorInvalidCredential, *err)
+	entityMock.AssertNotCalled(t, "GetCredentialsByType", mock.Anything, mock.Anything, mock.Anything)
+	entityMock.AssertNotCalled(t, "UpdateCredentials", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUserService_UpdateSelfUserPassword_RejectsEmptyCredentialPayload(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "0ldP@ssword!", json.RawMessage(`{}`))
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorMissingCredentials, *err)
+	entityMock.AssertNotCalled(t, "GetCredentialsByType", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUserService_UpdateSelfUserPassword_ReturnsServerErrorWhenStoredCredentialReadFails(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.
+		On("GetCredentialsByType", mock.Anything, svcTestUserID1, "password").
+		Return(nil, errors.New("store unavailable")).
+		Once()
+
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "0ldP@ss", json.RawMessage(`{"password":"n3wP@ss"}`))
+
+	require.NotNil(t, err)
+	require.Equal(t, tidcommon.InternalServerError, *err)
+	entityMock.AssertNotCalled(t, "UpdateCredentials", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUserService_UpdateSelfUserPassword_ReturnsNotFoundWhenVerificationReportsUnknownEntity(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.
+		On("GetCredentialsByType", mock.Anything, svcTestUserID1, "password").
+		Return(storedPasswordCredential(), nil).
+		Once()
+	entityMock.
+		On("AuthenticateEntityByID", mock.Anything, svcTestUserID1,
+			map[string]interface{}{"password": "0ldP@ss"}).
+		Return(nil, entitypkg.ErrEntityNotFound).
+		Once()
+
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "0ldP@ss", json.RawMessage(`{"password":"n3wP@ss"}`))
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorUserNotFound, *err)
+	entityMock.AssertNotCalled(t, "UpdateCredentials", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUserService_UpdateSelfUserPassword_ReturnsServerErrorWhenVerificationFailsUnexpectedly(t *testing.T) {
+	// An unexpected verification failure must not fall through to the write. Anything other than a
+	// clean "wrong password" leaves the caller unproven.
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.
+		On("GetCredentialsByType", mock.Anything, svcTestUserID1, "password").
+		Return(storedPasswordCredential(), nil).
+		Once()
+	entityMock.
+		On("AuthenticateEntityByID", mock.Anything, svcTestUserID1,
+			map[string]interface{}{"password": "0ldP@ss"}).
+		Return(nil, errors.New("hash backend unavailable")).
+		Once()
+
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "0ldP@ss", json.RawMessage(`{"password":"n3wP@ss"}`))
+
+	require.NotNil(t, err)
+	require.Equal(t, tidcommon.InternalServerError, *err)
+	entityMock.AssertNotCalled(t, "UpdateCredentials", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUserService_UpdateSelfUserPassword_RejectsAbsentCredentialPayload(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(context.Background(), svcTestUserID1, "0ldP@ss", nil)
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorMissingCredentials, *err)
+	entityMock.AssertNotCalled(t, "GetCredentialsByType", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUserService_UpdateSelfUserPassword_RejectsMalformedCredentialPayload(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "0ldP@ss", json.RawMessage(`{"password":`))
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorInvalidRequestFormat, *err)
+	entityMock.AssertNotCalled(t, "GetCredentialsByType", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUserService_UpdateSelfUserPassword_ReturnsNotFoundForUnknownUser(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.
+		On("GetCredentialsByType", mock.Anything, svcTestUserID1, "password").
+		Return(nil, entitypkg.ErrEntityNotFound).
+		Once()
+
+	service := &userService{entityService: entityMock, authzService: newAllowAllAuthz(t)}
+
+	err := service.UpdateSelfUserPassword(
+		context.Background(), svcTestUserID1, "0ldP@ss", json.RawMessage(`{"password":"n3wP@ss"}`))
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorUserNotFound, *err)
+}

--- a/backend/tests/mocks/usermock/UserServiceInterface_mock.go
+++ b/backend/tests/mocks/usermock/UserServiceInterface_mock.go
@@ -827,6 +827,77 @@ func (_c *UserServiceInterfaceMock_SetDependencyRegistry_Call) RunAndReturn(run 
 	return _c
 }
 
+// UpdateSelfUserPassword provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) UpdateSelfUserPassword(ctx context.Context, userID string, currentPassword string, credentials json.RawMessage) *common.ServiceError {
+	ret := _mock.Called(ctx, userID, currentPassword, credentials)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateSelfUserPassword")
+	}
+
+	var r0 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, json.RawMessage) *common.ServiceError); ok {
+		r0 = returnFunc(ctx, userID, currentPassword, credentials)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.ServiceError)
+		}
+	}
+	return r0
+}
+
+// UserServiceInterfaceMock_UpdateSelfUserPassword_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateSelfUserPassword'
+type UserServiceInterfaceMock_UpdateSelfUserPassword_Call struct {
+	*mock.Call
+}
+
+// UpdateSelfUserPassword is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+//   - currentPassword string
+//   - credentials json.RawMessage
+func (_e *UserServiceInterfaceMock_Expecter) UpdateSelfUserPassword(ctx interface{}, userID interface{}, currentPassword interface{}, credentials interface{}) *UserServiceInterfaceMock_UpdateSelfUserPassword_Call {
+	return &UserServiceInterfaceMock_UpdateSelfUserPassword_Call{Call: _e.mock.On("UpdateSelfUserPassword", ctx, userID, currentPassword, credentials)}
+}
+
+func (_c *UserServiceInterfaceMock_UpdateSelfUserPassword_Call) Run(run func(ctx context.Context, userID string, currentPassword string, credentials json.RawMessage)) *UserServiceInterfaceMock_UpdateSelfUserPassword_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 json.RawMessage
+		if args[3] != nil {
+			arg3 = args[3].(json.RawMessage)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_UpdateSelfUserPassword_Call) Return(serviceError *common.ServiceError) *UserServiceInterfaceMock_UpdateSelfUserPassword_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_UpdateSelfUserPassword_Call) RunAndReturn(run func(ctx context.Context, userID string, currentPassword string, credentials json.RawMessage) *common.ServiceError) *UserServiceInterfaceMock_UpdateSelfUserPassword_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateUser provides a mock function for the type UserServiceInterfaceMock
 func (_mock *UserServiceInterfaceMock) UpdateUser(ctx context.Context, userID string, user1 *providers.User) (*providers.User, *common.ServiceError) {
 	ret := _mock.Called(ctx, userID, user1)

--- a/docs/content/use-cases/b2c/try-it-out/profile-section.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/profile-section.mdx
@@ -24,7 +24,7 @@ Complete [Set Up Your Environment](../../build-environment) before starting this
 <PatternPicker>
 <Pattern value="redirect" label="Redirect-based" description="Hosted screens, simplest to add" icon="external-link" default>
 
-In the redirect-based pattern, the consumer application renders the profile screen itself. Profile attributes are read from `/users/me` and ID token. Updates go through <ProductName />'s self-service endpoints: `/users/me` for attribute changes, `/users/me/meta` for schema metadata retrieve, and `/users/me/update-credentials` for password changes. These endpoints act on the signed-in user's own record, so no extra permissions are needed; the access token alone is enough.
+In the redirect-based pattern, the consumer application renders the profile screen itself. Profile attributes are read from `/users/me` and the ID token. Updates go through <ProductName />'s self-service endpoints: `/users/me` for attribute changes, `/users/me/meta` for schema metadata retrieval, and `/users/me/update-credentials` for password changes. These endpoints act on the signed-in user's own record, so no extra permissions are needed and the access token alone is enough to read attributes and schema metadata. Changing a password requires the user's current password in the request body when the account already has a stored password. Accounts without an existing password can set one without `currentPassword`. The endpoint returns `403` with code `USR-1029` when a stored-password account omits or supplies an incorrect `currentPassword`.
 
 **Try the Use Case**
 

--- a/samples/apps/vanilla-sample/src/services/userProfileService.ts
+++ b/samples/apps/vanilla-sample/src/services/userProfileService.ts
@@ -82,7 +82,7 @@ export const updateCurrentUserProfile = async (
     return normalizeUserProfile(await response.json() as Partial<UserProfile>);
 };
 
-export const updateCurrentUserPassword = async (password: string): Promise<void> => {
+export const updateCurrentUserPassword = async (password: string, currentPassword: string): Promise<void> => {
     const response = await fetch('/api/profile/password', {
         method: 'POST',
         headers: {
@@ -90,6 +90,7 @@ export const updateCurrentUserPassword = async (password: string): Promise<void>
             Accept: 'application/json',
         },
         body: JSON.stringify({
+            currentPassword,
             attributes: {
                 password,
             },

--- a/samples/apps/vanilla-sample/src/views/ProfilePage.tsx
+++ b/samples/apps/vanilla-sample/src/views/ProfilePage.tsx
@@ -101,6 +101,7 @@ const ProfilePage = () => {
     const [error, setError] = useState('');
     const [successMessage, setSuccessMessage] = useState('');
     const [passwordState, setPasswordState] = useState({
+        currentPassword: '',
         newPassword: '',
         confirmPassword: '',
     });
@@ -157,7 +158,7 @@ const ProfilePage = () => {
         setSuccessMessage('');
     };
 
-    const handlePasswordChange = (key: 'newPassword' | 'confirmPassword', value: string) => {
+    const handlePasswordChange = (key: 'currentPassword' | 'newPassword' | 'confirmPassword', value: string) => {
         setPasswordState((prev) => ({
             ...prev,
             [key]: value,
@@ -238,6 +239,13 @@ const ProfilePage = () => {
         }
 
         const trimmedPassword = passwordState.newPassword.trim();
+        const trimmedCurrentPassword = passwordState.currentPassword.trim();
+
+        if (!trimmedCurrentPassword) {
+            setError('Enter your current password.');
+            setSuccessMessage('');
+            return;
+        }
 
         if (!trimmedPassword) {
             setError('Enter a new password.');
@@ -256,8 +264,9 @@ const ProfilePage = () => {
         setSuccessMessage('');
 
         try {
-            await updateCurrentUserPassword(trimmedPassword);
+            await updateCurrentUserPassword(trimmedPassword, trimmedCurrentPassword);
             setPasswordState({
+                currentPassword: '',
                 newPassword: '',
                 confirmPassword: '',
             });
@@ -520,6 +529,17 @@ const ProfilePage = () => {
                                             },
                                         }}
                                     >
+                                        <Box display="flex" flexDirection="column" gap={0.5}>
+                                            <InputLabel htmlFor="current-password">Current Password</InputLabel>
+                                            <OutlinedInput
+                                                id="current-password"
+                                                type="password"
+                                                autoComplete="current-password"
+                                                size="small"
+                                                value={passwordState.currentPassword}
+                                                onChange={(event) => handlePasswordChange('currentPassword', event.target.value)}
+                                            />
+                                        </Box>
                                         <Box display="flex" flexDirection="column" gap={0.5}>
                                             <InputLabel htmlFor="new-password">New Password</InputLabel>
                                             <OutlinedInput

--- a/samples/apps/wayfinder-sample/frontend/src/api/userApi.js
+++ b/samples/apps/wayfinder-sample/frontend/src/api/userApi.js
@@ -45,10 +45,10 @@ export async function updateMyUser(accessToken, attributes) {
   });
 }
 
-export async function updateMyCredentials(accessToken, attributes) {
+export async function updateMyCredentials(accessToken, attributes, currentPassword) {
   return thunderRequest(`/users/me/update-credentials`, accessToken, {
     method: "POST",
-    body: JSON.stringify({ attributes })
+    body: JSON.stringify(currentPassword ? { currentPassword, attributes } : { attributes })
   });
 }
 

--- a/samples/apps/wayfinder-sample/frontend/src/pages/ProfilePage.jsx
+++ b/samples/apps/wayfinder-sample/frontend/src/pages/ProfilePage.jsx
@@ -232,6 +232,7 @@ function Profile({ getAccessToken }) {
 }
 
 function PasswordSection({ getAccessTokenRef, disabled }) {
+  const [currentPassword, setCurrentPassword] = useState("");
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const [isSaving, setIsSaving] = useState(false);
@@ -255,7 +256,8 @@ function PasswordSection({ getAccessTokenRef, disabled }) {
     setIsSaving(true);
     try {
       const accessToken = await getAccessTokenRef.current();
-      await updateMyCredentials(accessToken, { password });
+      await updateMyCredentials(accessToken, { password }, currentPassword);
+      setCurrentPassword("");
       setPassword("");
       setConfirm("");
       setMessage("Password updated.");
@@ -285,6 +287,17 @@ function PasswordSection({ getAccessTokenRef, disabled }) {
       <form onSubmit={handleSubmit}>
         <div style={rowGridStyle}>
           <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Current password</span>
+            <input
+              type="password"
+              autoComplete="current-password"
+              value={currentPassword}
+              onChange={(event) => setCurrentPassword(event.target.value)}
+              disabled={disabled || isSaving}
+              style={inputStyle}
+            />
+          </label>
+          <label style={fieldStyle}>
             <span style={fieldLabelStyle}>New password</span>
             <input
               type="password"
@@ -311,7 +324,7 @@ function PasswordSection({ getAccessTokenRef, disabled }) {
           <button
             className="dashboard-action"
             type="submit"
-            disabled={disabled || isSaving || !password || !confirm}
+            disabled={disabled || isSaving || !currentPassword || !password || !confirm}
           >
             <KeyRound size={16} /> {isSaving ? "Saving…" : "Update password"}
           </button>

--- a/tests/e2e/pages/wayfinder-sample/wayfinder-profile.page.ts
+++ b/tests/e2e/pages/wayfinder-sample/wayfinder-profile.page.ts
@@ -18,6 +18,7 @@ import { Timeouts } from "../../constants/timeouts";
 export class WayfinderProfilePage extends BasePage {
   readonly heading: Locator;
   readonly saveChangesButton: Locator;
+  readonly currentPasswordInput: Locator;
   readonly newPasswordInput: Locator;
   readonly confirmPasswordInput: Locator;
   readonly updatePasswordButton: Locator;
@@ -26,6 +27,7 @@ export class WayfinderProfilePage extends BasePage {
     super(page);
     this.heading = page.getByRole("heading", { name: /^profile$/i });
     this.saveChangesButton = page.getByRole("button", { name: /save changes/i });
+    this.currentPasswordInput = page.getByLabel("Current password", { exact: true });
     this.newPasswordInput = page.getByLabel("New password", { exact: true });
     this.confirmPasswordInput = page.getByLabel("Confirm new password");
     this.updatePasswordButton = page.getByRole("button", { name: /update password/i });
@@ -54,8 +56,14 @@ export class WayfinderProfilePage extends BasePage {
     await expect(this.page.getByText("Profile updated.")).toBeVisible({ timeout: Timeouts.DEFAULT_ACTION });
   }
 
-  /** Set a new password and save. Verifies the "Password updated." confirmation. */
-  async changePassword(newPassword: string) {
+  /**
+   * Set a new password and save. Verifies the "Password updated." confirmation.
+   *
+   * The current password is required: POST /users/me/update-credentials verifies it before the
+   * write, so a stolen access token alone cannot change the credential.
+   */
+  async changePassword(currentPassword: string, newPassword: string) {
+    await this.currentPasswordInput.fill(currentPassword);
     await this.newPasswordInput.fill(newPassword);
     await this.confirmPasswordInput.fill(newPassword);
     await this.updatePasswordButton.click();

--- a/tests/e2e/tests/wayfinder/b2c-tryout/profile.spec.ts
+++ b/tests/e2e/tests/wayfinder/b2c-tryout/profile.spec.ts
@@ -87,7 +87,7 @@ describeOrSkip("Wayfinder B2C Tryout - Profile", { tag: [TestTags.WAYFINDER] }, 
     });
 
     await test.step("Change the password", async () => {
-      await profilePage.changePassword(newPassword);
+      await profilePage.changePassword(customer.password, newPassword);
     });
 
     await test.step("Sign back in with the new password to confirm the credential update took effect", async () => {

--- a/tests/integration/user/user_self_api_test.go
+++ b/tests/integration/user/user_self_api_test.go
@@ -112,6 +112,18 @@ func (s *SelfUserEndpointsSuite) doUserRequest(method, path string, payload inte
 	return s.userClient.Do(req)
 }
 
+// doUserRequestRawBody sends a body verbatim rather than marshalling a Go value, so a test can
+// exercise byte-level shapes that json.Marshal would normalise away.
+func (s *SelfUserEndpointsSuite) doUserRequestRawBody(method, path, rawBody string) (*http.Response, error) {
+	req, err := http.NewRequest(method, testutils.TestServerURL+path, bytes.NewReader([]byte(rawBody)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	return s.userClient.Do(req)
+}
+
 func (s *SelfUserEndpointsSuite) TestSelfUserGetProfile() {
 	resp, err := s.doUserRequest(http.MethodGet, "/users/me", nil)
 	s.Require().NoError(err)
@@ -162,6 +174,7 @@ func (s *SelfUserEndpointsSuite) TestSelfUserUpdateProfile() {
 func (s *SelfUserEndpointsSuite) TestSelfUserUpdateCredentials() {
 	newPassword := s.password + "!"
 	payload := map[string]interface{}{
+		"currentPassword": s.password,
 		"attributes": map[string]interface{}{
 			"password": newPassword,
 		},
@@ -320,4 +333,98 @@ func (s *SelfUserEndpointsSuite) TestSelfUserUpdateCredentialsMissingAttributesR
 	s.Require().NoError(err)
 	defer verifyResp.Body.Close()
 	s.Equal(http.StatusOK, verifyResp.StatusCode, "the existing password must still grant access")
+}
+
+// requireExistingPasswordStillWorks asserts that a rejected credential update left the account's
+// password untouched, by authenticating with it and reading the profile back.
+func (s *SelfUserEndpointsSuite) requireExistingPasswordStillWorks() {
+	s.T().Helper()
+
+	client, err := testutils.GetHTTPClientForUser(s.username, s.password)
+	s.Require().NoError(err, "the existing password must still authenticate")
+
+	req, err := http.NewRequest(http.MethodGet, testutils.TestServerURL+"/users/me", nil)
+	s.Require().NoError(err)
+	verifyResp, err := client.Do(req)
+	s.Require().NoError(err)
+	defer verifyResp.Body.Close()
+	s.Equal(http.StatusOK, verifyResp.StatusCode, "the existing password must still grant access")
+}
+
+// TestSelfUserUpdateCredentialsWrongCurrentPasswordRejected verifies that possession of a valid
+// access token is not on its own enough to rotate the password. This is the takeover path the
+// current-password check exists to close.
+func (s *SelfUserEndpointsSuite) TestSelfUserUpdateCredentialsWrongCurrentPasswordRejected() {
+	resp, err := s.doUserRequest(http.MethodPost, "/users/me/update-credentials",
+		map[string]interface{}{
+			"currentPassword": s.password + "-wrong",
+			"attributes":      map[string]interface{}{"password": s.password + "-new"},
+		})
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.requireSelfError(resp, http.StatusForbidden, "USR-1029")
+	s.requireExistingPasswordStillWorks()
+}
+
+// TestSelfUserUpdateCredentialsMissingCurrentPasswordRejected verifies that omitting the current
+// password fails the same way as supplying a wrong one, so the response does not reveal whether
+// the account has a password set.
+func (s *SelfUserEndpointsSuite) TestSelfUserUpdateCredentialsMissingCurrentPasswordRejected() {
+	resp, err := s.doUserRequest(http.MethodPost, "/users/me/update-credentials",
+		map[string]interface{}{
+			"attributes": map[string]interface{}{"password": s.password + "-new"},
+		})
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.requireSelfError(resp, http.StatusForbidden, "USR-1029")
+	s.requireExistingPasswordStillWorks()
+}
+
+// TestSelfUserUpdateCredentialsNonPasswordTypeRejected verifies that the self-service endpoint
+// writes only the password. Without this, proving the password would authorise writing any other
+// schema-declared credential.
+func (s *SelfUserEndpointsSuite) TestSelfUserUpdateCredentialsNonPasswordTypeRejected() {
+	resp, err := s.doUserRequest(http.MethodPost, "/users/me/update-credentials",
+		map[string]interface{}{
+			"currentPassword": s.password,
+			"attributes":      map[string]interface{}{"pin": "4321"},
+		})
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.requireSelfError(resp, http.StatusBadRequest, "USR-1024")
+	s.requireExistingPasswordStillWorks()
+}
+
+// TestSelfUserUpdateCredentialsNonObjectAttributesRejected verifies that an `attributes` value
+// which is valid JSON but not an object is refused. The handler only checks that the raw value is
+// non-empty and not literally "{}", so the service is what has to reject this shape.
+func (s *SelfUserEndpointsSuite) TestSelfUserUpdateCredentialsNonObjectAttributesRejected() {
+	resp, err := s.doUserRequest(http.MethodPost, "/users/me/update-credentials",
+		map[string]interface{}{
+			"currentPassword": s.password,
+			"attributes":      "not-an-object",
+		})
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.requireSelfError(resp, http.StatusBadRequest, "USR-1001")
+	s.requireExistingPasswordStillWorks()
+}
+
+// TestSelfUserUpdateCredentialsWhitespaceEmptyAttributesRejected verifies the service backstops the
+// handler. The handler rejects an empty attribute object by comparing the trimmed body against the
+// exact string "{}", which "{ }" does not match, so the request reaches the service and must be
+// refused there rather than treated as a credential write.
+func (s *SelfUserEndpointsSuite) TestSelfUserUpdateCredentialsWhitespaceEmptyAttributesRejected() {
+	body := fmt.Sprintf(`{"currentPassword":%q,"attributes":{ }}`, s.password)
+
+	resp, err := s.doUserRequestRawBody(http.MethodPost, "/users/me/update-credentials", body)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.requireSelfError(resp, http.StatusBadRequest, "USR-1017")
+	s.requireExistingPasswordStillWorks()
 }


### PR DESCRIPTION
### Purpose

`POST /users/me/update-credentials` wrote a new password on the strength of the access token alone. Anyone holding a stolen or leaked token for an account could set a password on it, and that password keeps working long after the token expires, so temporary token possession turns into permanent account access. The user now has to prove they know the current password before the write goes through.

The endpoint also accepted any schema-declared credential, not just the password. That is narrowed here too, so proving your password cannot be used to write a different credential type.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
Two changes to `POST /users/me/update-credentials`:

1. A `currentPassword` field is now required when the account already has a password stored. Requests that omit it, or supply the wrong value, are rejected with `403` and code `USR-1029`.
2. Only `password` may be written. Any other credential type in `attributes` is rejected with `400` and code `USR-1024`.

The request body schema changed from `UpdateSelfUserRequest` to a dedicated `UpdateSelfCredentialsRequest`, which carries `currentPassword` as a sibling of `attributes`.

#### 💥 Impact
Existing clients calling this endpoint without `currentPassword` will start receiving `403` for accounts that have a password. The endpoint has existed since the user self service API was introduced, so this affects any integration already built against it. Both bundled sample apps were affected and are updated in this PR.

Clients writing a credential type other than `password` through this endpoint will start receiving `400`. Use the admin credential update endpoint for those.

The admin reset path `POST /users/{userId}/update-credentials` is unchanged. It still needs no current password and still accepts any schema-declared credential, since an admin cannot know the target user's password.

#### 🔄 Migration Guide
Add the user's existing password to the request body:

```json
{
  "currentPassword": "0ldP@ssword!",
  "attributes": {
    "password": "n3wP@ssword!"
  }
}
```

Clients should surface a `403` carrying `USR-1029` against the current password field rather than as a generic failure, since it means only that the supplied password was wrong.

---

### Approach

#### Backend
- `backend/internal/user/service.go` - `UpdateSelfUserCredentials` reads the stored password credential first, then requires and verifies `currentPassword` before delegating to `UpdateUserCredentials`. Verification reuses `AuthenticateEntityByID` instead of adding a second password comparison path, so there stays exactly one place in the codebase where a password is checked against storage.
- Kept as a separate method from `UpdateUserCredentials` (the admin path) rather than adding a flag to it. The two have different trust models, and a boolean parameter deciding whether to verify is the kind of thing that eventually gets passed wrong.
- `validateSelfCredentialPayload` rejects any credential key other than `password`. 
- An account with no password stored yet proceeds without verification. There is nothing to verify against, and demanding proof there would leave those users unable to ever set a password.
- `backend/internal/user/model.go` - adds `UpdateSelfCredentialsRequest`, with `CurrentPassword` as a sibling of `Attributes` rather than a member of it. The entity layer only accepts schema-declared credential keys inside `attributes`, so a current password nested there would be rejected as an unknown credential.
- `backend/internal/user/constants.go` - names `CredentialTypePassword`, since password now acts as the account level proof of ownership and not just one more credential type.
- `backend/internal/user/error_constants.go` and `backend/internal/user/handler.go` - add `ErrorInvalidCurrentPassword` (`USR-1029`), mapped to `403`. `403` rather than `401` because the caller is authenticated and it is this specific action that is refused; a `401` would tell the client its session is invalid and should be re-established, which is not the case. `USR-1024` for the rejected credential type maps to `400`.
- `backend/internal/system/i18n/core/defaults.go` - regenerated with `make generate_i18n` for the two new message keys, not hand edited.

#### Sample apps
Both bundled samples called this endpoint without a current password and broke against the new contract. Those are addressed here,

- `samples/apps/wayfinder-sample/frontend/src/api/userApi.js` and `src/pages/ProfilePage.jsx` - `updateMyCredentials` takes a current password and sends it when present, so a first-time set still works. The profile form gains a "Current password" field, wired into validation and the submit gate.
- `samples/apps/vanilla-sample/src/services/userProfileService.ts` and `src/views/ProfilePage.tsx` - the same change. The Next.js route at `src/app/api/profile/password/route.ts` proxies the body as-is and needed nothing.

This PR is related to [[Design Discussion] Require current credential verification on self-service credential update](https://github.com/thunder-id/thunderid/discussions/5227)

### Related Issues
- https://github.com/thunder-id/thunderid/issues/5291

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [x] Breaking changes section filled.
    - [x] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-service password changes now require the current password when one is already set.
  * First-time password setup remains available without current-password verification.
  * Self-service credential updates now accept password credentials only.

* **Bug Fixes**
  * Incorrect or missing current passwords return HTTP 403 Forbidden.
  * Unsupported credential types return a documented validation error.
  * Admin credential resets continue without requiring the user’s current password.

* **Documentation**
  * Updated guidance to explain current-password requirements for password changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->