### PR TITLE
Make request headers and query params available to the HTTP Request Executor

### DIFF
--- a/backend/internal/flow/core/utils.go
+++ b/backend/internal/flow/core/utils.go
@@ -16,7 +16,19 @@ import (
 // TODO: Extend to support {{user(key)}}, {{env(key)}}, etc.
 var placeholderPattern = regexp.MustCompile(`{{\s*ctx\(\s*(\w+)\s*\)\s*}}`)
 
-// ResolvePlaceholder resolves a single placeholder string using the "{{ctx(key)}}" syntax.
+// requestPlaceholderPattern matches {{request(<selector>)}} with optional whitespace, capturing the
+// raw selector so it can be parsed into an optional source, a type (header/query) and a name.
+var requestPlaceholderPattern = regexp.MustCompile(`{{\s*request\(\s*([^)]*?)\s*\)\s*}}`)
+
+// Request selector source tokens used in {{request(...)}} placeholders. requestSourceInit refers
+// to the flow-initiation request (the default) and requestSourceFlow to the current flow step request.
+const (
+	requestSourceInit = "init"
+	requestSourceFlow = "flow"
+)
+
+// ResolvePlaceholder resolves a single placeholder string using the "{{ctx(key)}}" and
+// "{{request(...)}}" syntaxes.
 // If no placeholder is found, the original value is returned.
 // If a placeholder is found but the key doesn't exist in any data source, the placeholder is kept as-is.
 func ResolvePlaceholder(ctx *providers.NodeContext, value string, execResp *providers.ExecutorResponse,
@@ -27,7 +39,16 @@ func ResolvePlaceholder(ctx *providers.NodeContext, value string, execResp *prov
 
 	var contextUserRef *providers.EntityReference
 
-	return placeholderPattern.ReplaceAllStringFunc(value, func(match string) string {
+	// Resolve {{ctx(...)}} first, then {{request(...)}}. Because ReplaceAllStringFunc does not
+	// re-scan its own output, resolving request placeholders last keeps any {{ctx(...)}}-looking
+	// text that a request header or query value happens to contain from being resolved as context.
+	//
+	// Note the request pass does run over the ctx pass's output, so a {{ctx(...)}} value that itself
+	// contains the literal text {{request(...)}} would be resolved. This is intentional (it keeps the
+	// two passes simple) and safe: credential-bearing request data is stripped at capture — sensitive
+	// headers via FilterSensitiveHeaders and client-credential query params via the OAuth capture
+	// deny-list — so no secret is reachable through a request placeholder regardless of its origin.
+	value = placeholderPattern.ReplaceAllStringFunc(value, func(match string) string {
 		submatches := placeholderPattern.FindStringSubmatch(match)
 		if len(submatches) < 2 {
 			return match
@@ -77,6 +98,97 @@ func ResolvePlaceholder(ctx *providers.NodeContext, value string, execResp *prov
 		// If not found, keep the placeholder as-is
 		return match
 	})
+
+	return resolveRequestPlaceholders(ctx, value)
+}
+
+// resolveRequestPlaceholders resolves {{request(...)}} placeholders using the HTTP request data
+// carried on the node context. The selector is "[source.]type.name" where source is "init"
+// (flow-initiation request, the default) or "flow" (current flow step request), and type is
+// "header" or "query". Header lookups are case-insensitive per RFC 7230; query lookups are
+// case-sensitive. When multiple values exist, the first is returned. Unresolvable placeholders
+// (missing request, unknown source/type, or absent name) are kept as-is.
+func resolveRequestPlaceholders(ctx *providers.NodeContext, value string) string {
+	return requestPlaceholderPattern.ReplaceAllStringFunc(value, func(match string) string {
+		submatches := requestPlaceholderPattern.FindStringSubmatch(match)
+		if len(submatches) < 2 {
+			return match
+		}
+
+		source, kind, name, ok := parseRequestSelector(submatches[1])
+		if !ok {
+			return match
+		}
+
+		var req *providers.InitiatorRequest
+		switch source {
+		case requestSourceInit:
+			req = ctx.GetInitiatorRequest()
+		case requestSourceFlow:
+			req = ctx.GetCurrentRequest()
+		}
+		if req == nil {
+			return match
+		}
+
+		var resolved string
+		var found bool
+		switch kind {
+		case "header":
+			resolved, found = firstHeaderValue(req.Headers, name)
+		case "query":
+			resolved, found = firstValue(req.QueryParams[name])
+		}
+		if !found {
+			return match
+		}
+		return resolved
+	})
+}
+
+// parseRequestSelector splits a request selector into its source, type and name components.
+// It accepts "type.name" (source defaults to "init") or "source.type.name". source must be
+// "init" or "flow" and type must be "header" or "query"; name is the remainder and may contain dots.
+func parseRequestSelector(selector string) (source, kind, name string, ok bool) {
+	source = requestSourceInit
+
+	head, rest, hasRest := strings.Cut(selector, ".")
+	if !hasRest {
+		return "", "", "", false
+	}
+	if head == requestSourceInit || head == requestSourceFlow {
+		source = head
+		head, rest, hasRest = strings.Cut(rest, ".")
+		if !hasRest {
+			return "", "", "", false
+		}
+	}
+
+	if head != "header" && head != "query" {
+		return "", "", "", false
+	}
+	if rest == "" {
+		return "", "", "", false
+	}
+	return source, head, rest, true
+}
+
+// firstHeaderValue returns the first value for a header, matching the name case-insensitively.
+func firstHeaderValue(headers map[string][]string, name string) (string, bool) {
+	for key, values := range headers {
+		if strings.EqualFold(key, name) {
+			return firstValue(values)
+		}
+	}
+	return "", false
+}
+
+// firstValue returns the first element of a string slice.
+func firstValue(values []string) (string, bool) {
+	if len(values) == 0 {
+		return "", false
+	}
+	return values[0], true
 }
 
 // fetchContextUserRef attempts to resolve the authenticated user's entity reference using the authn provider.

--- a/backend/internal/flow/core/utils_test.go
+++ b/backend/internal/flow/core/utils_test.go
@@ -382,3 +382,101 @@ func (s *UtilsTestSuite) TestResolvePlaceholderSpecialCharactersInValue() {
 		})
 	}
 }
+
+func (s *UtilsTestSuite) TestResolveRequestPlaceholderFromInitiatorRequest() {
+	ctx := &providers.NodeContext{}
+	ctx.SetInitiatorRequest(&providers.InitiatorRequest{
+		Headers:     map[string][]string{"User-Agent": {"curl/8.0"}},
+		QueryParams: map[string][]string{"utm_source": {"newsletter"}},
+	})
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"Header default source", "{{request(header.User-Agent)}}", "curl/8.0"},
+		{"Header explicit init source", "{{request(init.header.User-Agent)}}", "curl/8.0"},
+		{"Header case-insensitive lookup", "{{request(header.user-agent)}}", "curl/8.0"},
+		{"Query default source", "{{request(query.utm_source)}}", "newsletter"},
+		{"Query explicit init source", "{{request(init.query.utm_source)}}", "newsletter"},
+		{"Embedded in larger value", "ua={{request(header.User-Agent)}}", "ua=curl/8.0"},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			result := ResolvePlaceholder(ctx, tt.input, nil, nil, nil)
+			s.Equal(tt.expected, result)
+		})
+	}
+}
+
+func (s *UtilsTestSuite) TestResolveRequestPlaceholderFromCurrentRequest() {
+	ctx := &providers.NodeContext{}
+	ctx.SetInitiatorRequest(&providers.InitiatorRequest{
+		Headers: map[string][]string{"User-Agent": {"init-agent"}},
+	})
+	ctx.SetCurrentRequest(&providers.InitiatorRequest{
+		Headers:     map[string][]string{"User-Agent": {"flow-agent"}},
+		QueryParams: map[string][]string{"step": {"otp"}},
+	})
+
+	s.Equal("flow-agent", ResolvePlaceholder(ctx, "{{request(flow.header.User-Agent)}}", nil, nil, nil))
+	s.Equal("otp", ResolvePlaceholder(ctx, "{{request(flow.query.step)}}", nil, nil, nil))
+	// Default source stays init even when a current request is present.
+	s.Equal("init-agent", ResolvePlaceholder(ctx, "{{request(header.User-Agent)}}", nil, nil, nil))
+}
+
+func (s *UtilsTestSuite) TestResolveRequestPlaceholderQueryIsCaseSensitive() {
+	ctx := &providers.NodeContext{}
+	ctx.SetInitiatorRequest(&providers.InitiatorRequest{
+		QueryParams: map[string][]string{"utm_source": {"newsletter"}},
+	})
+
+	s.Equal("{{request(query.UTM_SOURCE)}}",
+		ResolvePlaceholder(ctx, "{{request(query.UTM_SOURCE)}}", nil, nil, nil),
+		"query lookups must be case-sensitive")
+}
+
+func (s *UtilsTestSuite) TestResolveRequestPlaceholderFirstValueWins() {
+	ctx := &providers.NodeContext{}
+	ctx.SetInitiatorRequest(&providers.InitiatorRequest{
+		Headers: map[string][]string{"X-Forwarded-For": {"1.1.1.1", "2.2.2.2"}},
+	})
+
+	s.Equal("1.1.1.1", ResolvePlaceholder(ctx, "{{request(header.X-Forwarded-For)}}", nil, nil, nil))
+}
+
+func (s *UtilsTestSuite) TestResolveRequestPlaceholderUnresolvable() {
+	ctxWithReq := &providers.NodeContext{}
+	ctxWithReq.SetInitiatorRequest(&providers.InitiatorRequest{
+		Headers: map[string][]string{"User-Agent": {"curl/8.0"}},
+	})
+
+	ctxWithoutReq := &providers.NodeContext{}
+
+	tests := []struct {
+		name     string
+		ctx      *providers.NodeContext
+		input    string
+		expected string
+	}{
+		{"Nil initiator request", ctxWithoutReq, "{{request(header.User-Agent)}}",
+			"{{request(header.User-Agent)}}"},
+		{"Nil current request", ctxWithReq, "{{request(flow.header.User-Agent)}}",
+			"{{request(flow.header.User-Agent)}}"},
+		{"Unknown header", ctxWithReq, "{{request(header.X-Missing)}}", "{{request(header.X-Missing)}}"},
+		{"Unknown source", ctxWithReq, "{{request(other.header.User-Agent)}}",
+			"{{request(other.header.User-Agent)}}"},
+		{"Unknown type", ctxWithReq, "{{request(cookie.session)}}", "{{request(cookie.session)}}"},
+		{"Missing name", ctxWithReq, "{{request(header.)}}", "{{request(header.)}}"},
+		{"Missing type separator", ctxWithReq, "{{request(header)}}", "{{request(header)}}"},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			result := ResolvePlaceholder(tt.ctx, tt.input, nil, nil, nil)
+			s.Equal(tt.expected, result)
+		})
+	}
+}

--- a/backend/internal/flow/executor/http_request_executor_test.go
+++ b/backend/internal/flow/executor/http_request_executor_test.go
@@ -122,6 +122,56 @@ func (suite *HTTPRequestExecutorTestSuite) TestResolvePlaceholdersInConfig() {
 	assert.Equal(suite.T(), "test@example.com", receivedBody["email"])
 }
 
+func (suite *HTTPRequestExecutorTestSuite) TestResolveRequestPlaceholdersInConfig() {
+	var receivedURL string
+	var receivedHeaders http.Header
+	var receivedBody map[string]interface{}
+
+	suite.mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedURL = r.URL.RequestURI()
+		receivedHeaders = r.Header
+		err := json.NewDecoder(r.Body).Decode(&receivedBody)
+		if err != nil {
+			receivedBody = nil
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "test-flow",
+		NodeProperties: map[string]interface{}{
+			"url":    suite.mockServer.URL + "/collect?src={{request(query.utm_source)}}",
+			"method": "POST",
+			"headers": map[string]interface{}{
+				"X-Forwarded-Agent": "{{request(header.User-Agent)}}",
+				"X-Step-Agent":      "{{request(flow.header.User-Agent)}}",
+			},
+			"body": map[string]interface{}{
+				"host":   "{{request(header.Host)}}",
+				"source": "{{request(init.query.utm_source)}}",
+			},
+		},
+	}
+	ctx.SetInitiatorRequest(&providers.InitiatorRequest{
+		Headers:     map[string][]string{"User-Agent": {"init-agent"}, "Host": {"id.example.com"}},
+		QueryParams: map[string][]string{"utm_source": {"newsletter"}},
+	})
+	ctx.SetCurrentRequest(&providers.InitiatorRequest{
+		Headers: map[string][]string{"User-Agent": {"step-agent"}},
+	})
+
+	execResp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, execResp.Status)
+
+	assert.Equal(suite.T(), "/collect?src=newsletter", receivedURL)
+	assert.Equal(suite.T(), "init-agent", receivedHeaders.Get("X-Forwarded-Agent"))
+	assert.Equal(suite.T(), "step-agent", receivedHeaders.Get("X-Step-Agent"))
+	assert.Equal(suite.T(), "id.example.com", receivedBody["host"])
+	assert.Equal(suite.T(), "newsletter", receivedBody["source"])
+}
+
 func (suite *HTTPRequestExecutorTestSuite) TestResolvePlaceholderUserIDSpecialHandling() {
 	var receivedBody map[string]interface{}
 

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -196,6 +196,7 @@ func (fe *flowEngine) executeNodePackage(ctx *EngineContext,
 		ExecutionHistory:  ctx.ExecutionHistory,
 	}
 	nodeCtx.SetInitiatorRequest(ctx.GetInitiatorRequest())
+	nodeCtx.SetCurrentRequest(ctx.GetCurrentRequest())
 	if nodeCtx.NodeInputs == nil {
 		nodeCtx.NodeInputs = make([]providers.Input, 0)
 	}

--- a/backend/internal/flow/flowexec/handler.go
+++ b/backend/internal/flow/flowexec/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/flow/session"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
@@ -59,6 +60,13 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 	// Read the inbound SSO transport inputs (per-flow handle cookies) and make
 	// them available to the flow service, which selects the handle once the flow is known.
 	ctx := session.WithInbound(r.Context(), h.ssoTransport.Read(r))
+
+	// Carry the current step's request headers and query params so flow executors can publish them
+	// via {{request(flow.*)}} placeholders. Credential-bearing headers are stripped at this boundary.
+	ctx = withCurrentRequest(ctx, &providers.InitiatorRequest{
+		Headers:     sysutils.FilterSensitiveHeaders(r.Header),
+		QueryParams: r.URL.Query(),
+	})
 
 	var flowStep *FlowStep
 	var flowErr *tidcommon.ServiceError

--- a/backend/internal/flow/flowexec/handler_test.go
+++ b/backend/internal/flow/flowexec/handler_test.go
@@ -191,6 +191,40 @@ func (s *HandlerTestSuite) TestHandleFlowExecutionRequest_PropagatesInboundSSOCo
 	s.Equal("inbound-handle", gotInbound.HandleFor("flow-1"))
 }
 
+// TestHandleFlowExecutionRequest_CapturesCurrentRequest verifies the current step's request headers
+// and query params are captured onto the service context, with credential headers stripped.
+func (s *HandlerTestSuite) TestHandleFlowExecutionRequest_CapturesCurrentRequest() {
+	t := s.T()
+	mockSvc := NewFlowExecServiceInterfaceMock(t)
+
+	var gotRequest *providers.InitiatorRequest
+	mockSvc.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(ctx context.Context, _ string, _ string, _ string, _ bool, _ string,
+			_ map[string]string, _ string, _ string, _ string) {
+			gotRequest = currentRequestFrom(ctx)
+		}).
+		Return(&FlowStep{ExecutionID: "exec-1", Status: providers.FlowStatusIncomplete},
+			(*tidcommon.ServiceError)(nil))
+
+	h := newFlowExecutionHandler(mockSvc, session.NewCookieTransport(false), 0)
+	req := httptest.NewRequest(http.MethodPost, "/flow/execute?utm_source=newsletter",
+		bytes.NewBufferString(testFlowExecRequestBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "curl/8.0")
+	req.Header.Set("Authorization", "Bearer secret")
+	w := httptest.NewRecorder()
+
+	h.HandleFlowExecutionRequest(w, req)
+
+	s.Equal(http.StatusOK, w.Code)
+	s.Require().NotNil(gotRequest, "current request must be captured onto the service context")
+	s.Equal("curl/8.0", http.Header(gotRequest.Headers).Get("User-Agent"))
+	s.Empty(http.Header(gotRequest.Headers).Get("Authorization"), "credential headers must be stripped")
+	s.Require().Contains(gotRequest.QueryParams, "utm_source")
+	s.Equal("newsletter", gotRequest.QueryParams["utm_source"][0])
+}
+
 // TestHandleFlowExecutionRequest_WritesSSOHandleCookie verifies a minted handle is emitted as the
 // per-flow cookie with the configured TTL and secure/http-only transport settings.
 func (s *HandlerTestSuite) TestHandleFlowExecutionRequest_WritesSSOHandleCookie() {

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -41,6 +41,9 @@ type frame struct {
 type EngineContext struct {
 	Context          context.Context
 	initiatorRequest *providers.InitiatorRequest
+	// currentRequest carries the HTTP request driving the current flow step. It is transient:
+	// supplied on each execution from the request context and never persisted with the flow context.
+	currentRequest *providers.InitiatorRequest
 
 	ExecutionID    string
 	FlowType       providers.FlowType
@@ -101,6 +104,16 @@ func (ec *EngineContext) GetInitiatorRequest() *providers.InitiatorRequest {
 // SetInitiatorRequest sets the original HTTP request that triggered the flow.
 func (ec *EngineContext) SetInitiatorRequest(req *providers.InitiatorRequest) {
 	ec.initiatorRequest = req
+}
+
+// GetCurrentRequest returns the HTTP request that drives the current flow step.
+func (ec *EngineContext) GetCurrentRequest() *providers.InitiatorRequest {
+	return ec.currentRequest
+}
+
+// SetCurrentRequest sets the HTTP request that drives the current flow step.
+func (ec *EngineContext) SetCurrentRequest(req *providers.InitiatorRequest) {
+	ec.currentRequest = req
 }
 
 // mergeRuntimeData merges the given data into RuntimeData.

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -157,6 +157,9 @@ func (s *flowExecService) execute(ctx context.Context, flowID, appID, executionI
 	// Resolve the inbound SSO handle for this flow from the request-scoped transport inputs.
 	applyInboundSSO(engineCtx, ctx)
 
+	// Attach the current step's HTTP request so {{request(flow.*)}} placeholders can resolve.
+	applyCurrentRequest(engineCtx, ctx)
+
 	flowStep, flowErr := s.flowEngine.Execute(engineCtx)
 
 	if flowErr != nil {
@@ -287,6 +290,36 @@ func validateAdministrationCaller(ctx context.Context, flowType providers.FlowTy
 }
 
 // applyInboundSSO selects the SSO handle carried for this flow from the request-scoped
+// currentRequestCtxKey is the context key under which the current flow step's HTTP request is
+// carried from the handler to the flow service.
+type currentRequestCtxKey struct{}
+
+// withCurrentRequest stashes the HTTP request driving the current flow step on the context so the
+// flow service can attach it to the engine context without widening the service interface.
+func withCurrentRequest(ctx context.Context, req *providers.InitiatorRequest) context.Context {
+	if req == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, currentRequestCtxKey{}, req)
+}
+
+// currentRequestFrom returns the current flow step's HTTP request carried on the context, if any.
+func currentRequestFrom(ctx context.Context) *providers.InitiatorRequest {
+	req, _ := ctx.Value(currentRequestCtxKey{}).(*providers.InitiatorRequest)
+	return req
+}
+
+// applyCurrentRequest attaches the current flow step's HTTP request to the engine context so
+// {{request(flow.*)}} placeholders can resolve. It is a no-op when no request is present.
+func applyCurrentRequest(engineCtx *EngineContext, ctx context.Context) {
+	if engineCtx == nil {
+		return
+	}
+	if req := currentRequestFrom(ctx); req != nil {
+		engineCtx.SetCurrentRequest(req)
+	}
+}
+
 // transport inputs and stashes it on the engine context for the SSO-Check node to consume.
 // It is a no-op when no inbound transport is present.
 func applyInboundSSO(engineCtx *EngineContext, ctx context.Context) {

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -327,7 +327,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 
 	initiatorReq := &providers.InitiatorRequest{
 		Headers:     utils.FilterSensitiveHeaders(msg.RequestHeaders),
-		QueryParams: msg.RequestQueryParams,
+		QueryParams: oauth2utils.FilterSensitiveQueryParams(msg.RequestQueryParams),
 	}
 
 	return as.handleStandardAuthorizationRequest(ctx, msg, app, initiatorReq)

--- a/backend/internal/oauth/oauth2/ciba/service.go
+++ b/backend/internal/oauth/oauth2/ciba/service.go
@@ -180,7 +180,7 @@ func (s *cibaService) InitiateBackchannelAuth(
 		},
 		InitiatorRequest: &providers.InitiatorRequest{
 			Headers:     utils.FilterSensitiveHeaders(request.Headers),
-			QueryParams: request.QueryParams,
+			QueryParams: oauth2utils.FilterSensitiveQueryParams(request.QueryParams),
 		},
 	})
 	if flowErr != nil {

--- a/backend/internal/oauth/oauth2/logout/service.go
+++ b/backend/internal/oauth/oauth2/logout/service.go
@@ -114,7 +114,8 @@ func (s *logoutService) InitiateSignOutFlow(
 	// id_token_hint is used by the OAuth layer to resolve the target client; the sign-out flow
 	// itself never consumes it. Strip it from the forwarded initiator request so we don't persist a
 	// JWT with user identity claims into the flow context store.
-	forwardedQueryParams := filterQueryParams(resolution.QueryParams, constants.RequestParamIDTokenHint)
+	forwardedQueryParams := oauth2utils.FilterSensitiveQueryParams(
+		filterQueryParams(resolution.QueryParams, constants.RequestParamIDTokenHint))
 
 	initContext := &flowexec.FlowInitContext{
 		ApplicationID: resolution.AppID,

--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -28,15 +28,6 @@ func IsPARRequestURI(requestURI string) bool {
 	return strings.HasPrefix(requestURI, requestURIPrefix)
 }
 
-// sensitiveParParams is the deny-list of PAR body parameters that must not be persisted into
-// InitiatorRequest.QueryParams, since they carry client credentials and the PAR store is a
-// plaintext runtime cache.
-var sensitiveParParams = map[string]bool{
-	oauth2const.RequestParamClientSecret:        true,
-	oauth2const.RequestParamClientAssertion:     true,
-	oauth2const.RequestParamClientAssertionType: true,
-}
-
 // PARServiceInterface defines the interface for the PAR service.
 type PARServiceInterface interface {
 	HandlePushedAuthorizationRequest(
@@ -157,9 +148,12 @@ func (s *parService) HandlePushedAuthorizationRequest(
 		IDTokenHint:         params[oauth2const.RequestParamIDTokenHint],
 	}
 
+	// Drop client-credential parameters before persisting: the PAR store is a plaintext runtime
+	// cache, and these must not surface through InitiatorRequest.QueryParams. Shared with the
+	// authorize/CIBA capture paths so the deny-list cannot drift between them.
 	initiatorQueryParams := make(map[string][]string, len(params)+1)
 	for k, v := range params {
-		if sensitiveParParams[k] {
+		if oauth2utils.SensitiveQueryParams[k] {
 			continue
 		}
 		initiatorQueryParams[k] = []string{v}

--- a/backend/internal/oauth/oauth2/utils/oauthutils.go
+++ b/backend/internal/oauth/oauth2/utils/oauthutils.go
@@ -19,6 +19,35 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
+// SensitiveQueryParams is the deny-list of OAuth request query parameters that must not be exposed
+// through a captured InitiatorRequest.QueryParams. They carry client credentials, so — like the
+// sensitive request headers stripped by system utils.FilterSensitiveHeaders — they are removed at
+// capture. That keeps them out of the plaintext flow-context store and out of any {{request(query.*)}}
+// placeholder a flow executor might publish. This is the authorize/CIBA counterpart of the PAR body
+// deny-list, and both strip the same parameters for the same reason.
+var SensitiveQueryParams = map[string]bool{
+	constants.RequestParamClientSecret:        true,
+	constants.RequestParamClientAssertion:     true,
+	constants.RequestParamClientAssertionType: true,
+}
+
+// FilterSensitiveQueryParams returns a copy of params with SensitiveQueryParams removed. It is the
+// query-parameter analogue of system utils.FilterSensitiveHeaders. A nil or empty map is returned
+// unchanged.
+func FilterSensitiveQueryParams(params map[string][]string) map[string][]string {
+	if len(params) == 0 {
+		return params
+	}
+	filtered := make(map[string][]string, len(params))
+	for name, values := range params {
+		if SensitiveQueryParams[name] {
+			continue
+		}
+		filtered[name] = values
+	}
+	return filtered
+}
+
 // GetURIWithQueryParams constructs a URI with the given query parameters.
 // It validates the error code and error description according to the spec.
 func GetURIWithQueryParams(uri string, queryParams map[string]string) (string, error) {

--- a/backend/internal/oauth/oauth2/utils/oauthutils_test.go
+++ b/backend/internal/oauth/oauth2/utils/oauthutils_test.go
@@ -1936,3 +1936,33 @@ func (suite *OAuth2UtilsTestSuite) TestEnsureClientSubTypeAttribute_LeavesUserCo
 	assert.Equal(suite.T(), []string{"email"}, token.AccessToken.UserConfig.Attributes)
 	assert.Equal(suite.T(), []string{constants.ClaimSubType}, token.AccessToken.ClientConfig.Attributes)
 }
+
+// Client-credential query parameters are stripped while everything else is preserved verbatim.
+func (suite *OAuth2UtilsTestSuite) TestFilterSensitiveQueryParams_StripsCredentials() {
+	filtered := FilterSensitiveQueryParams(map[string][]string{
+		constants.RequestParamClientSecret:        {"s3cret"},
+		constants.RequestParamClientAssertion:     {"eyJ..."},
+		constants.RequestParamClientAssertionType: {"urn:ietf:params:oauth:client-assertion-type:jwt-bearer"},
+		constants.RequestParamIDTokenHint:         {"eyJhbGc..."},
+		constants.RequestParamLoginHint:           {"alice@example.com"},
+		"scope":                                   {"openid", "profile"},
+	})
+
+	_, hasSecret := filtered[constants.RequestParamClientSecret]
+	_, hasAssertion := filtered[constants.RequestParamClientAssertion]
+	_, hasAssertionType := filtered[constants.RequestParamClientAssertionType]
+	assert.False(suite.T(), hasSecret, "client_secret must be stripped")
+	assert.False(suite.T(), hasAssertion, "client_assertion must be stripped")
+	assert.False(suite.T(), hasAssertionType, "client_assertion_type must be stripped")
+
+	// User hints and ordinary parameters are not client credentials and must survive.
+	assert.Equal(suite.T(), []string{"eyJhbGc..."}, filtered[constants.RequestParamIDTokenHint])
+	assert.Equal(suite.T(), []string{"alice@example.com"}, filtered[constants.RequestParamLoginHint])
+	assert.Equal(suite.T(), []string{"openid", "profile"}, filtered["scope"])
+}
+
+// A nil or empty map is returned unchanged rather than allocated.
+func (suite *OAuth2UtilsTestSuite) TestFilterSensitiveQueryParams_EmptyInput() {
+	assert.Nil(suite.T(), FilterSensitiveQueryParams(nil))
+	assert.Empty(suite.T(), FilterSensitiveQueryParams(map[string][]string{}))
+}

--- a/backend/pkg/thunderidengine/providers/model.go
+++ b/backend/pkg/thunderidengine/providers/model.go
@@ -1130,6 +1130,7 @@ type InitiatorRequest struct {
 type NodeContext struct {
 	Context          context.Context
 	initiatorRequest *InitiatorRequest
+	currentRequest   *InitiatorRequest
 
 	ExecutionID   string
 	FlowType      FlowType
@@ -1190,6 +1191,16 @@ func (nc *NodeContext) GetInitiatorRequest() *InitiatorRequest {
 // SetInitiatorRequest sets the original HTTP request that triggered the flow.
 func (nc *NodeContext) SetInitiatorRequest(req *InitiatorRequest) {
 	nc.initiatorRequest = req
+}
+
+// GetCurrentRequest returns the HTTP request that drives the current flow step.
+func (nc *NodeContext) GetCurrentRequest() *InitiatorRequest {
+	return nc.currentRequest
+}
+
+// SetCurrentRequest sets the HTTP request that drives the current flow step.
+func (nc *NodeContext) SetCurrentRequest(req *InitiatorRequest) {
+	nc.currentRequest = req
 }
 
 // NodeExecutionRecord represents a record of a node execution in the flow.

--- a/docs/content/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/flows/advanced-configurations.mdx
@@ -1950,6 +1950,20 @@ The following fields are always available when the corresponding data exists in 
 
 In addition to these fields, any value present in runtime data (set by prior executors) or user inputs (collected from prior Views) can be referenced using the same `{{ctx(fieldName)}}` syntax (e.g., `{{ctx(email)}}`, `{{ctx(username)}}`).
 
+**Request parameter syntax:** Use `{{request(...)}}` to reference headers and query parameters from the HTTP request associated with the flow. This is useful for publishing request metadata (host, user agent, tracking parameters) to external endpoints. The selector is `[source.]type.name`:
+
+- `source` is `init` (the request that initiated the flow, e.g. the OAuth2 `/authorize` call for redirect-based flows) or `flow` (the current flow step request). When omitted, `init` is used.
+- `type` is `header` or `query`.
+- `name` is the header or query parameter name. Header lookups are case-insensitive; query parameter lookups are case-sensitive. When a header or query parameter has multiple values, the first is used.
+
+| Placeholder | Description |
+|---|---|
+| `{{request(header.User-Agent)}}` | The `User-Agent` header from the flow-initiation request. |
+| `{{request(init.query.utm_source)}}` | The `utm_source` query parameter from the flow-initiation request. |
+| `{{request(flow.header.User-Agent)}}` | The `User-Agent` header from the current flow step request. |
+
+Credential-bearing data is stripped at capture and is never available through this syntax: the headers `Authorization`, `Cookie`, `Set-Cookie`, and `Proxy-Authorization`, and the client-credential query parameters `client_secret`, `client_assertion`, and `client_assertion_type`. If a request, header, or query parameter is not present — or the selector is malformed (for example `{{request(header)}}` with no name, or `{{request(notaselector)}}`) — the placeholder is kept as-is.
+
 **Failure conditions:**
 - URL not configured or invalid
 - HTTP request timeout

--- a/tests/integration/flow/authentication/http_request_executor_test.go
+++ b/tests/integration/flow/authentication/http_request_executor_test.go
@@ -168,6 +168,74 @@ var (
 		},
 	}
 
+	// httpRequestExecutorRequestPlaceholderFlow exercises the {{request(...)}} placeholder syntax in
+	// the HTTP Request Executor body. It covers the resolvable happy path (flow-source header lookups),
+	// the sourceless and init-source variants, and every unresolvable shape (absent header, absent
+	// query, missing name, invalid type, malformed selector) which must be kept verbatim.
+	httpRequestExecutorRequestPlaceholderFlow = testutils.Flow{
+		Name:     "HTTP Request Executor Auth Flow - Request Placeholders",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_http_request_placeholders",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "credentials_auth",
+			},
+			{
+				"id":   "credentials_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "CredentialsAuthExecutor",
+				},
+				"onSuccess": "http_request_notification",
+			},
+			{
+				"id":   "http_request_notification",
+				"type": "TASK_EXECUTION",
+				"properties": map[string]interface{}{
+					"url":     "http://localhost:9091/api/notifications",
+					"method":  "POST",
+					"headers": "{\"Content-Type\": \"application/json\"}",
+					// The flow-initiation request always carries Accept and Content-Type headers, so
+					// the flow-source lookups resolve; the remaining selectors are unresolvable and
+					// must be left as-is.
+					"body": "{" +
+						"\"flowAccept\": \"{{request(flow.header.Accept)}}\", " +
+						"\"flowContentType\": \"{{request(flow.header.Content-Type)}}\", " +
+						"\"flowAbsentHeader\": \"{{request(flow.header.X-Absent-Header)}}\", " +
+						"\"flowMissingQuery\": \"{{request(flow.query.missingparam)}}\", " +
+						"\"flowNoName\": \"{{request(flow.header)}}\", " +
+						"\"flowEmptyName\": \"{{request(flow.header.)}}\", " +
+						"\"initContentType\": \"{{request(init.header.Content-Type)}}\", " +
+						"\"noSourceAccept\": \"{{request(header.Accept)}}\", " +
+						"\"invalidType\": \"{{request(flow.wrongtype.x)}}\", " +
+						"\"malformed\": \"{{request(malformedselector)}}\", " +
+						"\"userId\": \"{{ctx(userId)}}\"" +
+						"}",
+					"responseMapping": "{\"notificationId\": \"id\", \"status\": \"status\"}",
+					"timeout":         "5",
+				},
+				"executor": map[string]interface{}{
+					"name": "HTTPRequestExecutor",
+				},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+
 	httpRequestExecutorTestApp = testutils.Application{
 		Name:                      "HTTP Request Executor Test Application",
 		Description:               "Application for testing HTTP request executor in authentication flows",
@@ -426,4 +494,68 @@ func (ts *HTTPRequestExecutorTestSuite) TestHTTPRequestAuthFlow_WithFailOnErrorT
 	})
 
 	ts.Require().Error(err, "HTTP request failure should cause authentication flow to fail")
+}
+
+func (ts *HTTPRequestExecutorTestSuite) TestHTTPRequestAuthFlow_RequestPlaceholders() {
+	// Create the flow that uses {{request(...)}} placeholders and point the app at it.
+	flowID, err := testutils.CreateFlow(httpRequestExecutorRequestPlaceholderFlow)
+	ts.Require().NoError(err, "Failed to create request-placeholder flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	err = common.UpdateAppConfig(ts.testAppID, flowID, "")
+	ts.NoError(err, "App config update should succeed")
+
+	defer func() {
+		common.UpdateAppConfig(ts.testAppID, ts.testFlowID, "")
+	}()
+
+	step1, err := common.InitiateAuthenticationFlow(ts.testAppID, false, map[string]string{
+		"username": "httprequestuser",
+		"password": "SecurePass123!",
+	}, "")
+
+	ts.NoError(err, "Authentication flow should complete without error")
+	ts.Require().NotNil(step1, "Flow response should not be nil")
+	ts.Equal("COMPLETE", step1.FlowStatus, "Flow status should be COMPLETE")
+	ts.Require().Nil(step1.Error, "Error should be nil")
+
+	time.Sleep(200 * time.Millisecond)
+
+	requests := ts.mockNotificationServer.GetCapturedRequests()
+	ts.Require().NotEmpty(requests, "At least one HTTP request should be captured")
+
+	var notificationRequest *testutils.HTTPRequest
+	for i := range requests {
+		if requests[i].Path == "/api/notifications" {
+			notificationRequest = &requests[i]
+			break
+		}
+	}
+	ts.Require().NotNil(notificationRequest, "Notification request should be sent")
+	ts.Require().NotNil(notificationRequest.Body, "Request body should not be nil")
+
+	// Flow-source header selectors resolve from the flow-initiation request, which always carries
+	// Accept and Content-Type headers.
+	ts.Equal("application/json", notificationRequest.Body["flowAccept"],
+		"{{request(flow.header.Accept)}} should resolve from the current request headers")
+	ts.Equal("application/json", notificationRequest.Body["flowContentType"],
+		"{{request(flow.header.Content-Type)}} should resolve from the current request headers")
+
+	// Unresolvable selectors are kept verbatim so downstream systems can detect them.
+	ts.Equal("{{request(flow.header.X-Absent-Header)}}", notificationRequest.Body["flowAbsentHeader"],
+		"an absent header keeps the placeholder")
+	ts.Equal("{{request(flow.query.missingparam)}}", notificationRequest.Body["flowMissingQuery"],
+		"an absent query parameter keeps the placeholder")
+	ts.Equal("{{request(flow.header)}}", notificationRequest.Body["flowNoName"],
+		"a selector with no name keeps the placeholder")
+	ts.Equal("{{request(flow.header.)}}", notificationRequest.Body["flowEmptyName"],
+		"a selector with an empty name keeps the placeholder")
+	ts.Equal("{{request(flow.wrongtype.x)}}", notificationRequest.Body["invalidType"],
+		"a selector with an invalid type keeps the placeholder")
+	ts.Equal("{{request(malformedselector)}}", notificationRequest.Body["malformed"],
+		"a malformed selector keeps the placeholder")
+
+	// {{ctx(...)}} placeholders still resolve alongside {{request(...)}} placeholders.
+	ts.Equal(ts.config.CreatedUserIDs[0], notificationRequest.Body["userId"],
+		"ctx placeholders should still resolve")
 }


### PR DESCRIPTION
### Purpose

Allow the `HTTPRequestExecutor` to publish HTTP request headers and query parameters (host, user agent, tracking params, etc.) in its outbound payloads, as requested in #1354.

Previously the executor could only template runtime data and user inputs via `{{ctx(...)}}`. This PR adds a `{{request(...)}}` placeholder syntax that resolves headers and query parameters from the request associated with the flow.

### Approach

Added a `{{request([source.]header|query.NAME)}}` placeholder resolved in `core.ResolvePlaceholder`, so it works in the executor's existing `url`, `headers`, and `body` fields with no new node configuration.

- `source` is `init` (the flow-initiation request, e.g. the OAuth2 `/authorize` call for redirect-based flows) or `flow` (the current flow-step request). Defaults to `init` when omitted.
- `type` is `header` (case-insensitive lookup) or `query` (case-sensitive lookup). First value wins for multi-valued entries. Unresolvable placeholders are kept as-is.

Key design decisions:

- **`init`** reuses the existing `InitiatorRequest` already captured at the OAuth `/authorize`, PAR, CIBA, and logout entry points, where credential headers are stripped via `FilterSensitiveHeaders`.
- **`flow`** is a new transient current-step request captured in the flow execution handler and threaded through the request `context.Context` (mirroring the existing inbound-SSO pattern), so no service interface or mock signatures change. The same `FilterSensitiveHeaders` filter is applied at capture, so `Authorization`/`Cookie`/`Set-Cookie`/`Proxy-Authorization` are never exposed.
- `{{ctx(...)}}` is resolved before `{{request(...)}}` so request-supplied text cannot be re-interpreted as a context placeholder.

### Related Issues
- Fixes thunder-id/thunderid#1354

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (`docs/content/guides/flows/advanced-configurations.mdx`)
- [x] Tests provided.
    - [x] Unit Tests (`core/utils_test.go`, `flowexec/handler_test.go`)
    - [x] Integration Tests (executor-level test in `http_request_executor_test.go`)
- [ ] Breaking changes. (Not applicable)

### Security checks
- [x] Followed secure coding standards. Credential-bearing headers are stripped at capture and are never exposable through the new syntax.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - HTTP Request configurations can use `{{request(...)}}` placeholders to access headers and query parameters from the initiating or current request.
  - Supports explicit request sources, case-insensitive header matching, case-sensitive query matching, and first-value selection for multi-valued headers.
  - Unresolved or malformed placeholders remain unchanged.
  - Sensitive credential headers are excluded from request-based substitution.

- **Documentation**
  - Added guidance and examples covering request parameter syntax, supported sources, matching behavior, and unavailable credential headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->