### PR TITLE
Update threat model template's residual risks format

### DIFF
--- a/docs-internals/templates/threat-model.md
+++ b/docs-internals/templates/threat-model.md
@@ -236,7 +236,9 @@ Fill this in only if the change processes personal data.
 
 <Bounded, accepted, or in-progress risks for this area.>
 
-- <residual risk> (tracking: <issue link>)
+| Risk | Description | Current Status | Recommendation |
+| --- | --- | --- | --- |
+| <short risk name> | <what the risk is and why it exists> | <current status> | <the current mitigation, if any, and the concrete next step> (tracking: <issue link>) |
 
 ## Appendix
 


### PR DESCRIPTION
### Purpose
The Residual risks (open items) section in the threat model template is a freeform bullet list (`- <residual risk> (tracking: <issue link>)`). Using it in practice, a single risk needs to convey its current status and the concrete next step separately from its description, which a bullet doesn't structure well.

### Approach
Replaces the bullet with a table: Risk, Description, Current Status, Recommendation. No other section of the template changes.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reformatted the threat-model template’s residual risks section into a table.
  - Added fields for risk description, current status, concrete recommendations, and tracking links.
  - Status options now indicate whether a risk is accepted, in progress, or planned with mitigation.
  - Recommendations can include actionable guidance and a corresponding tracking reference.
  - This provides a more structured way to record, review, and track open residual risks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->