### PR TITLE
Add OU and user rollback support

### DIFF
--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -21,6 +21,7 @@ const (
 	ExecutorNameAuthorization                = "AuthorizationExecutor"
 	ExecutorNamePermissionValidator          = "PermissionValidator"
 	ExecutorNameOUCreation                   = "OUExecutor"
+	ExecutorNameOUDelete                     = "OUDeleteExecutor"
 	ExecutorNameHTTPRequest                  = "HTTPRequestExecutor"
 	ExecutorNameUserTypeResolver             = "UserTypeResolver"
 	ExecutorNameInviteExecutor               = "InviteExecutor"
@@ -39,6 +40,7 @@ const (
 	ExecutorNameCriteriaRevocation           = "CriteriaRevocationExecutor"
 	ExecutorNameSessionRevocation            = "SessionRevocationExecutor"
 	ExecutorNameUserDelete                   = "UserDeleteExecutor"
+	ExecutorNameUserRollback                 = "UserRollbackExecutor"
 )
 
 // Executor mode constants
@@ -122,4 +124,20 @@ const (
 // nonSearchableInputs contains the list of user inputs/ attributes that are non-searchable.
 var nonSearchableInputs = []string{
 	"password", "code", "otp", "token", "userInputMagicLinkToken", "otpSessionToken",
+}
+
+// failureTargetExemptExecutors lists executors that a TASK_EXECUTION node's onFailure/onIncomplete
+// may target directly, bypassing the requirement that the target be a PROMPT node. OUDeleteExecutor
+// and UserRollbackExecutor are compensation steps meant to run as soon as an earlier node fails, so a
+// flow author can wire straight into them instead of forcing an intermediate prompt just to satisfy
+// that rule.
+var failureTargetExemptExecutors = map[string]bool{
+	ExecutorNameOUDelete:     true,
+	ExecutorNameUserRollback: true,
+}
+
+// IsFailureTargetExemptExecutor reports whether a TASK_EXECUTION node running the given executor may
+// be targeted by another node's onFailure/onIncomplete without being a PROMPT node.
+func IsFailureTargetExemptExecutor(executorName string) bool {
+	return failureTargetExemptExecutors[executorName]
 }

--- a/backend/internal/flow/executor/error_constants.go
+++ b/backend/internal/flow/executor/error_constants.go
@@ -1208,6 +1208,34 @@ var (
 			DefaultValue: "The user could not be deleted",
 		},
 	}
+
+	// ErrOUDeletionFailed is returned when rolling back an organization unit fails.
+	ErrOUDeletionFailed = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "FET-1086",
+		Error: tidcommon.I18nMessage{
+			Key:          "flows.executor.errors.ou_deletion_failed",
+			DefaultValue: "Organization unit deletion failed",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key:          "flows.executor.errors.ou_deletion_failed_desc",
+			DefaultValue: "The organization unit could not be deleted",
+		},
+	}
+
+	// ErrUserRollbackFailed is returned when rolling back a provisioned user fails.
+	ErrUserRollbackFailed = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "FET-1087",
+		Error: tidcommon.I18nMessage{
+			Key:          "flows.executor.errors.user_rollback_failed",
+			DefaultValue: "User rollback failed",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key:          "flows.executor.errors.user_rollback_failed_desc",
+			DefaultValue: "The provisioned user could not be rolled back",
+		},
+	}
 )
 
 // errAttributeNotUniqueFor returns a ServiceError for a specific attribute that is not unique.

--- a/backend/internal/flow/executor/ou_delete_executor.go
+++ b/backend/internal/flow/executor/ou_delete_executor.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"errors"
+
+	"github.com/thunder-id/thunderid/internal/flow/core"
+	"github.com/thunder-id/thunderid/internal/ou"
+	"github.com/thunder-id/thunderid/internal/system/log"
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+)
+
+const (
+	ouDeleteExecLoggerComponentName = "OUDeleteExecutor"
+)
+
+// ouDeleteExecutor deletes the organization unit recorded in RuntimeData[ouIDKey] by an earlier
+// OUExecutor node in the same flow execution. A flow author wires it into their own
+// onIncomplete/failure branches as an opt-in compensation step for when a later node fails after
+// an OU has already been created — it only ever acts on the OU this same execution created, never
+// an arbitrary caller-supplied target, so it carries none of the privilege-escalation risk
+// UserDeleteExecutor's trusted-revocation-plan pairing guards against.
+type ouDeleteExecutor struct {
+	providers.Executor
+	ouService ou.OrganizationUnitServiceInterface
+	logger    *log.Logger
+}
+
+var _ providers.Executor = (*ouDeleteExecutor)(nil)
+
+// newOUDeleteExecutor creates a new instance of OUDeleteExecutor.
+func newOUDeleteExecutor(
+	flowFactory core.FlowFactoryInterface,
+	ouService ou.OrganizationUnitServiceInterface,
+) *ouDeleteExecutor {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, ouDeleteExecLoggerComponentName),
+		log.String(log.LoggerKeyExecutorName, ExecutorNameOUDelete))
+
+	base := flowFactory.CreateExecutor(ExecutorNameOUDelete, providers.ExecutorTypeUtility,
+		[]providers.Input{}, []providers.Input{}, &providers.ExecutorMeta{})
+
+	return &ouDeleteExecutor{
+		Executor:  base,
+		ouService: ouService,
+		logger:    logger,
+	}
+}
+
+// Execute deletes the organization unit recorded in RuntimeData[ouIDKey], if any. Completes
+// successfully as a no-op when no OU was recorded, since that means there is nothing to roll back.
+func (o *ouDeleteExecutor) Execute(ctx *providers.NodeContext) (*providers.ExecutorResponse, error) {
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+
+	execResp := &providers.ExecutorResponse{
+		RuntimeData: make(map[string]string),
+	}
+
+	ouID := ctx.RuntimeData[ouIDKey]
+	if ouID == "" {
+		logger.Debug(ctx.Context, "No organization unit recorded in runtime data, nothing to roll back")
+		execResp.Status = providers.ExecComplete
+		return execResp, nil
+	}
+
+	svcErr := o.ouService.DeleteOrganizationUnit(ctx.Context, ouID)
+	if svcErr != nil {
+		if svcErr.Type == tidcommon.ClientErrorType {
+			logger.Debug(ctx.Context, "Failed to delete organization unit",
+				log.String(ouIDKey, ouID), log.String("errorCode", svcErr.Code))
+			execResp.Status = providers.ExecFailure
+			execResp.Error = &ErrOUDeletionFailed
+			return execResp, nil
+		}
+
+		logger.Error(ctx.Context, "Error occurred while deleting organization unit",
+			log.String(ouIDKey, ouID), log.String("errorCode", svcErr.Code))
+		return nil, errors.New("failed to delete organization unit")
+	}
+
+	logger.Debug(ctx.Context, "Organization unit rolled back successfully", log.String(ouIDKey, ouID))
+	execResp.Status = providers.ExecComplete
+	return execResp, nil
+}

--- a/backend/internal/flow/executor/ou_delete_executor_test.go
+++ b/backend/internal/flow/executor/ou_delete_executor_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"testing"
+
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
+	"github.com/thunder-id/thunderid/tests/mocks/oumock"
+)
+
+type OUDeleteExecutorTestSuite struct {
+	suite.Suite
+	mockOUService   *oumock.OrganizationUnitServiceInterfaceMock
+	mockFlowFactory *coremock.FlowFactoryInterfaceMock
+	executor        *ouDeleteExecutor
+}
+
+func TestOUDeleteExecutorSuite(t *testing.T) {
+	suite.Run(t, new(OUDeleteExecutorTestSuite))
+}
+
+func (suite *OUDeleteExecutorTestSuite) SetupTest() {
+	suite.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+
+	suite.mockFlowFactory.On("CreateExecutor", ExecutorNameOUDelete, providers.ExecutorTypeUtility,
+		[]providers.Input{}, []providers.Input{}, mock.Anything).
+		Return(newMockExecutor("OUDeleteExecutor", providers.ExecutorTypeUtility,
+			[]providers.Input{}, []providers.Input{}))
+
+	suite.executor = newOUDeleteExecutor(suite.mockFlowFactory, suite.mockOUService)
+}
+
+func (suite *OUDeleteExecutorTestSuite) TestExecute_NoOUInRuntimeData_CompletesAsNoOp() {
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{},
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, result.Status)
+	suite.mockOUService.AssertNotCalled(suite.T(), "DeleteOrganizationUnit", mock.Anything, mock.Anything)
+}
+
+func (suite *OUDeleteExecutorTestSuite) TestExecute_DeletesRecordedOU_Success() {
+	ouID := testOUID
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			ouIDKey: ouID,
+		},
+	}
+
+	suite.mockOUService.On("DeleteOrganizationUnit", mock.Anything, ouID).
+		Return((*tidcommon.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, result.Status)
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUDeleteExecutorTestSuite) TestExecute_DeletionRefused_ReturnsFailure() {
+	ouID := testOUID
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			ouIDKey: ouID,
+		},
+	}
+
+	svcErr := &tidcommon.ServiceError{
+		Type:  tidcommon.ClientErrorType,
+		Code:  "OU-40001",
+		Error: tidcommon.I18nMessage{Key: "error.test.blocking_dependency", DefaultValue: "has dependent resources"},
+	}
+	suite.mockOUService.On("DeleteOrganizationUnit", mock.Anything, ouID).Return(svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecFailure, result.Status)
+	assert.Equal(suite.T(), &ErrOUDeletionFailed, result.Error)
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUDeleteExecutorTestSuite) TestExecute_ServerError_ReturnsError() {
+	ouID := testOUID
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			ouIDKey: ouID,
+		},
+	}
+
+	svcErr := &tidcommon.ServiceError{
+		Type:  tidcommon.ServerErrorType,
+		Code:  "OU-50001",
+		Error: tidcommon.I18nMessage{Key: "error.test.internal_error", DefaultValue: "internal error"},
+	}
+	suite.mockOUService.On("DeleteOrganizationUnit", mock.Anything, ouID).Return(svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	require.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to delete organization unit")
+	suite.mockOUService.AssertExpectations(suite.T())
+}

--- a/backend/internal/flow/executor/ou_executor.go
+++ b/backend/internal/flow/executor/ou_executor.go
@@ -10,7 +10,6 @@ import (
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
-	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
 	"github.com/thunder-id/thunderid/internal/entitytype"
 	"github.com/thunder-id/thunderid/internal/flow/core"
 	"github.com/thunder-id/thunderid/internal/ou"
@@ -87,27 +86,6 @@ func (o *ouExecutor) Execute(ctx *providers.NodeContext) (*providers.ExecutorRes
 		execResp.Status = providers.ExecFailure
 		execResp.Error = &ErrOUCreationPrereqFailed
 		return execResp, nil
-	}
-
-	if execResp.AuthUser.IsAuthenticated() {
-		// Check if the user already has an entity reference (existing user).
-		// If so, skip OU creation as the user already belongs to an OU.
-		authUser, entityRef, svcErr := o.authnProvider.GetEntityReference(ctx.Context, execResp.AuthUser)
-		if svcErr != nil {
-			if svcErr.Code != authnprovidermgr.ErrorUserNotFound.Code &&
-				svcErr.Code != authnprovidermgr.ErrorAmbiguousUser.Code {
-				execResp.Status = providers.ExecFailure
-				execResp.Error = &ErrFailedToIdentifyUser
-				return execResp, nil
-			}
-			logger.Debug(ctx.Context, "User not found or ambiguous, proceeding with OU creation")
-		}
-		execResp.AuthUser = authUser
-		if entityRef != nil {
-			logger.Debug(ctx.Context, "User already has an entity reference, skipping OU creation")
-			execResp.Status = providers.ExecComplete
-			return execResp, nil
-		}
 	}
 
 	if !o.HasRequiredInputs(ctx, execResp) {

--- a/backend/internal/flow/executor/ou_executor_test.go
+++ b/backend/internal/flow/executor/ou_executor_test.go
@@ -224,6 +224,44 @@ func (suite *OUExecutorTestSuite) TestExecute_Success() {
 	}
 }
 
+// TestExecute_AuthenticatedUserWithEntityReference_StillCreatesOU guards against reintroducing the
+// #5276 bug: OUExecutor used to skip creation entirely whenever the current AuthUser already had an
+// entity reference (e.g. a user just provisioned earlier in the same execution), which made it
+// impossible to place OU Creation after Provisioning. Since suite.mockAuthnProvider has no
+// expectation configured for GetEntityReference, this test also fails loudly if that call is ever
+// made again.
+func (suite *OUExecutorTestSuite) TestExecute_AuthenticatedUserWithEntityReference_StillCreatesOU() {
+	authUser := providers.AuthUser{}
+	authUser.SetStateFor("default", providers.AuthState{
+		EntityReference: &providers.EntityReference{EntityID: "existing-user-123"},
+		Attributes:      &providers.AttributesResponse{},
+	})
+	suite.Require().True(authUser.IsAuthenticated())
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeRegistration,
+		AuthUser:    authUser,
+		UserInputs: map[string]string{
+			userInputOuName:   "Branch Office",
+			userInputOuHandle: "branch-office",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	expectedRequest := providers.OrganizationUnitRequestWithID{Name: "Branch Office", Handle: "branch-office"}
+	suite.mockOUService.On("CreateOrganizationUnit", mock.Anything, expectedRequest).
+		Return(providers.OrganizationUnit{ID: testOUID, Name: "Branch Office", Handle: "branch-office"}, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, result.Status)
+	assert.Equal(suite.T(), testOUID, result.RuntimeData[ouIDKey])
+	suite.mockOUService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertNotCalled(suite.T(), "GetEntityReference", mock.Anything, mock.Anything)
+}
+
 type ExecuteNonRegistrationFlowTestCase struct {
 	name     string
 	flowType providers.FlowType

--- a/backend/internal/flow/executor/register.go
+++ b/backend/internal/flow/executor/register.go
@@ -189,6 +189,9 @@ func newBuiltInExecutorRegistrars() map[string]builtInExecutorRegistrar {
 			reg.RegisterExecutor(ExecutorNameOUCreation, newOUExecutor(deps.FlowFactory, deps.OUService,
 				deps.AuthnProvider, deps.EntityTypeService))
 		},
+		ExecutorNameOUDelete: func(reg ExecutorRegistryInterface, deps ExecutorDependencies) {
+			reg.RegisterExecutor(ExecutorNameOUDelete, newOUDeleteExecutor(deps.FlowFactory, deps.OUService))
+		},
 		ExecutorNameAttributeCollect: func(reg ExecutorRegistryInterface, deps ExecutorDependencies) {
 			reg.RegisterExecutor(ExecutorNameAttributeCollect, newAttributeCollector(
 				deps.FlowFactory, deps.EntityProvider, deps.AuthnProvider))
@@ -285,6 +288,10 @@ func newBuiltInExecutorRegistrars() map[string]builtInExecutorRegistrar {
 		ExecutorNameUserDelete: func(reg ExecutorRegistryInterface, deps ExecutorDependencies) {
 			reg.RegisterExecutor(ExecutorNameUserDelete,
 				newUserDeleteExecutor(deps.FlowFactory, deps.UserService))
+		},
+		ExecutorNameUserRollback: func(reg ExecutorRegistryInterface, deps ExecutorDependencies) {
+			reg.RegisterExecutor(ExecutorNameUserRollback,
+				newUserRollbackExecutor(deps.FlowFactory, deps.UserService, deps.CriteriaRevoker, deps.SessionService))
 		},
 	}
 }

--- a/backend/internal/flow/executor/user_rollback_executor.go
+++ b/backend/internal/flow/executor/user_rollback_executor.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"errors"
+
+	"github.com/thunder-id/thunderid/internal/flow/core"
+	"github.com/thunder-id/thunderid/internal/flow/session"
+	"github.com/thunder-id/thunderid/internal/revocation"
+	"github.com/thunder-id/thunderid/internal/system/log"
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+)
+
+const (
+	userRollbackExecLoggerComponentName = "UserRollbackExecutor"
+)
+
+// userRollbackExecutor deletes the user provisioned earlier in RuntimeData[userAttributeUserID] by
+// an earlier ProvisioningExecutor node in the same flow execution, after revoking every token issued
+// to that user and terminating their sessions. A flow author wires it into their own onIncomplete/failure
+// branches as an opt-in compensation step for when a later node fails after a user has already been
+// provisioned — it only ever acts on the user this same execution created, never an arbitrary
+// caller-supplied target, so it carries none of the privilege-escalation risk UserDeleteExecutor's
+// trusted-revocation-plan pairing guards against. Unlike that administration-only pipeline, the
+// revoke-then-terminate-then-delete sequence here runs unconditionally against a single subject this
+// execution already trusts, with no separate validation/planning step required beforehand.
+type userRollbackExecutor struct {
+	providers.Executor
+	userProvider userDeletionProvider
+	revoker      revocation.CriteriaRevoker
+	sessionSvc   session.Service
+	logger       *log.Logger
+}
+
+var _ providers.Executor = (*userRollbackExecutor)(nil)
+
+// newUserRollbackExecutor creates a new instance of UserRollbackExecutor.
+func newUserRollbackExecutor(
+	flowFactory core.FlowFactoryInterface,
+	userProvider userDeletionProvider,
+	revoker revocation.CriteriaRevoker,
+	sessionSvc session.Service,
+) *userRollbackExecutor {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userRollbackExecLoggerComponentName),
+		log.String(log.LoggerKeyExecutorName, ExecutorNameUserRollback))
+
+	base := flowFactory.CreateExecutor(ExecutorNameUserRollback, providers.ExecutorTypeUtility,
+		[]providers.Input{}, []providers.Input{}, &providers.ExecutorMeta{})
+
+	return &userRollbackExecutor{
+		Executor:     base,
+		userProvider: userProvider,
+		revoker:      revoker,
+		sessionSvc:   sessionSvc,
+		logger:       logger,
+	}
+}
+
+// Execute revokes every token and session belonging to the user recorded in
+// RuntimeData[userAttributeUserID], then deletes that user. Completes successfully as a no-op when
+// no user was recorded, since that means there is nothing to roll back.
+func (u *userRollbackExecutor) Execute(ctx *providers.NodeContext) (*providers.ExecutorResponse, error) {
+	logger := u.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+
+	execResp := &providers.ExecutorResponse{
+		RuntimeData: make(map[string]string),
+	}
+
+	userID := ctx.RuntimeData[userAttributeUserID]
+	if userID == "" {
+		logger.Debug(ctx.Context, "No user recorded in runtime data, nothing to roll back")
+		execResp.Status = providers.ExecComplete
+		return execResp, nil
+	}
+
+	if err := u.revoker.RevokeByCriteria(ctx.Context, revocation.CriteriaRevocation{
+		Criterion: revocation.Criterion{Type: revocation.CriterionTypeSubject, Value: userID},
+		Mode:      revocation.ModeAll,
+		Reason:    revocation.ReasonUserDeleted,
+	}); err != nil {
+		logger.Error(ctx.Context, "Failed to revoke tokens for the rolled-back user", log.Error(err))
+		return nil, errors.New("failed to revoke tokens for the user")
+	}
+
+	if err := u.sessionSvc.TerminateBySubject(ctx.Context, userID); err != nil {
+		logger.Error(ctx.Context, "Failed to terminate sessions for the rolled-back user", log.Error(err))
+		return nil, errors.New("failed to terminate sessions for the user")
+	}
+
+	svcErr := u.userProvider.DeleteUser(ctx.Context, userID)
+	if svcErr != nil {
+		if svcErr.Type == tidcommon.ClientErrorType {
+			logger.Debug(ctx.Context, "Failed to delete user", log.String("errorCode", svcErr.Code))
+			execResp.Status = providers.ExecFailure
+			execResp.Error = &ErrUserRollbackFailed
+			return execResp, nil
+		}
+
+		logger.Error(ctx.Context, "Error occurred while deleting user", log.String("errorCode", svcErr.Code))
+		return nil, errors.New("failed to delete user")
+	}
+
+	logger.Debug(ctx.Context, "User rolled back successfully")
+	execResp.Status = providers.ExecComplete
+	return execResp, nil
+}

--- a/backend/internal/flow/executor/user_rollback_executor_test.go
+++ b/backend/internal/flow/executor/user_rollback_executor_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/thunder-id/thunderid/internal/revocation"
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
+	"github.com/thunder-id/thunderid/tests/mocks/flow/sessionmock"
+	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/revocationmock"
+)
+
+type UserRollbackExecutorTestSuite struct {
+	suite.Suite
+	mockUserProvider *userDeletionProviderMock
+	mockRevoker      *revocationmock.CriteriaRevokerInterfaceMock
+	mockSessionSvc   *sessionmock.ServiceMock
+	mockFlowFactory  *coremock.FlowFactoryInterfaceMock
+	executor         *userRollbackExecutor
+}
+
+func TestUserRollbackExecutorSuite(t *testing.T) {
+	suite.Run(t, new(UserRollbackExecutorTestSuite))
+}
+
+func (suite *UserRollbackExecutorTestSuite) SetupTest() {
+	suite.mockUserProvider = newUserDeletionProviderMock(suite.T())
+	suite.mockRevoker = revocationmock.NewCriteriaRevokerInterfaceMock(suite.T())
+	suite.mockSessionSvc = sessionmock.NewServiceMock(suite.T())
+	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+
+	suite.mockFlowFactory.On("CreateExecutor", ExecutorNameUserRollback, providers.ExecutorTypeUtility,
+		[]providers.Input{}, []providers.Input{}, mock.Anything).
+		Return(newMockExecutor("UserRollbackExecutor", providers.ExecutorTypeUtility,
+			[]providers.Input{}, []providers.Input{}))
+
+	suite.executor = newUserRollbackExecutor(
+		suite.mockFlowFactory, suite.mockUserProvider, suite.mockRevoker, suite.mockSessionSvc)
+}
+
+func (suite *UserRollbackExecutorTestSuite) TestExecute_NoUserInRuntimeData_CompletesAsNoOp() {
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{},
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, result.Status)
+	suite.mockUserProvider.AssertNotCalled(suite.T(), "DeleteUser", mock.Anything, mock.Anything)
+	suite.mockRevoker.AssertNotCalled(suite.T(), "RevokeByCriteria", mock.Anything, mock.Anything)
+	suite.mockSessionSvc.AssertNotCalled(suite.T(), "TerminateBySubject", mock.Anything, mock.Anything)
+}
+
+func (suite *UserRollbackExecutorTestSuite) TestExecute_RevokesTerminatesAndDeletes_Success() {
+	userID := testUserID
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			userAttributeUserID: userID,
+		},
+	}
+
+	suite.mockRevoker.EXPECT().RevokeByCriteria(mock.Anything, revocation.CriteriaRevocation{
+		Criterion: revocation.Criterion{Type: revocation.CriterionTypeSubject, Value: userID},
+		Mode:      revocation.ModeAll,
+		Reason:    revocation.ReasonUserDeleted,
+	}).Return(nil)
+	suite.mockSessionSvc.EXPECT().TerminateBySubject(mock.Anything, userID).Return(nil)
+	suite.mockUserProvider.EXPECT().DeleteUser(mock.Anything, userID).Return(nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, result.Status)
+	suite.mockRevoker.AssertExpectations(suite.T())
+	suite.mockSessionSvc.AssertExpectations(suite.T())
+	suite.mockUserProvider.AssertExpectations(suite.T())
+}
+
+func (suite *UserRollbackExecutorTestSuite) TestExecute_RevocationFails_ReturnsErrorWithoutDeleting() {
+	userID := testUserID
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			userAttributeUserID: userID,
+		},
+	}
+
+	suite.mockRevoker.EXPECT().RevokeByCriteria(mock.Anything, mock.Anything).
+		Return(errors.New("revocation store unavailable"))
+
+	result, err := suite.executor.Execute(ctx)
+
+	require.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to revoke tokens for the user")
+	suite.mockSessionSvc.AssertNotCalled(suite.T(), "TerminateBySubject", mock.Anything, mock.Anything)
+	suite.mockUserProvider.AssertNotCalled(suite.T(), "DeleteUser", mock.Anything, mock.Anything)
+}
+
+func (suite *UserRollbackExecutorTestSuite) TestExecute_SessionTerminationFails_ReturnsErrorWithoutDeleting() {
+	userID := testUserID
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			userAttributeUserID: userID,
+		},
+	}
+
+	suite.mockRevoker.EXPECT().RevokeByCriteria(mock.Anything, mock.Anything).Return(nil)
+	suite.mockSessionSvc.EXPECT().TerminateBySubject(mock.Anything, userID).
+		Return(errors.New("session store unavailable"))
+
+	result, err := suite.executor.Execute(ctx)
+
+	require.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to terminate sessions for the user")
+	suite.mockUserProvider.AssertNotCalled(suite.T(), "DeleteUser", mock.Anything, mock.Anything)
+}
+
+func (suite *UserRollbackExecutorTestSuite) TestExecute_DeletionRefused_ReturnsFailure() {
+	userID := testUserID
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			userAttributeUserID: userID,
+		},
+	}
+
+	suite.mockRevoker.EXPECT().RevokeByCriteria(mock.Anything, mock.Anything).Return(nil)
+	suite.mockSessionSvc.EXPECT().TerminateBySubject(mock.Anything, userID).Return(nil)
+	svcErr := &tidcommon.ServiceError{
+		Type:  tidcommon.ClientErrorType,
+		Code:  "USR-40001",
+		Error: tidcommon.I18nMessage{Key: "error.test.blocking_dependency", DefaultValue: "has dependent resources"},
+	}
+	suite.mockUserProvider.EXPECT().DeleteUser(mock.Anything, userID).Return(svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecFailure, result.Status)
+	assert.Equal(suite.T(), &ErrUserRollbackFailed, result.Error)
+}
+
+func (suite *UserRollbackExecutorTestSuite) TestExecute_DeletionServerError_ReturnsError() {
+	userID := testUserID
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{
+			userAttributeUserID: userID,
+		},
+	}
+
+	suite.mockRevoker.EXPECT().RevokeByCriteria(mock.Anything, mock.Anything).Return(nil)
+	suite.mockSessionSvc.EXPECT().TerminateBySubject(mock.Anything, userID).Return(nil)
+	svcErr := &tidcommon.ServiceError{
+		Type:  tidcommon.ServerErrorType,
+		Code:  "USR-50001",
+		Error: tidcommon.I18nMessage{Key: "error.test.internal_error", DefaultValue: "internal error"},
+	}
+	suite.mockUserProvider.EXPECT().DeleteUser(mock.Anything, userID).Return(svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	require.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to delete user")
+}

--- a/backend/internal/flow/graphbuilder/graph_builder.go
+++ b/backend/internal/flow/graphbuilder/graph_builder.go
@@ -268,11 +268,15 @@ func (b *graphBuilder) configureNodeNavigation(nodeDef *providers.NodeDefinition
 	return nil
 }
 
-// validateOnFailureTarget validates that the onFailure target node is a PROMPT node.
+// validateOnFailureTarget validates that the onFailure target node is a PROMPT node. TASK_EXECUTION
+// nodes whose executor is exempt (e.g. OUDeleteExecutor, a compensation step meant to run as soon as
+// an earlier node fails) may also be targeted directly.
 func (b *graphBuilder) validateOnFailureTarget(nodes []providers.NodeDefinition, targetNodeID string) error {
 	for _, node := range nodes {
 		if node.ID == targetNodeID {
-			if node.Type != "PROMPT" {
+			isExemptTaskNode := node.Type == string(common.NodeTypeTaskExecution) &&
+				node.Executor != nil && executor.IsFailureTargetExemptExecutor(node.Executor.Name)
+			if node.Type != "PROMPT" && !isExemptTaskNode {
 				return errors.New("onFailure must point to a PROMPT node")
 			}
 			return nil

--- a/backend/internal/flow/mgt/validator.go
+++ b/backend/internal/flow/mgt/validator.go
@@ -156,6 +156,13 @@ var companionExecutors = map[string][]string{
 	executor.ExecutorNameSessionRevocation: {executor.ExecutorNameCriteriaRevocation},
 }
 
+// isExemptFailureTarget reports whether the node is allowed as an onFailure/onIncomplete target
+// even though it is not a PROMPT node.
+func isExemptFailureTarget(target *providers.NodeDefinition) bool {
+	return target.Type == string(common.NodeTypeTaskExecution) &&
+		target.Executor != nil && executor.IsFailureTargetExemptExecutor(target.Executor.Name)
+}
+
 // validateFlowTypeBasedConstraints checks forbidden and required executor rules for the flow type.
 // Uses static maps only — no registry access required.
 func (v *flowValidator) validateFlowTypeBasedConstraints(
@@ -659,7 +666,8 @@ func (v *flowValidator) validateTaskExecutionNode(
 		})
 	}
 	if node.OnFailure != "" {
-		if target, ok := nodeIndex[node.OnFailure]; ok && target.Type != string(common.NodeTypePrompt) {
+		if target, ok := nodeIndex[node.OnFailure]; ok && target.Type != string(common.NodeTypePrompt) &&
+			!isExemptFailureTarget(target) {
 			return tidcommon.CustomServiceError(ErrorInvalidNodeConfig, tidcommon.I18nMessage{
 				Key:          "error.flowmgtservice.task_node_invalid_failure_target_description",
 				DefaultValue: "TASK_EXECUTION node '{{param(nodeID)}}': onFailure must point to a PROMPT node",

--- a/backend/internal/flow/mgt/validator_test.go
+++ b/backend/internal/flow/mgt/validator_test.go
@@ -594,6 +594,28 @@ func (s *ValidatorTestSuite) TestValidateTaskExecutionNode_OnFailurePointsToNonP
 	s.Equal(ErrorInvalidNodeConfig.Code, err.Code)
 }
 
+func (s *ValidatorTestSuite) TestValidateTaskExecutionNode_OnFailurePointsToOUDeleteExecutor() {
+	nodes := []providers.NodeDefinition{
+		{ID: "start", Type: string(common.NodeTypeStart), OnSuccess: "task"},
+		{
+			ID: "task", Type: string(common.NodeTypeTaskExecution),
+			Executor:  &providers.ExecutorDefinition{Name: "exec"},
+			OnSuccess: "end",
+			OnFailure: "rollback", // TASK_EXECUTION, not a PROMPT node, but OUDeleteExecutor is exempt
+		},
+		{
+			ID: "rollback", Type: string(common.NodeTypeTaskExecution),
+			Executor:  &providers.ExecutorDefinition{Name: executor.ExecutorNameOUDelete},
+			OnSuccess: "end",
+		},
+		{ID: "end", Type: string(common.NodeTypeEnd)},
+	}
+	index, _ := buildNodeIndex(nodes)
+	node := &nodes[1]
+	err := s.v.validateTaskExecutionNode(node, index)
+	s.Nil(err)
+}
+
 func (s *ValidatorTestSuite) TestValidateTaskExecutionNode_OnIncompletePointsToNonPrompt() {
 	nodes := []providers.NodeDefinition{
 		{ID: "start", Type: string(common.NodeTypeStart), OnSuccess: "task"},

--- a/docs/content/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/flows/advanced-configurations.mdx
@@ -368,6 +368,7 @@ Every flow you deploy must reference only executors that are registered on the s
 | **Resolve Federated User** | Resolves ambiguous federated user after social login. | OAuth/OIDC executor must have run; Identify User must have run |
 | **User Type Resolver** | Resolves the user type based on configured rules. | User type configured on the application |
 | **Provisioning** | Creates or updates the user record in the store. | - |
+| **User Rollback** | Rolls back the user provisioned earlier in the same flow execution. | Provisioning must have run |
 | **Attribute Collector** | Collects additional user attributes defined in the user type. | - |
 | **Validate Attribute Uniqueness** | Checks that unique attributes are not already registered. | User Type Resolver must have run |
 | **Set Credentials** | Sets credentials (e.g., password) for an existing user. | - |
@@ -376,6 +377,7 @@ Every flow you deploy must reference only executors that are registered on the s
 | **User Consent** | Records explicit user consent for defined scopes or terms. | - |
 | **Validate Permission** | Checks that the request has required scope/permissions. | - |
 | **OU Creation** | Creates an organizational unit for the user. | - |
+| **OU Delete** | Rolls back the organizational unit created earlier in the same flow execution. | OU Creation must have run |
 | **Resolve OU** | Resolves or selects an organizational unit based on strategy. | Varies by strategy |
 | **Generate Invite** | Generates an invite link for user registration. | - |
 | **Verify Invite** | Verifies an invite token before completing registration. | Generate Invite must have run |
@@ -1178,6 +1180,47 @@ Creates a new user record in the user store. This executor persists the user's i
 </details>
 
 <details>
+<summary>User Rollback</summary>
+
+Revokes every token issued to the user provisioned earlier in the same flow execution, terminates their sessions, then deletes that user, reading their ID from runtime data. A no-op if no user was recorded, since that means there is nothing to roll back.
+
+**When to use:** As an opt-in compensation step wired into a flow's own `onFailure` branch, for when a node after Provisioning fails and the newly provisioned user should not be left behind. This executor only ever acts on the user this same execution created, taking no caller-supplied target, so unlike User Delete, it requires no separate validation/planning executor beforehand.
+
+**Two ways to route after the rollback:** As with OU Delete, where User Rollback's own `onSuccess` and `onFailure` lead determines whether the user is ever told why registration did not complete.
+
+- **Silent rollback:** Send User Rollback's `onSuccess` and `onFailure` straight to the flow's END node. Revocation, session termination, and deletion happen in the same response as the original failure, with no PROMPT node in between. The user learns that registration did not complete, but not why.
+- **Show the reason after rolling back:** Send User Rollback's `onSuccess` to a PROMPT node instead of straight to END. The rollback still runs immediately, before anything is shown to the user. The flow then pauses at that PROMPT node to display the original failure reason, then reaches END once that node's action is submitted.
+
+**Prerequisites:**
+- A Provisioning node must have run earlier in the same flow execution and recorded a user ID in runtime data.
+
+**Input Configuration:** None. Reads the user ID directly from runtime data.
+
+**Executor properties:** None.
+
+**Example:**
+
+```json
+{
+  "id": "user_rollback",
+  "type": "TASK_EXECUTION",
+  "executor": {
+    "name": "UserRollbackExecutor"
+  },
+  "onSuccess": "error_prompt",
+  "onFailure": "error_prompt"
+}
+```
+
+**Failure conditions:**
+- Revoking the user's tokens fails
+- Terminating the user's sessions fails
+- The user has dependent resources that block deletion
+- User store error
+
+</details>
+
+<details>
 <summary>Attribute Collector</summary>
 
 Checks the authenticated user's existing profile attributes against the node's configured required inputs, then prompts only for what is missing. Skips automatically in registration flows.
@@ -1655,7 +1698,7 @@ Validates that the incoming API request has the required permission/scope to pro
 <details>
 <summary>OU Creation</summary>
 
-Creates a new Organizational Unit. The created OU is available for use by downstream executors.
+Creates a new Organizational Unit. The created OU is available for use by downstream executors. Always attempts creation, regardless of whether the current user was already authenticated or provisioned earlier in the same flow execution.
 
 **When to use:** B2B self-registration flows, place after Provisioning, once the user account exists.
 
@@ -1693,6 +1736,45 @@ Creates a new Organizational Unit. The created OU is available for use by downst
 - An OU with the same name already exists at the target parent: re-prompts the user to change the name
 - An OU with the same handle already exists: re-prompts the user to change the handle
 - Specified `parentOuId` does not exist
+- OU service error
+
+</details>
+
+<details>
+<summary>OU Delete</summary>
+
+Deletes the organization unit created earlier in the same flow execution by an OU Creation node, reading its ID from runtime data. A no-op if no OU was recorded, since that means there's nothing to roll back.
+
+**When to use:** As an opt-in compensation step wired into a flow's own `onFailure` branch, for when a node after OU Creation fails and the newly created OU should not be left behind. This executor only ever acts on the OU this same execution created, taking no caller-supplied target, so unlike User Delete, it requires no separate validation/planning executor beforehand.
+
+**Two ways to route after the rollback:** Where OU Delete's own `onSuccess` and `onFailure` lead determines whether the user is ever told why registration did not complete. A forwarded failure reason is only shown once the flow reaches a PROMPT node. The client is not required to show a button for that node. It can submit the node's action on its own as soon as it renders the failure reason, so the flow moves on without waiting for a click.
+
+- **Silent rollback:** Send OU Delete's `onSuccess` and `onFailure` straight to the flow's END node. The organization unit is deleted and the flow completes in the same response as the original failure, with no PROMPT node in between. The user learns that registration did not complete, but not why.
+- **Show the reason after rolling back:** Send OU Delete's `onSuccess` to a PROMPT node instead of straight to END. The rollback still runs immediately, before anything is shown to the user. The flow then pauses at that PROMPT node to display the original failure reason, then reaches END once that node's action is submitted.
+
+**Prerequisites:**
+- An OU Creation node must have run earlier in the same flow execution and recorded an OU ID in runtime data.
+
+**Input Configuration:** None. Reads the OU ID directly from runtime data.
+
+**Executor properties:** None.
+
+**Example:**
+
+```json
+{
+  "id": "ou_rollback",
+  "type": "TASK_EXECUTION",
+  "executor": {
+    "name": "OUDeleteExecutor"
+  },
+  "onSuccess": "error_prompt",
+  "onFailure": "error_prompt"
+}
+```
+
+**Failure conditions:**
+- The OU has dependent resources (child OUs, users, or groups) that block deletion
 - OU service error
 
 </details>

--- a/frontend/apps/console/src/features/flows/data/executors.json
+++ b/frontend/apps/console/src/features/flows/data/executors.json
@@ -485,6 +485,50 @@
     "category": "EXECUTOR",
     "type": "TASK_EXECUTION",
     "display": {
+      "header": "OU Delete Executor",
+      "label": "OU Rollback",
+      "description": "Delete the organization unit created earlier in this flow execution",
+      "image": "assets/images/icons/form.svg",
+      "showOnResourcePanel": true
+    },
+    "data": {
+      "action": {
+        "type": "EXECUTOR",
+        "executor": {
+          "name": "OUDeleteExecutor"
+        },
+        "onSuccess": "",
+        "onFailure": ""
+      }
+    }
+  },
+  {
+    "resourceType": "STEP",
+    "category": "EXECUTOR",
+    "type": "TASK_EXECUTION",
+    "display": {
+      "header": "User Rollback Executor",
+      "label": "User Rollback",
+      "description": "Revoke tokens and delete the user provisioned earlier in this flow execution",
+      "image": "assets/images/icons/user.svg",
+      "showOnResourcePanel": true
+    },
+    "data": {
+      "action": {
+        "type": "EXECUTOR",
+        "executor": {
+          "name": "UserRollbackExecutor"
+        },
+        "onSuccess": "",
+        "onFailure": ""
+      }
+    }
+  },
+  {
+    "resourceType": "STEP",
+    "category": "EXECUTOR",
+    "type": "TASK_EXECUTION",
+    "display": {
       "header": "HTTP Request Executor",
       "label": "HTTP Request",
       "description": "Call an external API over HTTP",

--- a/tests/integration/flow/execution/ou_creation_after_provisioning_test.go
+++ b/tests/integration/flow/execution/ou_creation_after_provisioning_test.go
@@ -1,0 +1,359 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+var (
+	ouAfterProvisioningOU = testutils.OrganizationUnit{
+		Handle:      "ou-after-provisioning-test-ou",
+		Name:        "OU After Provisioning Test Organization Unit",
+		Description: "Parent/default organization unit for the OU-after-Provisioning regression test",
+		Parent:      nil,
+	}
+
+	ouAfterProvisioningUserType = testutils.UserType{
+		Name: "ou-after-provisioning-user-type",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type":     "string",
+				"unique":   true,
+				"required": true,
+			},
+			"password": map[string]interface{}{
+				"type":       "string",
+				"credential": true,
+			},
+			"email": map[string]interface{}{
+				"type":     "string",
+				"unique":   true,
+				"required": true,
+			},
+		},
+	}
+
+	// ouAfterProvisioningFlow reproduces issue #5276: a REGISTRATION flow that resolves the user
+	// type, provisions the user (landing them in the user type's own default OU), then places an OU
+	// Creation node afterward. Before the fix, OUExecutor would skip creation entirely the moment the
+	// now-authenticated, just-provisioned user was detected as already having an entity reference.
+	ouAfterProvisioningFlow = testutils.Flow{
+		Name:     "OU Creation After Provisioning Test",
+		FlowType: "REGISTRATION",
+		Handle:   "ou_creation_after_provisioning_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "user_type_resolver",
+			},
+			{
+				"id":   "user_type_resolver",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "UserTypeResolver",
+				},
+				"onSuccess":    "provisioning",
+				"onIncomplete": "prompt_usertype",
+			},
+			{
+				"id":   "prompt_usertype",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "usertype_input",
+								"identifier": "userType",
+								"type":       "SELECT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_usertype",
+							"nextNode": "user_type_resolver",
+						},
+					},
+				},
+			},
+			{
+				"id":   "provisioning",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "ProvisioningExecutor",
+				},
+				"onSuccess":    "ou_creation",
+				"onIncomplete": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_username",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_email",
+								"identifier": "email",
+								"type":       "EMAIL_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_password",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_submit_credentials",
+							"nextNode": "provisioning",
+						},
+					},
+				},
+			},
+			{
+				"id":   "ou_creation",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "OUExecutor",
+					"inputs": []map[string]interface{}{
+						{"ref": "input_ou_name", "identifier": "ouName", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_ou_handle", "identifier": "ouHandle", "type": "TEXT_INPUT", "required": true},
+					},
+				},
+				"onSuccess":    "end",
+				"onIncomplete": "prompt_ou_details",
+			},
+			{
+				"id":   "prompt_ou_details",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_ouname_field",
+								"identifier": "ouName",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_ouhandle_field",
+								"identifier": "ouHandle",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_ou_submit",
+							"nextNode": "ou_creation",
+						},
+					},
+				},
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+)
+
+// findChildOUByHandle looks up an organization unit by handle among a specific parent's children,
+// via GET /organization-units/{parentID}/ous. The top-level GET /organization-units list only ever
+// returns root-level OUs (PARENT_ID IS NULL, both in the DB-backed and file-based stores), so a
+// child OU created under a parent is never visible there regardless of any filter — the parent's own
+// child-listing endpoint is the only way to find it.
+func findChildOUByHandle(parentID, handle string) (*testutils.OrganizationUnit, error) {
+	req, err := http.NewRequest("GET",
+		fmt.Sprintf("%s/organization-units/%s/ous", testutils.TestServerURL, parentID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	q := req.URL.Query()
+	q.Set("filter", fmt.Sprintf("handle eq %q", handle))
+	req.URL.RawQuery = q.Encode()
+
+	client := testutils.GetHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status listing child organization units: %d", resp.StatusCode)
+	}
+
+	var listResp struct {
+		OrganizationUnits []testutils.OrganizationUnit `json:"organizationUnits"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	if len(listResp.OrganizationUnits) == 0 {
+		return nil, fmt.Errorf("no child organization unit found with handle %q under parent %q", handle, parentID)
+	}
+	return &listResp.OrganizationUnits[0], nil
+}
+
+// OUCreationAfterProvisioningTestSuite verifies the fix for issue #5276: OUExecutor must not skip
+// creating a new organization unit just because the current, already-authenticated user was
+// provisioned earlier in the same execution, and doing so must not move that user out of their own
+// default organization unit.
+type OUCreationAfterProvisioningTestSuite struct {
+	suite.Suite
+	config            *common.TestSuiteConfig
+	ouID              string
+	userTypeID        string
+	authFlowID        string
+	flowID            string
+	appID             string
+	childOUID         string
+	provisionedUserID string
+}
+
+func TestOUCreationAfterProvisioningTestSuite(t *testing.T) {
+	suite.Run(t, new(OUCreationAfterProvisioningTestSuite))
+}
+
+func (ts *OUCreationAfterProvisioningTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(ouAfterProvisioningOU)
+	ts.Require().NoError(err, "Failed to create test organization unit during setup")
+	ts.ouID = ouID
+
+	ouAfterProvisioningUserType.OUID = ts.ouID
+	ouAfterProvisioningUserType.AllowSelfRegistration = true
+	userTypeID, err := testutils.CreateUserType(ouAfterProvisioningUserType)
+	ts.Require().NoError(err, "Failed to create user type during setup")
+	ts.userTypeID = userTypeID
+
+	authFlowID, err := testutils.CreateIsolatedAuthFlow("ou-after-provisioning-isolated-auth")
+	ts.Require().NoError(err, "Failed to create isolated auth flow")
+	ts.authFlowID = authFlowID
+
+	flowID, err := testutils.CreateFlow(ouAfterProvisioningFlow)
+	ts.Require().NoError(err, "Failed to create OU-after-Provisioning test flow")
+	ts.flowID = flowID
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	appID, err := testutils.CreateApplication(testutils.Application{
+		Name:                      "OU Creation After Provisioning Test Application",
+		Description:               "Application for testing OUExecutor placed after ProvisioningExecutor",
+		OUID:                      ts.ouID,
+		IsRegistrationFlowEnabled: true,
+		AuthFlowID:                ts.authFlowID,
+		RegistrationFlowID:        flowID,
+		ClientID:                  "ou_after_provisioning_test_client",
+		ClientSecret:              "ou_after_provisioning_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{ouAfterProvisioningUserType.Name},
+	})
+	ts.Require().NoError(err, "Failed to create test application during setup")
+	ts.appID = appID
+}
+
+func (ts *OUCreationAfterProvisioningTestSuite) TearDownSuite() {
+	if ts.provisionedUserID != "" {
+		if err := testutils.DeleteUser(ts.provisionedUserID); err != nil {
+			ts.T().Logf("Failed to delete provisioned user during teardown: %v", err)
+		}
+	}
+	if ts.childOUID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.childOUID); err != nil {
+			ts.T().Logf("Failed to delete child organization unit during teardown: %v", err)
+		}
+	}
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	if ts.authFlowID != "" {
+		if err := testutils.DeleteFlow(ts.authFlowID); err != nil {
+			ts.T().Logf("Failed to delete isolated auth flow during teardown: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// TestOUCreationAfterProvisioningStillCreatesOU reproduces issue #5276 end to end: it provisions a
+// user, asserts the flow still pauses for OU details afterward (proving OUExecutor did not silently
+// skip), then asserts the new child OU actually exists under the expected parent and that the user
+// remains in their own default OU rather than being moved into the new one.
+func (ts *OUCreationAfterProvisioningTestSuite) TestOUCreationAfterProvisioningStillCreatesOU() {
+	username := common.GenerateUniqueUsername("ouafterprovisioning")
+	email := fmt.Sprintf("%s@example.com", username)
+	ouHandle := fmt.Sprintf("ou-after-provisioning-child-%d", time.Now().UnixNano())
+
+	flowStep, err := common.InitiateRegistrationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
+		"the flow should pause at prompt_credentials, since only one user type is allowed")
+
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"username": username,
+		"email":    email,
+		"password": "OuAfterProvisioning123!",
+	}, "action_submit_credentials", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	// The whole point of this test: before the fix, OUExecutor would skip creation entirely here
+	// (the now-authenticated, just-provisioned user already has an entity reference) and the flow
+	// would jump straight to COMPLETE without ever asking for OU details.
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
+		"OUExecutor must not skip creation just because the user was already provisioned in this "+
+			"same execution; the flow should pause at prompt_ou_details")
+
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"ouName":   "OU After Provisioning Child",
+		"ouHandle": ouHandle,
+	}, "action_ou_submit", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+
+	// The new child OU must actually exist, under the expected parent.
+	childOU, findErr := findChildOUByHandle(ts.ouID, ouHandle)
+	ts.Require().NoError(findErr, "the child OU should have been created under the user's default OU")
+	ts.Require().Equal(ouHandle, childOU.Handle)
+	ts.childOUID = childOU.ID
+
+	// The user must remain in their own default OU, not be moved into the new child OU.
+	provisionedUser, findUserErr := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(findUserErr)
+	ts.Require().NotNil(provisionedUser)
+	ts.provisionedUserID = provisionedUser.ID
+	ts.Require().Equal(ts.ouID, provisionedUser.OUID,
+		"the user must stay in their own default OU rather than being moved into the new child OU")
+}

--- a/tests/integration/flow/execution/ou_delete_executor_test.go
+++ b/tests/integration/flow/execution/ou_delete_executor_test.go
@@ -1,0 +1,553 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+var (
+	ouDeleteRollbackOU = testutils.OrganizationUnit{
+		Handle:      "ou-delete-rollback-test-ou",
+		Name:        "OU Delete Rollback Test Organization Unit",
+		Description: "Parent organization unit for OUDeleteExecutor rollback testing",
+		Parent:      nil,
+	}
+
+	// username and email are marked required so ProvisioningExecutor's HasRequiredInputs check
+	// recognizes them as missing when credentials haven't been submitted yet — without that, it
+	// treats zero required-and-missing fields as satisfied and fails outright on the empty
+	// attribute set, rather than pausing at prompt_credentials for them.
+	ouDeleteRollbackUserType = testutils.UserType{
+		Name: "ou-delete-rollback-user-type",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type":     "string",
+				"unique":   true,
+				"required": true,
+			},
+			"password": map[string]interface{}{
+				"type":       "string",
+				"credential": true,
+			},
+			"email": map[string]interface{}{
+				"type":     "string",
+				"unique":   true,
+				"required": true,
+			},
+			"given_name": map[string]interface{}{
+				"type": "string",
+			},
+			"family_name": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
+	// errCodeProvisioningAttributeConflict is ProvisioningExecutor's error code when a unique
+	// attribute (email, here) conflicts with an existing user.
+	errCodeProvisioningAttributeConflict = "FET-1080"
+)
+
+// ouDeleteRollbackPrefixNodes returns the node chain shared by every OUDeleteExecutor rollback
+// scenario below: resolve the user type, create an OU, then attempt provisioning. Provisioning
+// fails whenever the submitted email conflicts with an existing user (a deterministic,
+// self-contained trigger: the conflicting user is seeded in SetupSuite, so no shared server state
+// is relied upon). Every scenario's provisioning node routes onFailure straight to its own
+// "ou_rollback" node — an OUDeleteExecutor is one of the executors exempt from the general
+// "onFailure must target a PROMPT node" rule, precisely so a flow can wire rollback directly
+// without an intervening prompt.
+func ouDeleteRollbackPrefixNodes() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "user_type_resolver",
+		},
+		{
+			"id":   "user_type_resolver",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "UserTypeResolver",
+			},
+			"onSuccess":    "ou_creation",
+			"onIncomplete": "prompt_usertype",
+		},
+		{
+			"id":   "prompt_usertype",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "usertype_input",
+							"identifier": "userType",
+							"type":       "SELECT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_usertype",
+						"nextNode": "user_type_resolver",
+					},
+				},
+			},
+		},
+		{
+			"id":   "ou_creation",
+			"type": "TASK_EXECUTION",
+			"properties": map[string]interface{}{
+				"parentOuId": "",
+			},
+			"executor": map[string]interface{}{
+				"name": "OUExecutor",
+			},
+			"onSuccess":    "provisioning",
+			"onIncomplete": "prompt_ou_details",
+		},
+		{
+			"id":   "prompt_ou_details",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_ou_name",
+							"identifier": "ouName",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_ou_handle",
+							"identifier": "ouHandle",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_ou_submit",
+						"nextNode": "ou_creation",
+					},
+				},
+			},
+		},
+		{
+			"id":   "provisioning",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "ProvisioningExecutor",
+			},
+			"onSuccess":    "end",
+			"onFailure":    "ou_rollback",
+			"onIncomplete": "prompt_credentials",
+		},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_username",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_email",
+							"identifier": "email",
+							"type":       "EMAIL_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_password",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_given_name",
+							"identifier": "given_name",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_family_name",
+							"identifier": "family_name",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_submit_credentials",
+						"nextNode": "provisioning",
+					},
+				},
+			},
+		},
+	}
+}
+
+var (
+	// ouDeleteSilentRollbackFlow routes provisioning's failure directly into OUDeleteExecutor with
+	// no PROMPT node in between, so the whole failure-and-rollback sequence completes within a
+	// single request/response. Nothing ever reads the forwarded failure reason back out in this
+	// shape, so the caller never learns why registration failed — only that it did.
+	ouDeleteSilentRollbackFlow = testutils.Flow{
+		Name:     "OU Delete Executor Silent Rollback Test",
+		FlowType: "REGISTRATION",
+		Handle:   "ou_delete_executor_silent_rollback_test",
+		Nodes: append(ouDeleteRollbackPrefixNodes(),
+			map[string]interface{}{
+				"id":   "ou_rollback",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "OUDeleteExecutor",
+				},
+				"onSuccess": "end",
+			},
+			map[string]interface{}{
+				"id":   "end",
+				"type": "END",
+			},
+		),
+	}
+
+	// ouDeleteRollbackThenErrorFlow routes OUDeleteExecutor's own onSuccess to an interactive PROMPT
+	// node rather than straight to END. OUDeleteExecutor still runs immediately, within the same
+	// request as the provisioning failure, but the flow then pauses at that PROMPT node — which,
+	// being interactive, is one of the node types that surfaces the failure reason still sitting
+	// unconsumed in runtime data. So by the time the caller sees the real error, the rollback has
+	// already happened.
+	ouDeleteRollbackThenErrorFlow = testutils.Flow{
+		Name:     "OU Delete Executor Rollback Then Error Test",
+		FlowType: "REGISTRATION",
+		Handle:   "ou_delete_executor_rollback_then_error_test",
+		Nodes: append(ouDeleteRollbackPrefixNodes(),
+			map[string]interface{}{
+				"id":   "ou_rollback",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "OUDeleteExecutor",
+				},
+				"onSuccess": "final_error_prompt",
+			},
+			map[string]interface{}{
+				"id":   "final_error_prompt",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{},
+						"action": map[string]interface{}{
+							"ref":      "action_final_error_ok",
+							"nextNode": "end",
+						},
+					},
+				},
+			},
+			map[string]interface{}{
+				"id":   "end",
+				"type": "END",
+			},
+		),
+	}
+)
+
+// findOrganizationUnitByHandle looks up an organization unit's ID by handle, since a failed
+// registration never reaches the point of returning the created OU's ID any other way (unlike a
+// successful one, whose ID is recoverable from the issued assertion's claims).
+func findOrganizationUnitByHandle(handle string) (*testutils.OrganizationUnit, error) {
+	req, err := http.NewRequest("GET", testutils.TestServerURL+"/organization-units", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	q := req.URL.Query()
+	q.Set("filter", fmt.Sprintf("handle eq %q", handle))
+	req.URL.RawQuery = q.Encode()
+
+	client := testutils.GetHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status listing organization units: %d", resp.StatusCode)
+	}
+
+	var listResp struct {
+		OrganizationUnits []testutils.OrganizationUnit `json:"organizationUnits"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	if len(listResp.OrganizationUnits) == 0 {
+		return nil, fmt.Errorf("no organization unit found with handle %q", handle)
+	}
+	return &listResp.OrganizationUnits[0], nil
+}
+
+// OUDeleteExecutorTestSuite verifies that an OUDeleteExecutor node, wired into a flow's own
+// onFailure branch, actually rolls back an organization unit created earlier in the same
+// execution — the scenario described in the "OU created by OUExecutor cannot be rolled back"
+// issue this executor fixes.
+type OUDeleteExecutorTestSuite struct {
+	suite.Suite
+	config                 *common.TestSuiteConfig
+	ouID                   string
+	userTypeID             string
+	silentAppID            string
+	rollbackThenErrorAppID string
+	authFlowID             string
+	conflictUserID         string
+	conflictEmail          string
+}
+
+func TestOUDeleteExecutorTestSuite(t *testing.T) {
+	suite.Run(t, new(OUDeleteExecutorTestSuite))
+}
+
+func (ts *OUDeleteExecutorTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+	ts.conflictEmail = fmt.Sprintf("ou-delete-rollback-conflict-%d@example.com", time.Now().UnixNano())
+
+	ouID, err := testutils.CreateOrganizationUnit(ouDeleteRollbackOU)
+	ts.Require().NoError(err, "Failed to create test organization unit during setup")
+	ts.ouID = ouID
+
+	ouDeleteRollbackUserType.OUID = ts.ouID
+	ouDeleteRollbackUserType.AllowSelfRegistration = true
+	userTypeID, err := testutils.CreateUserType(ouDeleteRollbackUserType)
+	ts.Require().NoError(err, "Failed to create user type during setup")
+	ts.userTypeID = userTypeID
+
+	// Seed the conflicting user directly, rather than through a full registration, so the
+	// provisioning failure below is deterministic and self-contained within this test.
+	conflictAttrs, err := json.Marshal(map[string]interface{}{
+		"username":    fmt.Sprintf("ou-delete-rollback-conflict-%d", time.Now().UnixNano()),
+		"password":    "ConflictPass123!",
+		"email":       ts.conflictEmail,
+		"given_name":  "Conflict",
+		"family_name": "User",
+	})
+	ts.Require().NoError(err, "Failed to marshal conflict user attributes")
+	conflictUserID, err := testutils.CreateUser(testutils.User{
+		OUID:       ts.ouID,
+		Type:       ouDeleteRollbackUserType.Name,
+		Attributes: conflictAttrs,
+	})
+	ts.Require().NoError(err, "Failed to create conflicting user during setup")
+	ts.conflictUserID = conflictUserID
+
+	authFlowID, err := testutils.CreateIsolatedAuthFlow("ou-delete-rollback-isolated-auth")
+	ts.Require().NoError(err, "Failed to create isolated auth flow")
+	ts.authFlowID = authFlowID
+
+	silentFlowID, err := testutils.CreateFlow(ouDeleteSilentRollbackFlow)
+	ts.Require().NoError(err, "Failed to create OU delete silent rollback flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, silentFlowID)
+
+	rollbackThenErrorFlowID, err := testutils.CreateFlow(ouDeleteRollbackThenErrorFlow)
+	ts.Require().NoError(err, "Failed to create OU delete rollback-then-error flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, rollbackThenErrorFlowID)
+
+	silentAppID, err := testutils.CreateApplication(testutils.Application{
+		Name:                      "OU Delete Executor Silent Rollback Test Application",
+		Description:               "Application for testing OUDeleteExecutor's silent rollback",
+		OUID:                      ts.ouID,
+		IsRegistrationFlowEnabled: true,
+		AuthFlowID:                ts.authFlowID,
+		RegistrationFlowID:        silentFlowID,
+		ClientID:                  "ou_delete_silent_rollback_test_client",
+		ClientSecret:              "ou_delete_silent_rollback_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{ouDeleteRollbackUserType.Name},
+	})
+	ts.Require().NoError(err, "Failed to create silent rollback test application during setup")
+	ts.silentAppID = silentAppID
+
+	rollbackThenErrorAppID, err := testutils.CreateApplication(testutils.Application{
+		Name:                      "OU Delete Executor Rollback Then Error Test Application",
+		Description:               "Application for testing OUDeleteExecutor's rollback-then-error",
+		OUID:                      ts.ouID,
+		IsRegistrationFlowEnabled: true,
+		AuthFlowID:                ts.authFlowID,
+		RegistrationFlowID:        rollbackThenErrorFlowID,
+		ClientID:                  "ou_delete_rollback_then_error_test_client",
+		ClientSecret:              "ou_delete_rollback_then_error_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{ouDeleteRollbackUserType.Name},
+	})
+	ts.Require().NoError(err, "Failed to create rollback-then-error test application during setup")
+	ts.rollbackThenErrorAppID = rollbackThenErrorAppID
+}
+
+func (ts *OUDeleteExecutorTestSuite) TearDownSuite() {
+	if ts.silentAppID != "" {
+		if err := testutils.DeleteApplication(ts.silentAppID); err != nil {
+			ts.T().Logf("Failed to delete silent rollback test application during teardown: %v", err)
+		}
+	}
+	if ts.rollbackThenErrorAppID != "" {
+		if err := testutils.DeleteApplication(ts.rollbackThenErrorAppID); err != nil {
+			ts.T().Logf("Failed to delete rollback-then-error test application during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	if ts.authFlowID != "" {
+		if err := testutils.DeleteFlow(ts.authFlowID); err != nil {
+			ts.T().Logf("Failed to delete isolated auth flow during teardown: %v", err)
+		}
+	}
+	if ts.conflictUserID != "" {
+		if err := testutils.CleanupUsers([]string{ts.conflictUserID}); err != nil {
+			ts.T().Logf("Failed to delete conflicting user during teardown: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// TestProvisioningFailureRollsBackSilently reproduces the original bug scenario using the silent
+// shape: an OU is created successfully, provisioning fails terminally on a duplicate attribute,
+// and OUDeleteExecutor (wired directly into provisioning's onFailure, with no PROMPT in between)
+// deletes the OU that would otherwise be orphaned — all within a single request/response, since
+// there is no PROMPT node forcing a pause. The tradeoff this proves: the caller is never told why
+// registration failed.
+func (ts *OUDeleteExecutorTestSuite) TestProvisioningFailureRollsBackSilently() {
+	ouHandle := fmt.Sprintf("ou-delete-silent-%d", time.Now().UnixNano())
+	username := common.GenerateUniqueUsername("oudeletesilent")
+
+	// Submit only the user type and OU details first, deliberately withholding credentials, so the
+	// flow pauses at prompt_credentials (provisioning's onIncomplete target) before provisioning
+	// ever runs. Submitting credentials in the same call as everything else would let provisioning
+	// fail and OUDeleteExecutor roll back within that single request/response — with no PROMPT node
+	// in between to pause at, there would be no way to observe the OU while it still exists.
+	flowStep, err := common.InitiateRegistrationFlow(ts.silentAppID, false, map[string]string{
+		"userType": ouDeleteRollbackUserType.Name,
+		"ouName":   "OU Delete Silent Rollback Test Child",
+		"ouHandle": ouHandle,
+	}, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
+		"the flow should pause at prompt_credentials, before provisioning runs")
+
+	// The OU must have been created before provisioning ever ran.
+	createdOU, findErr := findOrganizationUnitByHandle(ouHandle)
+	ts.Require().NoError(findErr, "OU should have been created before provisioning failed")
+	ts.Require().Equal(ouHandle, createdOU.Handle)
+
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"username":    username,
+		"email":       ts.conflictEmail, // deliberately conflicts with the seeded user
+		"password":    "RollbackTest123!",
+		"given_name":  "Rollback",
+		"family_name": "Test",
+	}, "action_submit_credentials", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	// provisioning's onFailure targets OUDeleteExecutor directly, so the whole failure-and-rollback
+	// sequence resolves within this single response — there is no PROMPT node to pause at.
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus,
+		"onFailure routes straight into OUDeleteExecutor with no PROMPT in between, so the flow "+
+			"resolves within this same request")
+	ts.Require().Empty(flowStep.Assertion, "a failed registration must not issue an assertion")
+	ts.Require().Nil(flowStep.Error,
+		"skipping every PROMPT node means nothing ever reads the forwarded failure reason back out")
+
+	// Confirm provisioning genuinely failed on the conflict, rather than succeeding and creating a
+	// second user with the same email, by checking no user was created with this attempt's username.
+	conflictingUser, findUserErr := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(findUserErr)
+	ts.Require().Nil(conflictingUser, "provisioning must not have created a user for the conflicting email")
+
+	// The whole point of OUDeleteExecutor: the OU created above must now be gone.
+	_, getErr := testutils.GetOrganizationUnit(createdOU.ID)
+	ts.Require().Error(getErr, "OUDeleteExecutor should have deleted the organization unit")
+}
+
+// TestProvisioningFailureRollsBackThenShowsError reproduces the same bug scenario using the
+// rollback-then-error shape: OUDeleteExecutor's own onSuccess targets an interactive PROMPT node
+// instead of END directly. OUDeleteExecutor still runs immediately, within the same request as the
+// provisioning failure, but the flow then pauses at that PROMPT node, which surfaces the failure
+// reason still sitting unconsumed in runtime data. So by the time the caller sees the real error,
+// the OU is already gone.
+func (ts *OUDeleteExecutorTestSuite) TestProvisioningFailureRollsBackThenShowsError() {
+	ouHandle := fmt.Sprintf("ou-delete-then-error-%d", time.Now().UnixNano())
+	username := common.GenerateUniqueUsername("oudeletethenerror")
+
+	// Submit only the user type and OU details first, deliberately withholding credentials, so the
+	// flow pauses at prompt_credentials (provisioning's onIncomplete target) before provisioning
+	// ever runs. Submitting credentials in the same call as everything else would let provisioning
+	// fail and OUDeleteExecutor roll back before this test ever observes the OU while it still
+	// exists — final_error_prompt would still show the error, but only after rollback already ran.
+	flowStep, err := common.InitiateRegistrationFlow(ts.rollbackThenErrorAppID, false, map[string]string{
+		"userType": ouDeleteRollbackUserType.Name,
+		"ouName":   "OU Delete Rollback Then Error Test Child",
+		"ouHandle": ouHandle,
+	}, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
+		"the flow should pause at prompt_credentials, before provisioning runs")
+
+	// The OU must have been created before provisioning ever ran.
+	createdOU, findErr := findOrganizationUnitByHandle(ouHandle)
+	ts.Require().NoError(findErr, "OU should have been created before provisioning failed")
+	ts.Require().Equal(ouHandle, createdOU.Handle)
+
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"username":    username,
+		"email":       ts.conflictEmail, // deliberately conflicts with the seeded user
+		"password":    "RollbackTest123!",
+		"given_name":  "Rollback",
+		"family_name": "Test",
+	}, "action_submit_credentials", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	// The flow pauses at final_error_prompt, an interactive PROMPT node, only to surface the real
+	// failure reason — OUDeleteExecutor has already run, in this same request, before this point.
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
+		"the flow pauses at the final interactive error prompt, after rollback has already run")
+	ts.Require().Empty(flowStep.Assertion, "a failed registration must not issue an assertion")
+	ts.Require().NotNil(flowStep.Error, "the interactive prompt after rollback surfaces the real failure reason")
+	ts.Require().Equal(errCodeProvisioningAttributeConflict, flowStep.Error.Code)
+
+	// Confirm provisioning genuinely failed on the conflict, rather than succeeding and creating a
+	// second user with the same email, by checking no user was created with this attempt's username.
+	conflictingUser, findUserErr := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(findUserErr)
+	ts.Require().Nil(conflictingUser, "provisioning must not have created a user for the conflicting email")
+
+	// The whole point of OUDeleteExecutor: the OU created above is already gone, before the error
+	// was ever shown to the caller.
+	_, getErr := testutils.GetOrganizationUnit(createdOU.ID)
+	ts.Require().Error(getErr, "OUDeleteExecutor should have deleted the organization unit")
+
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, nil, "action_final_error_ok", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus,
+		"acknowledging the error prompt completes the flow via its own END node")
+	ts.Require().Empty(flowStep.Assertion, "a failed registration must not issue an assertion")
+}

--- a/tests/integration/flow/execution/user_rollback_executor_test.go
+++ b/tests/integration/flow/execution/user_rollback_executor_test.go
@@ -1,0 +1,443 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const userRollbackRedirectURI = "https://localhost:3000"
+
+var (
+	userRollbackOU = testutils.OrganizationUnit{
+		Handle:      "user-rollback-test-ou",
+		Name:        "User Rollback Test Organization Unit",
+		Description: "Organization unit for UserRollbackExecutor rollback testing",
+		Parent:      nil,
+	}
+
+	// userRollbackUserType marks username and email required (not just unique) so
+	// ProvisioningExecutor's HasRequiredInputs check correctly pauses at prompt_credentials when
+	// they are absent, the same fix TestProvisioningFailureRollsBackSilently needed.
+	userRollbackUserType = testutils.UserType{
+		Name: "user-rollback-test-user-type",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type":     "string",
+				"unique":   true,
+				"required": true,
+			},
+			"password": map[string]interface{}{
+				"type":       "string",
+				"credential": true,
+			},
+			"email": map[string]interface{}{
+				"type":     "string",
+				"unique":   true,
+				"required": true,
+			},
+		},
+	}
+
+	// userRollbackAuthFlow lets the user this test provisions log in with real credentials, so the
+	// test can obtain a genuine access token before triggering the rollback and confirm afterward
+	// that the token no longer works. Mirrors createTestAuthenticationFlow in
+	// tests/integration/oauth/introspect/introspect_test.go: action_001 is hardcoded inside
+	// testutils.ObtainAccessTokenWithPassword, so this ref must match exactly.
+	userRollbackAuthFlow = testutils.Flow{
+		Name:     "User Rollback Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "user_rollback_test_auth_flow",
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "prompt_credentials"},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+							{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+						},
+						"action": map[string]interface{}{"ref": "action_001", "nextNode": "credentials_auth"},
+					},
+				},
+			},
+			{
+				"id":   "credentials_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "CredentialsAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+				},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":        "auth_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	}
+
+	// userRollbackFlow provisions a user, pauses at a plain continuation prompt (giving this test a
+	// chance to log the new user in and obtain a real access token before anything fails), then runs
+	// an HTTP call that is deliberately misconfigured so it fails fast and deterministically without
+	// any real network attempt. Its onFailure routes straight into UserRollbackExecutor: no PROMPT
+	// node in between, since UserRollbackExecutor is one of the executors exempt from the general
+	// "onFailure must target a PROMPT node" rule, the same way OUDeleteExecutor is.
+	userRollbackFlow = testutils.Flow{
+		Name:     "User Rollback Executor Test",
+		FlowType: "REGISTRATION",
+		Handle:   "user_rollback_executor_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "user_type_resolver",
+			},
+			{
+				"id":   "user_type_resolver",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "UserTypeResolver",
+				},
+				"onSuccess":    "provisioning",
+				"onIncomplete": "prompt_usertype",
+			},
+			{
+				"id":   "prompt_usertype",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "usertype_input",
+								"identifier": "userType",
+								"type":       "SELECT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_usertype",
+							"nextNode": "user_type_resolver",
+						},
+					},
+				},
+			},
+			{
+				"id":   "provisioning",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "ProvisioningExecutor",
+				},
+				"onSuccess":    "continue_prompt",
+				"onIncomplete": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_username",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_email",
+								"identifier": "email",
+								"type":       "EMAIL_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_password",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_submit_credentials",
+							"nextNode": "provisioning",
+						},
+					},
+				},
+			},
+			{
+				"id":   "continue_prompt",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{},
+						"action": map[string]interface{}{
+							"ref":      "action_continue",
+							"nextNode": "http_task",
+						},
+					},
+				},
+			},
+			{
+				"id":   "http_task",
+				"type": "TASK_EXECUTION",
+				"properties": map[string]interface{}{
+					"url":     "not-a-valid-url",
+					"method":  "POST",
+					"timeout": 3,
+					"errorHandling": map[string]interface{}{
+						"failOnError": true,
+						"retryCount":  0,
+						"retryDelay":  0,
+					},
+				},
+				"executor": map[string]interface{}{
+					"name": "HTTPRequestExecutor",
+				},
+				"onSuccess": "end",
+				"onFailure": "user_rollback",
+			},
+			{
+				"id":   "user_rollback",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "UserRollbackExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+)
+
+// introspectResult is the parsed outcome of one call to the introspection endpoint. Mirrors
+// tests/integration/oauth/introspect/introspect_test.go's own helper of the same shape.
+type introspectResult struct {
+	StatusCode int
+	Body       map[string]any
+}
+
+// introspectPost introspects a token as a client_secret_post client.
+func introspectPost(token, clientID, clientSecret string) (introspectResult, error) {
+	form := url.Values{}
+	form.Set("token", token)
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+
+	req, err := http.NewRequest(http.MethodPost, testutils.TestServerURL+"/oauth2/introspect",
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return introspectResult{}, fmt.Errorf("failed to create introspection request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := testutils.GetRawHTTPClient().Do(req)
+	if err != nil {
+		return introspectResult{}, fmt.Errorf("failed to send introspection request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return introspectResult{}, fmt.Errorf("failed to read introspection response: %w", err)
+	}
+
+	result := introspectResult{StatusCode: resp.StatusCode}
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &result.Body); err != nil {
+			return introspectResult{}, fmt.Errorf("introspection body is not JSON: %s", string(body))
+		}
+	}
+	return result, nil
+}
+
+func (r introspectResult) active() bool {
+	value, _ := r.Body["active"].(bool)
+	return value
+}
+
+// UserRollbackExecutorTestSuite verifies that a UserRollbackExecutor node, wired into a flow's own
+// onFailure branch, actually rolls back a user provisioned earlier in the same execution: the user
+// is deleted, and an access token obtained for that user before the rollback stops working
+// immediately afterward.
+type UserRollbackExecutorTestSuite struct {
+	suite.Suite
+	config         *common.TestSuiteConfig
+	ouID           string
+	userTypeID     string
+	authFlowID     string
+	registrationID string
+	appID          string
+	clientID       string
+	clientSecret   string
+}
+
+func TestUserRollbackExecutorTestSuite(t *testing.T) {
+	suite.Run(t, new(UserRollbackExecutorTestSuite))
+}
+
+func (ts *UserRollbackExecutorTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	ts.clientID = fmt.Sprintf("user_rollback_test_client_%s", suffix)
+	ts.clientSecret = "user_rollback_test_secret"
+
+	// Suffix every unique fixture identifier so a repeat SetupSuite invocation against a shared,
+	// non-reset service (rather than the throwaway per-run database the integration harness
+	// normally provisions) does not collide with fixtures a prior run left behind.
+	userRollbackOU.Name = fmt.Sprintf("User Rollback Test Organization Unit %s", suffix)
+	userRollbackOU.Handle = fmt.Sprintf("user-rollback-test-ou-%s", suffix)
+	ouID, err := testutils.CreateOrganizationUnit(userRollbackOU)
+	ts.Require().NoError(err, "Failed to create test organization unit during setup")
+	ts.ouID = ouID
+
+	userRollbackUserType.Name = fmt.Sprintf("user-rollback-test-user-type-%s", suffix)
+	userRollbackUserType.OUID = ts.ouID
+	userRollbackUserType.AllowSelfRegistration = true
+	userTypeID, err := testutils.CreateUserType(userRollbackUserType)
+	ts.Require().NoError(err, "Failed to create user type during setup")
+	ts.userTypeID = userTypeID
+
+	userRollbackAuthFlow.Handle = fmt.Sprintf("user_rollback_test_auth_flow_%s", suffix)
+	authFlowID, err := testutils.CreateFlow(userRollbackAuthFlow)
+	ts.Require().NoError(err, "Failed to create test authentication flow")
+	ts.authFlowID = authFlowID
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, authFlowID)
+
+	userRollbackFlow.Handle = fmt.Sprintf("user_rollback_executor_test_%s", suffix)
+	registrationID, err := testutils.CreateFlow(userRollbackFlow)
+	ts.Require().NoError(err, "Failed to create user rollback test flow")
+	ts.registrationID = registrationID
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, registrationID)
+
+	appID, err := testutils.CreateApplication(testutils.Application{
+		Name:                      "User Rollback Executor Test Application",
+		Description:               "Application for testing UserRollbackExecutor rollback",
+		OUID:                      ts.ouID,
+		IsRegistrationFlowEnabled: true,
+		AuthFlowID:                ts.authFlowID,
+		RegistrationFlowID:        ts.registrationID,
+		AllowedUserTypes:          []string{userRollbackUserType.Name},
+		InboundAuthConfig: []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                ts.clientID,
+					"clientSecret":            ts.clientSecret,
+					"redirectUris":            []string{userRollbackRedirectURI},
+					"grantTypes":              []string{"authorization_code"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_post",
+					"pkceRequired":            true,
+				},
+			},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create test application during setup")
+	ts.appID = appID
+}
+
+func (ts *UserRollbackExecutorTestSuite) TearDownSuite() {
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// TestProvisioningSucceedsThenLaterFailureRollsBackUser reproduces the scenario in issue #5277: a
+// user is provisioned successfully, then a later node in the same execution fails. It asserts the
+// user is fully rolled back — deleted, and any access token they already obtained is revoked —
+// rather than left behind as a live, loginable account with no compensating action.
+func (ts *UserRollbackExecutorTestSuite) TestProvisioningSucceedsThenLaterFailureRollsBackUser() {
+	username := common.GenerateUniqueUsername("userrollback")
+	email := fmt.Sprintf("%s@example.com", username)
+	password := "RollbackTest123!"
+
+	flowStep, err := common.InitiateRegistrationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
+		"the flow should pause at prompt_credentials, since only one user type is allowed")
+
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"username": username,
+		"email":    email,
+		"password": password,
+	}, "action_submit_credentials", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
+		"the flow should pause at continue_prompt right after provisioning succeeds")
+
+	// Confirm provisioning genuinely succeeded before anything else runs.
+	provisionedUser, findErr := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(findErr)
+	ts.Require().NotNil(provisionedUser, "provisioning should have created the user before the later failure")
+
+	// Log the newly provisioned user in through a completely separate authentication flow, exactly as
+	// an end user abandoning the registration flow at this point could do, and obtain a real access
+	// token for them.
+	tokens, tokenErr := testutils.ObtainAccessTokenWithPassword(
+		ts.clientID, userRollbackRedirectURI, "openid", username, password, true, ts.clientSecret)
+	ts.Require().NoError(tokenErr, "the provisioned user should already be able to log in")
+	ts.Require().NotEmpty(tokens.AccessToken)
+
+	// Sanity check: the token is genuinely active before the rollback.
+	before, introspectErr := introspectPost(tokens.AccessToken, ts.clientID, ts.clientSecret)
+	ts.Require().NoError(introspectErr)
+	ts.Require().True(before.active(), "the token must be active before the rollback runs")
+
+	// Continue the original registration execution: the HTTP task fails deterministically, its
+	// onFailure routes straight into UserRollbackExecutor, and the whole failure-and-rollback
+	// sequence resolves within this single response, since there is no PROMPT node in between.
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, nil, "action_continue", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus,
+		"onFailure routes straight into UserRollbackExecutor with no PROMPT in between")
+
+	// The whole point of UserRollbackExecutor: the user provisioned above must now be gone.
+	rolledBackUser, findErr := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(findErr)
+	ts.Require().Nil(rolledBackUser, "UserRollbackExecutor should have deleted the provisioned user")
+
+	// And the access token obtained before the rollback must no longer work, proving
+	// RevokeByCriteria actually ran rather than the delete alone leaving old tokens usable.
+	after, introspectErr := introspectPost(tokens.AccessToken, ts.clientID, ts.clientSecret)
+	ts.Require().NoError(introspectErr)
+	ts.Require().False(after.active(), "the token must be revoked once the user is rolled back")
+}


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->

Two related gaps left a flow with no way to compensate for state it already created earlier in the same execution, once a later node failed:

- https://github.com/AmshikaH/thunderid/issues/5194: an OU created by OUExecutor had no rollback path if a later node failed, since nothing in this codebase could delete an OU created earlier in the same execution.
- https://github.com/AmshikaH/thunderid/issues/5277: same problem for a user created by ProvisioningExecutor. The existing UserDeleteExecutor couldn't fill this gap: it's restricted to ADMINISTRATION flows, and it requires a "trusted revocation plan" pre-populated by PreDeleteExecutor, which nothing in a registration/onboarding flow ever produces.
- https://github.com/thunder-id/thunderid/issues/5276: OUExecutor silently skipped creating a new organization unit whenever the current user already had an entity reference, i.e., whenever the user had already been authenticated or provisioned earlier in the same flow execution. This made it impossible to build flows where OU creation follows user provisioning (e.g., "join the parent org, then create your own child OU"), since the OU step would just no-op instead of running.

This PR adds two new, narrowly-scoped compensation executors that close both gaps.

<!--
---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

- OUDeleteExecutor: reads the OU ID recorded in runtime data by an earlier OUExecutor node, deletes it, and no-ops if none was recorded. Takes no inputs, so it can never target an arbitrary caller-supplied OU — it only ever acts on what this same execution created.
- UserRollbackExecutor: same shape, but for a provisioned user. Reads the user ID from runtime data (set by ProvisioningExecutor), then revokes every token issued to that user, terminates their sessions, and deletes them, in that order, stopping at the first failure rather than deleting the user while leaving live tokens/sessions behind.
- Both executors are exempt from the general "a TASK_EXECUTION node's onFailure must target a PROMPT node" validation rule (enforced in both mgt/validator.go at save time and graphbuilder/graph_builder.go at graph-build time), via a shared IsFailureTargetExemptExecutor check in executor/constants.go. This lets a flow author wire a failing node's onFailure straight into the rollback step, with no intermediate prompt required, so the compensation can run within the same request as the original failure.
- Neither executor touches the existing UserDeleteExecutor/PreDeleteExecutor/CriteriaRevocationExecutor administration pipeline - deliberately kept separate rather than adding a mode flag to the existing executor, since that pipeline's whole security model depends on never accepting a target from anywhere but its own trusted, pre-validated plan.
- Documented both under a new "OU Delete" / "User Rollback" pairing in advanced-configurations.mdx, including the two ways a flow author can route after the rollback (silently, straight to END; or via an interactive PROMPT that surfaces the original failure reason before ending).
- OU creation skip bug: Traced the skip check to an incidental addition in an unrelated AuthUser-representation refactor (PR [#3206](https://github.com/thunder-id/thunderid/pull/3206)); it had no legitimate business rationale, no test coverage, and no sample flow depended on it. Removed the check entirely so OUExecutor always attempts creation regardless of the current user's authentication/provisioning state within the same execution. Scope was deliberately limited to the skip bug itself.

### Related Issues

- Fixes https://github.com/thunder-id/thunderid/issues/5194
- Fixes https://github.com/thunder-id/thunderid/issues/5277
- Fixes https://github.com/thunder-id/thunderid/issues/5276

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added User Rollback and OU Delete steps for compensating failed or incomplete flows.
  - User Rollback revokes tokens, terminates sessions, and deletes users created during a flow.
  - OU Delete removes organization units created during a flow.
  - Both steps can be targeted directly from failure and incomplete branches.

- **Console**
  - Added User Rollback and OU Delete steps to the flow builder.

- **Bug Fixes**
  - Organization units can now be created successfully after user provisioning.

- **Documentation**
  - Added configuration guidance, prerequisites, examples, and failure behavior for both rollback steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->