### PR TITLE
Take a context in the layout, theme and translation stores

### DIFF
--- a/backend/internal/design/layout/mgt/composite_store.go
+++ b/backend/internal/design/layout/mgt/composite_store.go
@@ -4,6 +4,8 @@
 package layoutmgt
 
 import (
+	"context"
+
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 )
@@ -27,22 +29,22 @@ func newCompositeLayoutStore(fileStore, dbStore layoutMgtStoreInterface) *compos
 }
 
 // GetLayoutListCount retrieves the total count of layouts from both stores.
-func (c *compositeLayoutStore) GetLayoutListCount() (int, error) {
+func (c *compositeLayoutStore) GetLayoutListCount(ctx context.Context) (int, error) {
 	return declarativeresource.CompositeMergeCountHelper(
-		func() (int, error) { return c.dbStore.GetLayoutListCount() },
-		func() (int, error) { return c.fileStore.GetLayoutListCount() },
+		func() (int, error) { return c.dbStore.GetLayoutListCount(ctx) },
+		func() (int, error) { return c.fileStore.GetLayoutListCount(ctx) },
 	)
 }
 
 // GetLayoutList retrieves layouts from both stores with pagination.
 // Applies the 1000-record limit in composite mode to prevent memory exhaustion.
 // Returns errResultLimitExceededInCompositeMode if the limit is exceeded.
-func (c *compositeLayoutStore) GetLayoutList(limit, offset int) ([]Layout, error) {
+func (c *compositeLayoutStore) GetLayoutList(ctx context.Context, limit, offset int) ([]Layout, error) {
 	items, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
-		func() (int, error) { return c.dbStore.GetLayoutListCount() },
-		func() (int, error) { return c.fileStore.GetLayoutListCount() },
-		func(count int) ([]Layout, error) { return c.dbStore.GetLayoutList(count, 0) },
-		func(count int) ([]Layout, error) { return c.fileStore.GetLayoutList(count, 0) },
+		func() (int, error) { return c.dbStore.GetLayoutListCount(ctx) },
+		func() (int, error) { return c.fileStore.GetLayoutListCount(ctx) },
+		func(count int) ([]Layout, error) { return c.dbStore.GetLayoutList(ctx, count, 0) },
+		func(count int) ([]Layout, error) { return c.fileStore.GetLayoutList(ctx, count, 0) },
 		mergeAndDeduplicateLayouts,
 		limit,
 		offset,
@@ -60,16 +62,16 @@ func (c *compositeLayoutStore) GetLayoutList(limit, offset int) ([]Layout, error
 
 // CreateLayout creates a new layout in the database store only.
 // Conflict checking is handled at the service layer.
-func (c *compositeLayoutStore) CreateLayout(id string, layout CreateLayoutRequest) error {
-	return c.dbStore.CreateLayout(id, layout)
+func (c *compositeLayoutStore) CreateLayout(ctx context.Context, id string, layout CreateLayoutRequest) error {
+	return c.dbStore.CreateLayout(ctx, id, layout)
 }
 
 // GetLayout retrieves a layout by ID from either store.
 // Checks database store first, then falls back to file store (declarative).
-func (c *compositeLayoutStore) GetLayout(id string) (Layout, error) {
+func (c *compositeLayoutStore) GetLayout(ctx context.Context, id string) (Layout, error) {
 	layout, err := declarativeresource.CompositeGetHelper(
 		func() (Layout, error) {
-			layout, err := c.dbStore.GetLayout(id)
+			layout, err := c.dbStore.GetLayout(ctx, id)
 			if err != nil {
 				return Layout{}, err
 			}
@@ -77,7 +79,7 @@ func (c *compositeLayoutStore) GetLayout(id string) (Layout, error) {
 			return layout, nil
 		},
 		func() (Layout, error) {
-			layout, err := c.fileStore.GetLayout(id)
+			layout, err := c.fileStore.GetLayout(ctx, id)
 			if err != nil {
 				return Layout{}, err
 			}
@@ -90,9 +92,9 @@ func (c *compositeLayoutStore) GetLayout(id string) (Layout, error) {
 }
 
 // IsLayoutExist checks if a layout exists in either store.
-func (c *compositeLayoutStore) IsLayoutExist(id string) (bool, error) {
+func (c *compositeLayoutStore) IsLayoutExist(ctx context.Context, id string) (bool, error) {
 	// Check database store first
-	exists, err := c.dbStore.IsLayoutExist(id)
+	exists, err := c.dbStore.IsLayoutExist(ctx, id)
 	if err != nil {
 		return false, err
 	}
@@ -101,42 +103,43 @@ func (c *compositeLayoutStore) IsLayoutExist(id string) (bool, error) {
 	}
 
 	// Check file store
-	return c.fileStore.IsLayoutExist(id)
+	return c.fileStore.IsLayoutExist(ctx, id)
 }
 
 // UpdateLayout updates a layout in the database store only.
 // Returns an error if the layout is declarative (immutable).
-func (c *compositeLayoutStore) UpdateLayout(id string, layout UpdateLayoutRequest) error {
+func (c *compositeLayoutStore) UpdateLayout(ctx context.Context, id string, layout UpdateLayoutRequest) error {
 	return declarativeresource.CompositeUpdateHelper(
 		layout,
 		func(UpdateLayoutRequest) string { return id },
-		func(id string) (bool, error) { return c.fileStore.IsLayoutExist(id) },
-		func(UpdateLayoutRequest) error { return c.dbStore.UpdateLayout(id, layout) },
+		func(id string) (bool, error) { return c.fileStore.IsLayoutExist(ctx, id) },
+		func(UpdateLayoutRequest) error { return c.dbStore.UpdateLayout(ctx, id, layout) },
 		errCannotUpdateDeclarativeLayout,
 	)
 }
 
 // DeleteLayout deletes a layout from the database store only.
 // Returns an error if the layout is declarative (immutable).
-func (c *compositeLayoutStore) DeleteLayout(id string) error {
+func (c *compositeLayoutStore) DeleteLayout(ctx context.Context, id string) error {
 	return declarativeresource.CompositeDeleteHelper(
 		id,
-		func(id string) (bool, error) { return c.fileStore.IsLayoutExist(id) },
-		func(id string) error { return c.dbStore.DeleteLayout(id) },
+		func(id string) (bool, error) { return c.fileStore.IsLayoutExist(ctx, id) },
+		func(id string) error { return c.dbStore.DeleteLayout(ctx, id) },
 		errCannotDeleteDeclarativeLayout,
 	)
 }
 
 // IsLayoutDeclarative checks if a layout is immutable (exists in file store).
-func (c *compositeLayoutStore) IsLayoutDeclarative(id string) bool {
-	exists, err := c.fileStore.IsLayoutExist(id)
+func (c *compositeLayoutStore) IsLayoutDeclarative(ctx context.Context, id string) bool {
+	exists, err := c.fileStore.IsLayoutExist(ctx, id)
 	return err == nil && exists
 }
 
 // IsLayoutHandleConflict checks if a layout handle conflicts in either store.
-func (c *compositeLayoutStore) IsLayoutHandleConflict(handle string, excludeID string) (bool, error) {
+func (c *compositeLayoutStore) IsLayoutHandleConflict(ctx context.Context, handle string, excludeID string) (bool,
+	error) {
 	// Check file store first
-	conflict, err := c.fileStore.IsLayoutHandleConflict(handle, excludeID)
+	conflict, err := c.fileStore.IsLayoutHandleConflict(ctx, handle, excludeID)
 	if err != nil {
 		return false, err
 	}
@@ -144,7 +147,7 @@ func (c *compositeLayoutStore) IsLayoutHandleConflict(handle string, excludeID s
 		return true, nil
 	}
 	// Then check db store
-	return c.dbStore.IsLayoutHandleConflict(handle, excludeID)
+	return c.dbStore.IsLayoutHandleConflict(ctx, handle, excludeID)
 }
 
 // mergeAndDeduplicateLayouts merges layouts from DB and file stores, removing duplicates.

--- a/backend/internal/design/layout/mgt/composite_store_test.go
+++ b/backend/internal/design/layout/mgt/composite_store_test.go
@@ -31,10 +31,10 @@ func (suite *CompositeLayoutStoreTestSuite) SetupTest() {
 
 // Test GetLayoutListCount - Adds counts from both stores
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutListCount_AddsCounts() {
-	suite.mockDBStore.On("GetLayoutListCount").Return(2, nil)
-	suite.mockFileStore.On("GetLayoutListCount").Return(3, nil)
+	suite.mockDBStore.On("GetLayoutListCount", testCtx()).Return(2, nil)
+	suite.mockFileStore.On("GetLayoutListCount", testCtx()).Return(3, nil)
 
-	count, err := suite.store.GetLayoutListCount()
+	count, err := suite.store.GetLayoutListCount(testCtx())
 
 	suite.NoError(err)
 	suite.Equal(5, count) // 2 + 3 = 5 (no deduplication in count)
@@ -43,9 +43,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutListCount_AddsCounts() 
 // Test GetLayoutListCount - DB store error
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutListCount_DBStoreError() {
 	testErr := errors.New("db error")
-	suite.mockDBStore.On("GetLayoutListCount").Return(0, testErr)
+	suite.mockDBStore.On("GetLayoutListCount", testCtx()).Return(0, testErr)
 
-	_, err := suite.store.GetLayoutListCount()
+	_, err := suite.store.GetLayoutListCount(testCtx())
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -54,10 +54,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutListCount_DBStoreError(
 // Test GetLayoutListCount - File store count error
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutListCount_FileStoreCountError() {
 	testErr := errors.New("file store error")
-	suite.mockDBStore.On("GetLayoutListCount").Return(2, nil)
-	suite.mockFileStore.On("GetLayoutListCount").Return(0, testErr)
+	suite.mockDBStore.On("GetLayoutListCount", testCtx()).Return(2, nil)
+	suite.mockFileStore.On("GetLayoutListCount", testCtx()).Return(0, testErr)
 
-	_, err := suite.store.GetLayoutListCount()
+	_, err := suite.store.GetLayoutListCount(testCtx())
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -65,10 +65,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutListCount_FileStoreCoun
 
 // Test GetLayoutListCount - Empty stores
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutListCount_EmptyStores() {
-	suite.mockDBStore.On("GetLayoutListCount").Return(0, nil)
-	suite.mockFileStore.On("GetLayoutListCount").Return(0, nil)
+	suite.mockDBStore.On("GetLayoutListCount", testCtx()).Return(0, nil)
+	suite.mockFileStore.On("GetLayoutListCount", testCtx()).Return(0, nil)
 
-	count, err := suite.store.GetLayoutListCount()
+	count, err := suite.store.GetLayoutListCount(testCtx())
 
 	suite.NoError(err)
 	suite.Equal(0, count)
@@ -79,12 +79,12 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutList_Pagination() {
 	dbLayouts := []Layout{{ID: "layout1"}, {ID: "layout2"}}
 	fileLayouts := []Layout{{ID: "layout2"}, {ID: "layout3"}}
 
-	suite.mockDBStore.On("GetLayoutListCount").Return(2, nil)
-	suite.mockFileStore.On("GetLayoutListCount").Return(2, nil)
-	suite.mockDBStore.On("GetLayoutList", 2, 0).Return(dbLayouts, nil)
-	suite.mockFileStore.On("GetLayoutList", 2, 0).Return(fileLayouts, nil)
+	suite.mockDBStore.On("GetLayoutListCount", testCtx()).Return(2, nil)
+	suite.mockFileStore.On("GetLayoutListCount", testCtx()).Return(2, nil)
+	suite.mockDBStore.On("GetLayoutList", testCtx(), 2, 0).Return(dbLayouts, nil)
+	suite.mockFileStore.On("GetLayoutList", testCtx(), 2, 0).Return(fileLayouts, nil)
 
-	layouts, err := suite.store.GetLayoutList(2, 1)
+	layouts, err := suite.store.GetLayoutList(testCtx(), 2, 1)
 
 	suite.NoError(err)
 	suite.Len(layouts, 2) // Should get 2 layouts from offset 1
@@ -93,10 +93,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutList_Pagination() {
 // Test GetLayoutList - Returns limit exceeded error
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutList_LimitExceeded() {
 	// Create more layouts than the max composite store limit (1000)
-	suite.mockDBStore.On("GetLayoutListCount").Return(1001, nil)
-	suite.mockFileStore.On("GetLayoutListCount").Return(0, nil)
+	suite.mockDBStore.On("GetLayoutListCount", testCtx()).Return(1001, nil)
+	suite.mockFileStore.On("GetLayoutListCount", testCtx()).Return(0, nil)
 
-	_, err := suite.store.GetLayoutList(100, 0)
+	_, err := suite.store.GetLayoutList(testCtx(), 100, 0)
 
 	suite.Error(err)
 	suite.Equal(errResultLimitExceededInCompositeMode, err)
@@ -105,9 +105,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutList_LimitExceeded() {
 // Test GetLayoutList - DB store error
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutList_DBStoreError() {
 	testErr := errors.New("db error")
-	suite.mockDBStore.On("GetLayoutListCount").Return(0, testErr)
+	suite.mockDBStore.On("GetLayoutListCount", testCtx()).Return(0, testErr)
 
-	_, err := suite.store.GetLayoutList(10, 0)
+	_, err := suite.store.GetLayoutList(testCtx(), 10, 0)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -116,10 +116,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutList_DBStoreError() {
 // Test GetLayoutList - File store count error
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutList_FileStoreCountError() {
 	testErr := errors.New("file store error")
-	suite.mockDBStore.On("GetLayoutListCount").Return(2, nil)
-	suite.mockFileStore.On("GetLayoutListCount").Return(0, testErr)
+	suite.mockDBStore.On("GetLayoutListCount", testCtx()).Return(2, nil)
+	suite.mockFileStore.On("GetLayoutListCount", testCtx()).Return(0, testErr)
 
-	_, err := suite.store.GetLayoutList(10, 0)
+	_, err := suite.store.GetLayoutList(testCtx(), 10, 0)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -128,11 +128,11 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutList_FileStoreCountErro
 // Test GetLayoutList - DB layouts list error
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutList_DBLayoutsListError() {
 	testErr := errors.New("db list error")
-	suite.mockDBStore.On("GetLayoutListCount").Return(2, nil)
-	suite.mockFileStore.On("GetLayoutListCount").Return(2, nil)
-	suite.mockDBStore.On("GetLayoutList", 2, 0).Return(nil, testErr)
+	suite.mockDBStore.On("GetLayoutListCount", testCtx()).Return(2, nil)
+	suite.mockFileStore.On("GetLayoutListCount", testCtx()).Return(2, nil)
+	suite.mockDBStore.On("GetLayoutList", testCtx(), 2, 0).Return(nil, testErr)
 
-	_, err := suite.store.GetLayoutList(10, 0)
+	_, err := suite.store.GetLayoutList(testCtx(), 10, 0)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -142,12 +142,12 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutList_DBLayoutsListError
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayoutList_FileLayoutsListError() {
 	testErr := errors.New("file list error")
 	dbLayouts := []Layout{{ID: "layout1"}}
-	suite.mockDBStore.On("GetLayoutListCount").Return(1, nil)
-	suite.mockFileStore.On("GetLayoutListCount").Return(2, nil)
-	suite.mockDBStore.On("GetLayoutList", 1, 0).Return(dbLayouts, nil)
-	suite.mockFileStore.On("GetLayoutList", 2, 0).Return(nil, testErr)
+	suite.mockDBStore.On("GetLayoutListCount", testCtx()).Return(1, nil)
+	suite.mockFileStore.On("GetLayoutListCount", testCtx()).Return(2, nil)
+	suite.mockDBStore.On("GetLayoutList", testCtx(), 1, 0).Return(dbLayouts, nil)
+	suite.mockFileStore.On("GetLayoutList", testCtx(), 2, 0).Return(nil, testErr)
 
-	_, err := suite.store.GetLayoutList(10, 0)
+	_, err := suite.store.GetLayoutList(testCtx(), 10, 0)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -160,9 +160,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestCreateLayout_Success() {
 		Description: "Test Description",
 		Layout:      json.RawMessage(`{"components": []}`),
 	}
-	suite.mockDBStore.On("CreateLayout", "layout1", createReq).Return(nil)
+	suite.mockDBStore.On("CreateLayout", testCtx(), "layout1", createReq).Return(nil)
 
-	err := suite.store.CreateLayout("layout1", createReq)
+	err := suite.store.CreateLayout(testCtx(), "layout1", createReq)
 
 	suite.NoError(err)
 	suite.mockDBStore.AssertExpectations(suite.T())
@@ -174,9 +174,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestCreateLayout_DBStoreError() {
 	createReq := CreateLayoutRequest{
 		DisplayName: "Test Layout",
 	}
-	suite.mockDBStore.On("CreateLayout", "layout1", createReq).Return(testErr)
+	suite.mockDBStore.On("CreateLayout", testCtx(), "layout1", createReq).Return(testErr)
 
-	err := suite.store.CreateLayout("layout1", createReq)
+	err := suite.store.CreateLayout(testCtx(), "layout1", createReq)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -185,9 +185,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestCreateLayout_DBStoreError() {
 // Test GetLayout - From DB store (DB takes precedence)
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayout_FromDBStore() {
 	expectedLayout := Layout{ID: "layout1", DisplayName: "DB Layout"}
-	suite.mockDBStore.On("GetLayout", "layout1").Return(expectedLayout, nil)
+	suite.mockDBStore.On("GetLayout", testCtx(), "layout1").Return(expectedLayout, nil)
 
-	layout, err := suite.store.GetLayout("layout1")
+	layout, err := suite.store.GetLayout(testCtx(), "layout1")
 
 	suite.NoError(err)
 	suite.Equal(expectedLayout.ID, layout.ID)
@@ -198,10 +198,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayout_FromDBStore() {
 // Test GetLayout - From file store (fallback when not in DB store)
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayout_FromFileStore() {
 	expectedLayout := Layout{ID: "layout1", DisplayName: "File Layout"}
-	suite.mockDBStore.On("GetLayout", "layout1").Return(Layout{}, errLayoutNotFound)
-	suite.mockFileStore.On("GetLayout", "layout1").Return(expectedLayout, nil)
+	suite.mockDBStore.On("GetLayout", testCtx(), "layout1").Return(Layout{}, errLayoutNotFound)
+	suite.mockFileStore.On("GetLayout", testCtx(), "layout1").Return(expectedLayout, nil)
 
-	layout, err := suite.store.GetLayout("layout1")
+	layout, err := suite.store.GetLayout(testCtx(), "layout1")
 
 	suite.NoError(err)
 	suite.Equal(expectedLayout.ID, layout.ID)
@@ -211,10 +211,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayout_FromFileStore() {
 
 // Test GetLayout - Not found in either store
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayout_NotFound() {
-	suite.mockFileStore.On("GetLayout", "layout1").Return(Layout{}, errLayoutNotFound)
-	suite.mockDBStore.On("GetLayout", "layout1").Return(Layout{}, errLayoutNotFound)
+	suite.mockFileStore.On("GetLayout", testCtx(), "layout1").Return(Layout{}, errLayoutNotFound)
+	suite.mockDBStore.On("GetLayout", testCtx(), "layout1").Return(Layout{}, errLayoutNotFound)
 
-	_, err := suite.store.GetLayout("layout1")
+	_, err := suite.store.GetLayout(testCtx(), "layout1")
 
 	suite.Error(err)
 	suite.Equal(errLayoutNotFound, err)
@@ -222,9 +222,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayout_NotFound() {
 
 // Test IsLayoutExist - Exists in DB store
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutExist_InDBStore() {
-	suite.mockDBStore.On("IsLayoutExist", "layout1").Return(true, nil)
+	suite.mockDBStore.On("IsLayoutExist", testCtx(), "layout1").Return(true, nil)
 
-	exists, err := suite.store.IsLayoutExist("layout1")
+	exists, err := suite.store.IsLayoutExist(testCtx(), "layout1")
 
 	suite.NoError(err)
 	suite.True(exists)
@@ -232,10 +232,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutExist_InDBStore() {
 
 // Test IsLayoutExist - Exists in file store
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutExist_InFileStore() {
-	suite.mockDBStore.On("IsLayoutExist", "layout1").Return(false, nil)
-	suite.mockFileStore.On("IsLayoutExist", "layout1").Return(true, nil)
+	suite.mockDBStore.On("IsLayoutExist", testCtx(), "layout1").Return(false, nil)
+	suite.mockFileStore.On("IsLayoutExist", testCtx(), "layout1").Return(true, nil)
 
-	exists, err := suite.store.IsLayoutExist("layout1")
+	exists, err := suite.store.IsLayoutExist(testCtx(), "layout1")
 
 	suite.NoError(err)
 	suite.True(exists)
@@ -243,10 +243,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutExist_InFileStore() {
 
 // Test IsLayoutExist - Not found
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutExist_NotFound() {
-	suite.mockDBStore.On("IsLayoutExist", "layout1").Return(false, nil)
-	suite.mockFileStore.On("IsLayoutExist", "layout1").Return(false, nil)
+	suite.mockDBStore.On("IsLayoutExist", testCtx(), "layout1").Return(false, nil)
+	suite.mockFileStore.On("IsLayoutExist", testCtx(), "layout1").Return(false, nil)
 
-	exists, err := suite.store.IsLayoutExist("layout1")
+	exists, err := suite.store.IsLayoutExist(testCtx(), "layout1")
 
 	suite.NoError(err)
 	suite.False(exists)
@@ -255,9 +255,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutExist_NotFound() {
 // Test IsLayoutExist - DB store error
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutExist_DBStoreError() {
 	testErr := errors.New("db error")
-	suite.mockDBStore.On("IsLayoutExist", "layout1").Return(false, testErr)
+	suite.mockDBStore.On("IsLayoutExist", testCtx(), "layout1").Return(false, testErr)
 
-	_, err := suite.store.IsLayoutExist("layout1")
+	_, err := suite.store.IsLayoutExist(testCtx(), "layout1")
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -268,10 +268,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestUpdateLayout_Success() {
 	updateReq := UpdateLayoutRequest{
 		DisplayName: "Updated Layout",
 	}
-	suite.mockFileStore.On("IsLayoutExist", "layout1").Return(false, nil)
-	suite.mockDBStore.On("UpdateLayout", "layout1", updateReq).Return(nil)
+	suite.mockFileStore.On("IsLayoutExist", testCtx(), "layout1").Return(false, nil)
+	suite.mockDBStore.On("UpdateLayout", testCtx(), "layout1", updateReq).Return(nil)
 
-	err := suite.store.UpdateLayout("layout1", updateReq)
+	err := suite.store.UpdateLayout(testCtx(), "layout1", updateReq)
 
 	suite.NoError(err)
 }
@@ -281,9 +281,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestUpdateLayout_RejectsDeclarative(
 	updateReq := UpdateLayoutRequest{
 		DisplayName: "Updated Layout",
 	}
-	suite.mockFileStore.On("IsLayoutExist", "layout1").Return(true, nil)
+	suite.mockFileStore.On("IsLayoutExist", testCtx(), "layout1").Return(true, nil)
 
-	err := suite.store.UpdateLayout("layout1", updateReq)
+	err := suite.store.UpdateLayout(testCtx(), "layout1", updateReq)
 
 	suite.Error(err)
 	suite.Equal(errCannotUpdateDeclarativeLayout, err)
@@ -295,9 +295,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestUpdateLayout_FileStoreCheckError
 	updateReq := UpdateLayoutRequest{
 		DisplayName: "Updated Layout",
 	}
-	suite.mockFileStore.On("IsLayoutExist", "layout1").Return(false, testErr)
+	suite.mockFileStore.On("IsLayoutExist", testCtx(), "layout1").Return(false, testErr)
 
-	err := suite.store.UpdateLayout("layout1", updateReq)
+	err := suite.store.UpdateLayout(testCtx(), "layout1", updateReq)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -305,19 +305,19 @@ func (suite *CompositeLayoutStoreTestSuite) TestUpdateLayout_FileStoreCheckError
 
 // Test DeleteLayout - Success (DB layout)
 func (suite *CompositeLayoutStoreTestSuite) TestDeleteLayout_Success() {
-	suite.mockFileStore.On("IsLayoutExist", "layout1").Return(false, nil)
-	suite.mockDBStore.On("DeleteLayout", "layout1").Return(nil)
+	suite.mockFileStore.On("IsLayoutExist", testCtx(), "layout1").Return(false, nil)
+	suite.mockDBStore.On("DeleteLayout", testCtx(), "layout1").Return(nil)
 
-	err := suite.store.DeleteLayout("layout1")
+	err := suite.store.DeleteLayout(testCtx(), "layout1")
 
 	suite.NoError(err)
 }
 
 // Test DeleteLayout - Rejects declarative layout
 func (suite *CompositeLayoutStoreTestSuite) TestDeleteLayout_RejectsDeclarative() {
-	suite.mockFileStore.On("IsLayoutExist", "layout1").Return(true, nil)
+	suite.mockFileStore.On("IsLayoutExist", testCtx(), "layout1").Return(true, nil)
 
-	err := suite.store.DeleteLayout("layout1")
+	err := suite.store.DeleteLayout(testCtx(), "layout1")
 
 	suite.Error(err)
 	suite.Equal(errCannotDeleteDeclarativeLayout, err)
@@ -326,9 +326,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestDeleteLayout_RejectsDeclarative(
 // Test DeleteLayout - File store check error
 func (suite *CompositeLayoutStoreTestSuite) TestDeleteLayout_FileStoreCheckError() {
 	testErr := errors.New("file store error")
-	suite.mockFileStore.On("IsLayoutExist", "layout1").Return(false, testErr)
+	suite.mockFileStore.On("IsLayoutExist", testCtx(), "layout1").Return(false, testErr)
 
-	err := suite.store.DeleteLayout("layout1")
+	err := suite.store.DeleteLayout(testCtx(), "layout1")
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -336,27 +336,27 @@ func (suite *CompositeLayoutStoreTestSuite) TestDeleteLayout_FileStoreCheckError
 
 // Test IsLayoutDeclarative - True for file-based layout
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutDeclarative_True() {
-	suite.mockFileStore.On("IsLayoutExist", "layout1").Return(true, nil)
+	suite.mockFileStore.On("IsLayoutExist", testCtx(), "layout1").Return(true, nil)
 
-	isDeclarative := suite.store.IsLayoutDeclarative("layout1")
+	isDeclarative := suite.store.IsLayoutDeclarative(testCtx(), "layout1")
 
 	suite.True(isDeclarative)
 }
 
 // Test IsLayoutDeclarative - False for DB layout
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutDeclarative_False() {
-	suite.mockFileStore.On("IsLayoutExist", "layout1").Return(false, nil)
+	suite.mockFileStore.On("IsLayoutExist", testCtx(), "layout1").Return(false, nil)
 
-	isDeclarative := suite.store.IsLayoutDeclarative("layout1")
+	isDeclarative := suite.store.IsLayoutDeclarative(testCtx(), "layout1")
 
 	suite.False(isDeclarative)
 }
 
 // Test IsLayoutDeclarative - False on error
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutDeclarative_Error() {
-	suite.mockFileStore.On("IsLayoutExist", "layout1").Return(false, errors.New("error"))
+	suite.mockFileStore.On("IsLayoutExist", testCtx(), "layout1").Return(false, errors.New("error"))
 
-	isDeclarative := suite.store.IsLayoutDeclarative("layout1")
+	isDeclarative := suite.store.IsLayoutDeclarative(testCtx(), "layout1")
 
 	suite.False(isDeclarative)
 }
@@ -390,9 +390,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestMergeAndDeduplicateLayouts_Empty
 
 // Test IsLayoutHandleConflict - Conflict in file store (returns early)
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutHandleConflict_ConflictInFileStore() {
-	suite.mockFileStore.On("IsLayoutHandleConflict", "classic", "").Return(true, nil)
+	suite.mockFileStore.On("IsLayoutHandleConflict", testCtx(), "classic", "").Return(true, nil)
 
-	conflict, err := suite.store.IsLayoutHandleConflict("classic", "")
+	conflict, err := suite.store.IsLayoutHandleConflict(testCtx(), "classic", "")
 
 	suite.NoError(err)
 	suite.True(conflict)
@@ -400,10 +400,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutHandleConflict_ConflictI
 
 // Test IsLayoutHandleConflict - No conflict in file, conflict in DB store
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutHandleConflict_ConflictInDBStore() {
-	suite.mockFileStore.On("IsLayoutHandleConflict", "classic", "layout1").Return(false, nil)
-	suite.mockDBStore.On("IsLayoutHandleConflict", "classic", "layout1").Return(true, nil)
+	suite.mockFileStore.On("IsLayoutHandleConflict", testCtx(), "classic", "layout1").Return(false, nil)
+	suite.mockDBStore.On("IsLayoutHandleConflict", testCtx(), "classic", "layout1").Return(true, nil)
 
-	conflict, err := suite.store.IsLayoutHandleConflict("classic", "layout1")
+	conflict, err := suite.store.IsLayoutHandleConflict(testCtx(), "classic", "layout1")
 
 	suite.NoError(err)
 	suite.True(conflict)
@@ -411,10 +411,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutHandleConflict_ConflictI
 
 // Test IsLayoutHandleConflict - No conflict in either store
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutHandleConflict_NoConflict() {
-	suite.mockFileStore.On("IsLayoutHandleConflict", "unique-handle", "layout1").Return(false, nil)
-	suite.mockDBStore.On("IsLayoutHandleConflict", "unique-handle", "layout1").Return(false, nil)
+	suite.mockFileStore.On("IsLayoutHandleConflict", testCtx(), "unique-handle", "layout1").Return(false, nil)
+	suite.mockDBStore.On("IsLayoutHandleConflict", testCtx(), "unique-handle", "layout1").Return(false, nil)
 
-	conflict, err := suite.store.IsLayoutHandleConflict("unique-handle", "layout1")
+	conflict, err := suite.store.IsLayoutHandleConflict(testCtx(), "unique-handle", "layout1")
 
 	suite.NoError(err)
 	suite.False(conflict)
@@ -423,9 +423,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutHandleConflict_NoConflic
 // Test IsLayoutHandleConflict - File store error
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutHandleConflict_FileStoreError() {
 	testErr := errors.New("file store error")
-	suite.mockFileStore.On("IsLayoutHandleConflict", "classic", "").Return(false, testErr)
+	suite.mockFileStore.On("IsLayoutHandleConflict", testCtx(), "classic", "").Return(false, testErr)
 
-	conflict, err := suite.store.IsLayoutHandleConflict("classic", "")
+	conflict, err := suite.store.IsLayoutHandleConflict(testCtx(), "classic", "")
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -435,10 +435,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutHandleConflict_FileStore
 // Test IsLayoutHandleConflict - DB store error
 func (suite *CompositeLayoutStoreTestSuite) TestIsLayoutHandleConflict_DBStoreError() {
 	testErr := errors.New("db store error")
-	suite.mockFileStore.On("IsLayoutHandleConflict", "classic", "layout1").Return(false, nil)
-	suite.mockDBStore.On("IsLayoutHandleConflict", "classic", "layout1").Return(false, testErr)
+	suite.mockFileStore.On("IsLayoutHandleConflict", testCtx(), "classic", "layout1").Return(false, nil)
+	suite.mockDBStore.On("IsLayoutHandleConflict", testCtx(), "classic", "layout1").Return(false, testErr)
 
-	conflict, err := suite.store.IsLayoutHandleConflict("classic", "layout1")
+	conflict, err := suite.store.IsLayoutHandleConflict(testCtx(), "classic", "layout1")
 
 	suite.Error(err)
 	suite.Equal(testErr, err)

--- a/backend/internal/design/layout/mgt/declarative_resource.go
+++ b/backend/internal/design/layout/mgt/declarative_resource.go
@@ -191,6 +191,9 @@ func parseToLayout(data []byte) (*Layout, error) {
 // validateLayoutWrapper wraps validateLayoutForDeclarativeResource to match ResourceConfig.Validator signature.
 // It also checks for duplicates across database stores in composite mode.
 func validateLayoutWrapper(dto interface{}, dbStore layoutMgtStoreInterface) error {
+	// Declarative resources are validated as they are loaded, outside any request, so there
+	// is no context to carry a deployment id and the configured identifier applies.
+	ctx := context.Background()
 	layout, ok := dto.(*Layout)
 	if !ok {
 		return fmt.Errorf("invalid type: expected *Layout")
@@ -203,7 +206,7 @@ func validateLayoutWrapper(dto interface{}, dbStore layoutMgtStoreInterface) err
 
 	// In composite mode, check for duplicates in database store
 	if dbStore != nil {
-		exists, err := dbStore.IsLayoutExist(layout.ID)
+		exists, err := dbStore.IsLayoutExist(ctx, layout.ID)
 		if err != nil {
 			return fmt.Errorf("failed to check for duplicate layout ID '%s': %w", layout.ID, err)
 		}

--- a/backend/internal/design/layout/mgt/declarative_resource_test.go
+++ b/backend/internal/design/layout/mgt/declarative_resource_test.go
@@ -317,7 +317,7 @@ func (s *DeclarativeResourceTestSuite) TestLoadDeclarativeResources_WithDBStore(
 	store := &layoutFileBasedStore{GenericFileBasedStore: genericStore}
 
 	dbStore := newLayoutMgtStoreInterfaceMock(s.T())
-	dbStore.On("IsLayoutExist", "layout-dup").Return(false, nil)
+	dbStore.On("IsLayoutExist", context.Background(), "layout-dup").Return(false, nil)
 
 	err = loadDeclarativeResources(store, dbStore)
 	s.NoError(err)
@@ -383,7 +383,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateLayoutWrapper_DBStoreDuplicat
 	}
 
 	dbStore := newLayoutMgtStoreInterfaceMock(s.T())
-	dbStore.On("IsLayoutExist", "layout1").Return(true, nil)
+	dbStore.On("IsLayoutExist", context.Background(), "layout1").Return(true, nil)
 
 	err := validateLayoutWrapper(layout, dbStore)
 	s.Error(err)
@@ -398,7 +398,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateLayoutWrapper_DBStoreError() 
 	}
 
 	dbStore := newLayoutMgtStoreInterfaceMock(s.T())
-	dbStore.On("IsLayoutExist", "layout1").Return(false, errors.New("db error"))
+	dbStore.On("IsLayoutExist", context.Background(), "layout1").Return(false, errors.New("db error"))
 
 	err := validateLayoutWrapper(layout, dbStore)
 	s.Error(err)

--- a/backend/internal/design/layout/mgt/file_based_store.go
+++ b/backend/internal/design/layout/mgt/file_based_store.go
@@ -4,6 +4,7 @@
 package layoutmgt
 
 import (
+	"context"
 	"errors"
 
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
@@ -16,6 +17,8 @@ type layoutFileBasedStore struct {
 
 // Create implements declarativeresource.Storer interface for resource loader
 func (f *layoutFileBasedStore) Create(id string, data interface{}) error {
+	// The declarative loader has no request behind it, so the configured identifier applies.
+	ctx := context.Background()
 	layout, ok := data.(*Layout)
 	if !ok {
 		declarativeresource.LogTypeAssertionError("layout", id)
@@ -27,11 +30,11 @@ func (f *layoutFileBasedStore) Create(id string, data interface{}) error {
 		Description: layout.Description,
 		Layout:      layout.Layout,
 	}
-	return f.CreateLayout(id, createReq)
+	return f.CreateLayout(ctx, id, createReq)
 }
 
 // CreateLayout implements layoutMgtStoreInterface.
-func (f *layoutFileBasedStore) CreateLayout(id string, layout CreateLayoutRequest) error {
+func (f *layoutFileBasedStore) CreateLayout(ctx context.Context, id string, layout CreateLayoutRequest) error {
 	layoutData := &Layout{
 		ID:          id,
 		Handle:      layout.Handle,
@@ -45,12 +48,12 @@ func (f *layoutFileBasedStore) CreateLayout(id string, layout CreateLayoutReques
 }
 
 // DeleteLayout implements layoutMgtStoreInterface.
-func (f *layoutFileBasedStore) DeleteLayout(id string) error {
+func (f *layoutFileBasedStore) DeleteLayout(ctx context.Context, id string) error {
 	return errors.New("deleteLayout is not supported in file-based store")
 }
 
 // GetLayout implements layoutMgtStoreInterface.
-func (f *layoutFileBasedStore) GetLayout(id string) (Layout, error) {
+func (f *layoutFileBasedStore) GetLayout(ctx context.Context, id string) (Layout, error) {
 	data, err := f.GenericFileBasedStore.Get(id)
 	if err != nil {
 		return Layout{}, errLayoutNotFound
@@ -64,7 +67,7 @@ func (f *layoutFileBasedStore) GetLayout(id string) (Layout, error) {
 }
 
 // GetLayoutList implements layoutMgtStoreInterface.
-func (f *layoutFileBasedStore) GetLayoutList(limit, offset int) ([]Layout, error) {
+func (f *layoutFileBasedStore) GetLayoutList(ctx context.Context, limit, offset int) ([]Layout, error) {
 	// Validate input parameters to prevent panics
 	if offset < 0 {
 		offset = 0
@@ -99,7 +102,7 @@ func (f *layoutFileBasedStore) GetLayoutList(limit, offset int) ([]Layout, error
 }
 
 // GetLayoutListCount implements layoutMgtStoreInterface.
-func (f *layoutFileBasedStore) GetLayoutListCount() (int, error) {
+func (f *layoutFileBasedStore) GetLayoutListCount(ctx context.Context) (int, error) {
 	count, err := f.GenericFileBasedStore.Count()
 	if err != nil {
 		return 0, err
@@ -108,8 +111,8 @@ func (f *layoutFileBasedStore) GetLayoutListCount() (int, error) {
 }
 
 // IsLayoutExist implements layoutMgtStoreInterface.
-func (f *layoutFileBasedStore) IsLayoutExist(id string) (bool, error) {
-	_, err := f.GetLayout(id)
+func (f *layoutFileBasedStore) IsLayoutExist(ctx context.Context, id string) (bool, error) {
+	_, err := f.GetLayout(ctx, id)
 	if err != nil {
 		return false, nil
 	}
@@ -117,17 +120,18 @@ func (f *layoutFileBasedStore) IsLayoutExist(id string) (bool, error) {
 }
 
 // UpdateLayout implements layoutMgtStoreInterface.
-func (f *layoutFileBasedStore) UpdateLayout(id string, layout UpdateLayoutRequest) error {
+func (f *layoutFileBasedStore) UpdateLayout(ctx context.Context, id string, layout UpdateLayoutRequest) error {
 	return errors.New("updateLayout is not supported in file-based store")
 }
 
 // IsLayoutDeclarative checks if a layout is immutable (in file-based store, all layouts are immutable).
-func (f *layoutFileBasedStore) IsLayoutDeclarative(id string) bool {
+func (f *layoutFileBasedStore) IsLayoutDeclarative(ctx context.Context, id string) bool {
 	return true
 }
 
 // IsLayoutHandleConflict checks if a layout handle already exists (excluding a specific ID).
-func (f *layoutFileBasedStore) IsLayoutHandleConflict(handle string, excludeID string) (bool, error) {
+func (f *layoutFileBasedStore) IsLayoutHandleConflict(ctx context.Context, handle string, excludeID string) (bool,
+	error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return false, err

--- a/backend/internal/design/layout/mgt/file_based_store_test.go
+++ b/backend/internal/design/layout/mgt/file_based_store_test.go
@@ -4,6 +4,7 @@
 package layoutmgt
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -76,13 +77,13 @@ func (suite *LayoutFileBasedStoreTestSuite) TestCreateLayout_Success() {
 	layoutReq := suite.createTestLayout("Centered Layout")
 
 	// Act
-	err := suite.store.CreateLayout("layout-001", layoutReq)
+	err := suite.store.CreateLayout(context.Background(), "layout-001", layoutReq)
 
 	// Assert
 	suite.NoError(err)
 
 	// Verify layout was created
-	retrieved, err := suite.store.GetLayout("layout-001")
+	retrieved, err := suite.store.GetLayout(context.Background(), "layout-001")
 	suite.NoError(err)
 	suite.Equal("layout-001", retrieved.ID)
 	suite.Equal("Centered Layout", retrieved.DisplayName)
@@ -93,10 +94,10 @@ func (suite *LayoutFileBasedStoreTestSuite) TestCreateLayout_Success() {
 func (suite *LayoutFileBasedStoreTestSuite) TestGetLayout_Success() {
 	// Arrange
 	layoutReq := suite.createTestLayout("Sidebar Layout")
-	_ = suite.store.CreateLayout("layout-002", layoutReq)
+	_ = suite.store.CreateLayout(context.Background(), "layout-002", layoutReq)
 
 	// Act
-	retrieved, err := suite.store.GetLayout("layout-002")
+	retrieved, err := suite.store.GetLayout(context.Background(), "layout-002")
 
 	// Assert
 	suite.NoError(err)
@@ -106,7 +107,7 @@ func (suite *LayoutFileBasedStoreTestSuite) TestGetLayout_Success() {
 
 func (suite *LayoutFileBasedStoreTestSuite) TestGetLayout_NotFound() {
 	// Act
-	retrieved, err := suite.store.GetLayout("non-existent")
+	retrieved, err := suite.store.GetLayout(context.Background(), "non-existent")
 
 	// Assert
 	suite.Error(err)
@@ -118,12 +119,12 @@ func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_Success() {
 	layout1 := suite.createTestLayout("Layout 1")
 	layout2 := suite.createTestLayout("Layout 2")
 	layout3 := suite.createTestLayout("Layout 3")
-	_ = suite.store.CreateLayout("layout-003", layout1)
-	_ = suite.store.CreateLayout("layout-004", layout2)
-	_ = suite.store.CreateLayout("layout-005", layout3)
+	_ = suite.store.CreateLayout(context.Background(), "layout-003", layout1)
+	_ = suite.store.CreateLayout(context.Background(), "layout-004", layout2)
+	_ = suite.store.CreateLayout(context.Background(), "layout-005", layout3)
 
 	// Act
-	layouts, err := suite.store.GetLayoutList(10, 0)
+	layouts, err := suite.store.GetLayoutList(context.Background(), 10, 0)
 
 	// Assert
 	suite.NoError(err)
@@ -134,18 +135,18 @@ func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_WithPagination() {
 	// Arrange
 	for i := 1; i <= 5; i++ {
 		layoutReq := suite.createTestLayout(fmt.Sprintf("Layout %d", i))
-		_ = suite.store.CreateLayout(fmt.Sprintf("layout-%03d", i), layoutReq)
+		_ = suite.store.CreateLayout(context.Background(), fmt.Sprintf("layout-%03d", i), layoutReq)
 	}
 
 	// Act - Get first 2 layouts
-	layouts, err := suite.store.GetLayoutList(2, 0)
+	layouts, err := suite.store.GetLayoutList(context.Background(), 2, 0)
 
 	// Assert
 	suite.NoError(err)
 	suite.Len(layouts, 2)
 
 	// Act - Get next 2 layouts
-	layouts, err = suite.store.GetLayoutList(2, 2)
+	layouts, err = suite.store.GetLayoutList(context.Background(), 2, 2)
 
 	// Assert
 	suite.NoError(err)
@@ -154,7 +155,7 @@ func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_WithPagination() {
 
 func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_EmptyStore() {
 	// Act
-	layouts, err := suite.store.GetLayoutList(10, 0)
+	layouts, err := suite.store.GetLayoutList(context.Background(), 10, 0)
 
 	// Assert
 	suite.NoError(err)
@@ -165,11 +166,11 @@ func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutListCount_Success() {
 	// Arrange
 	layout1 := suite.createTestLayout("Layout 6")
 	layout2 := suite.createTestLayout("Layout 7")
-	_ = suite.store.CreateLayout("layout-006", layout1)
-	_ = suite.store.CreateLayout("layout-007", layout2)
+	_ = suite.store.CreateLayout(context.Background(), "layout-006", layout1)
+	_ = suite.store.CreateLayout(context.Background(), "layout-007", layout2)
 
 	// Act
-	count, err := suite.store.GetLayoutListCount()
+	count, err := suite.store.GetLayoutListCount(context.Background())
 
 	// Assert
 	suite.NoError(err)
@@ -179,10 +180,10 @@ func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutListCount_Success() {
 func (suite *LayoutFileBasedStoreTestSuite) TestIsLayoutExist_True() {
 	// Arrange
 	layoutReq := suite.createTestLayout("Existing Layout")
-	_ = suite.store.CreateLayout("layout-008", layoutReq)
+	_ = suite.store.CreateLayout(context.Background(), "layout-008", layoutReq)
 
 	// Act
-	exists, err := suite.store.IsLayoutExist("layout-008")
+	exists, err := suite.store.IsLayoutExist(context.Background(), "layout-008")
 
 	// Assert
 	suite.NoError(err)
@@ -191,7 +192,7 @@ func (suite *LayoutFileBasedStoreTestSuite) TestIsLayoutExist_True() {
 
 func (suite *LayoutFileBasedStoreTestSuite) TestIsLayoutExist_False() {
 	// Act
-	exists, err := suite.store.IsLayoutExist("non-existent")
+	exists, err := suite.store.IsLayoutExist(context.Background(), "non-existent")
 
 	// Assert
 	suite.NoError(err)
@@ -203,7 +204,7 @@ func (suite *LayoutFileBasedStoreTestSuite) TestUpdateLayout_NotSupported() {
 	layoutReq := suite.createTestLayout("Update Test")
 
 	// Act
-	err := suite.store.UpdateLayout("layout-009", UpdateLayoutRequest{
+	err := suite.store.UpdateLayout(context.Background(), "layout-009", UpdateLayoutRequest{
 		DisplayName: "Updated Name",
 		Description: "Updated description",
 		Layout:      layoutReq.Layout,
@@ -216,7 +217,7 @@ func (suite *LayoutFileBasedStoreTestSuite) TestUpdateLayout_NotSupported() {
 
 func (suite *LayoutFileBasedStoreTestSuite) TestDeleteLayout_NotSupported() {
 	// Act
-	err := suite.store.DeleteLayout("layout-001")
+	err := suite.store.DeleteLayout(context.Background(), "layout-001")
 
 	// Assert
 	suite.Error(err)
@@ -243,7 +244,7 @@ func (suite *LayoutFileBasedStoreTestSuite) TestCreate_StorerInterface() {
 	suite.NoError(err)
 
 	// Verify
-	retrieved, err := suite.store.GetLayout("layout-010")
+	retrieved, err := suite.store.GetLayout(context.Background(), "layout-010")
 	suite.NoError(err)
 	suite.Equal("layout-010", retrieved.ID)
 }
@@ -264,11 +265,11 @@ func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_NegativeOffset() {
 	// Arrange
 	layout1 := suite.createTestLayout("Layout A")
 	layout2 := suite.createTestLayout("Layout B")
-	_ = suite.store.CreateLayout("layout-a", layout1)
-	_ = suite.store.CreateLayout("layout-b", layout2)
+	_ = suite.store.CreateLayout(context.Background(), "layout-a", layout1)
+	_ = suite.store.CreateLayout(context.Background(), "layout-b", layout2)
 
 	// Act - negative offset should be clamped to 0
-	layouts, err := suite.store.GetLayoutList(10, -5)
+	layouts, err := suite.store.GetLayoutList(context.Background(), 10, -5)
 
 	// Assert
 	suite.NoError(err)
@@ -278,10 +279,10 @@ func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_NegativeOffset() {
 func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_ZeroLimit() {
 	// Arrange
 	layout1 := suite.createTestLayout("Layout C")
-	_ = suite.store.CreateLayout("layout-c", layout1)
+	_ = suite.store.CreateLayout(context.Background(), "layout-c", layout1)
 
 	// Act - zero limit should return empty slice
-	layouts, err := suite.store.GetLayoutList(0, 0)
+	layouts, err := suite.store.GetLayoutList(context.Background(), 0, 0)
 
 	// Assert
 	suite.NoError(err)
@@ -291,10 +292,10 @@ func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_ZeroLimit() {
 func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_NegativeLimit() {
 	// Arrange
 	layout1 := suite.createTestLayout("Layout D")
-	_ = suite.store.CreateLayout("layout-d", layout1)
+	_ = suite.store.CreateLayout(context.Background(), "layout-d", layout1)
 
 	// Act - negative limit should return empty slice
-	layouts, err := suite.store.GetLayoutList(-10, 0)
+	layouts, err := suite.store.GetLayoutList(context.Background(), -10, 0)
 
 	// Assert
 	suite.NoError(err)
@@ -304,10 +305,10 @@ func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_NegativeLimit() {
 func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_OffsetBeyondList() {
 	// Arrange
 	layout1 := suite.createTestLayout("Layout E")
-	_ = suite.store.CreateLayout("layout-e", layout1)
+	_ = suite.store.CreateLayout(context.Background(), "layout-e", layout1)
 
 	// Act - offset beyond list length should return empty slice
-	layouts, err := suite.store.GetLayoutList(10, 100)
+	layouts, err := suite.store.GetLayoutList(context.Background(), 10, 100)
 
 	// Assert
 	suite.NoError(err)
@@ -318,10 +319,10 @@ func (suite *LayoutFileBasedStoreTestSuite) TestIsLayoutHandleConflict_Conflict(
 	// Arrange
 	layoutReq := suite.createTestLayout("Handle Conflict Test")
 	layoutReq.Handle = "conflict-handle"
-	_ = suite.store.CreateLayout("layout-hc1", layoutReq)
+	_ = suite.store.CreateLayout(context.Background(), "layout-hc1", layoutReq)
 
 	// Act - different ID with same handle should conflict
-	conflict, err := suite.store.IsLayoutHandleConflict("conflict-handle", "other-id")
+	conflict, err := suite.store.IsLayoutHandleConflict(context.Background(), "conflict-handle", "other-id")
 
 	// Assert
 	suite.NoError(err)
@@ -330,7 +331,7 @@ func (suite *LayoutFileBasedStoreTestSuite) TestIsLayoutHandleConflict_Conflict(
 
 func (suite *LayoutFileBasedStoreTestSuite) TestIsLayoutHandleConflict_NoConflict() {
 	// Act - non-existent handle should not conflict
-	conflict, err := suite.store.IsLayoutHandleConflict("non-existent-handle", "")
+	conflict, err := suite.store.IsLayoutHandleConflict(context.Background(), "non-existent-handle", "")
 
 	// Assert
 	suite.NoError(err)
@@ -341,10 +342,10 @@ func (suite *LayoutFileBasedStoreTestSuite) TestIsLayoutHandleConflict_SameIDExc
 	// Arrange
 	layoutReq := suite.createTestLayout("Same ID Exclude Test")
 	layoutReq.Handle = "same-id-handle"
-	_ = suite.store.CreateLayout("layout-hc2", layoutReq)
+	_ = suite.store.CreateLayout(context.Background(), "layout-hc2", layoutReq)
 
 	// Act - same ID should be excluded from conflict check
-	conflict, err := suite.store.IsLayoutHandleConflict("same-id-handle", "layout-hc2")
+	conflict, err := suite.store.IsLayoutHandleConflict(context.Background(), "same-id-handle", "layout-hc2")
 
 	// Assert
 	suite.NoError(err)

--- a/backend/internal/design/layout/mgt/layoutMgtStoreInterface_mock_test.go
+++ b/backend/internal/design/layout/mgt/layoutMgtStoreInterface_mock_test.go
@@ -5,6 +5,8 @@
 package layoutmgt
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -36,16 +38,16 @@ func (_m *layoutMgtStoreInterfaceMock) EXPECT() *layoutMgtStoreInterfaceMock_Exp
 }
 
 // CreateLayout provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) CreateLayout(id string, layout CreateLayoutRequest) error {
-	ret := _mock.Called(id, layout)
+func (_mock *layoutMgtStoreInterfaceMock) CreateLayout(ctx context.Context, id string, layout CreateLayoutRequest) error {
+	ret := _mock.Called(ctx, id, layout)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateLayout")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, CreateLayoutRequest) error); ok {
-		r0 = returnFunc(id, layout)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, CreateLayoutRequest) error); ok {
+		r0 = returnFunc(ctx, id, layout)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -58,25 +60,31 @@ type layoutMgtStoreInterfaceMock_CreateLayout_Call struct {
 }
 
 // CreateLayout is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - layout CreateLayoutRequest
-func (_e *layoutMgtStoreInterfaceMock_Expecter) CreateLayout(id interface{}, layout interface{}) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
-	return &layoutMgtStoreInterfaceMock_CreateLayout_Call{Call: _e.mock.On("CreateLayout", id, layout)}
+func (_e *layoutMgtStoreInterfaceMock_Expecter) CreateLayout(ctx interface{}, id interface{}, layout interface{}) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
+	return &layoutMgtStoreInterfaceMock_CreateLayout_Call{Call: _e.mock.On("CreateLayout", ctx, id, layout)}
 }
 
-func (_c *layoutMgtStoreInterfaceMock_CreateLayout_Call) Run(run func(id string, layout CreateLayoutRequest)) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
+func (_c *layoutMgtStoreInterfaceMock_CreateLayout_Call) Run(run func(ctx context.Context, id string, layout CreateLayoutRequest)) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 CreateLayoutRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(CreateLayoutRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 CreateLayoutRequest
+		if args[2] != nil {
+			arg2 = args[2].(CreateLayoutRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -87,22 +95,22 @@ func (_c *layoutMgtStoreInterfaceMock_CreateLayout_Call) Return(err error) *layo
 	return _c
 }
 
-func (_c *layoutMgtStoreInterfaceMock_CreateLayout_Call) RunAndReturn(run func(id string, layout CreateLayoutRequest) error) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
+func (_c *layoutMgtStoreInterfaceMock_CreateLayout_Call) RunAndReturn(run func(ctx context.Context, id string, layout CreateLayoutRequest) error) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteLayout provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) DeleteLayout(id string) error {
-	ret := _mock.Called(id)
+func (_mock *layoutMgtStoreInterfaceMock) DeleteLayout(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteLayout")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -115,369 +123,17 @@ type layoutMgtStoreInterfaceMock_DeleteLayout_Call struct {
 }
 
 // DeleteLayout is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *layoutMgtStoreInterfaceMock_Expecter) DeleteLayout(id interface{}) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
-	return &layoutMgtStoreInterfaceMock_DeleteLayout_Call{Call: _e.mock.On("DeleteLayout", id)}
+func (_e *layoutMgtStoreInterfaceMock_Expecter) DeleteLayout(ctx interface{}, id interface{}) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
+	return &layoutMgtStoreInterfaceMock_DeleteLayout_Call{Call: _e.mock.On("DeleteLayout", ctx, id)}
 }
 
-func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) Run(run func(id string)) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
+func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) Run(run func(ctx context.Context, id string)) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) Return(err error) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) RunAndReturn(run func(id string) error) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetLayout provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) GetLayout(id string) (Layout, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetLayout")
-	}
-
-	var r0 Layout
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (Layout, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) Layout); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(Layout)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// layoutMgtStoreInterfaceMock_GetLayout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayout'
-type layoutMgtStoreInterfaceMock_GetLayout_Call struct {
-	*mock.Call
-}
-
-// GetLayout is a helper method to define mock.On call
-//   - id string
-func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayout(id interface{}) *layoutMgtStoreInterfaceMock_GetLayout_Call {
-	return &layoutMgtStoreInterfaceMock_GetLayout_Call{Call: _e.mock.On("GetLayout", id)}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) Run(run func(id string)) *layoutMgtStoreInterfaceMock_GetLayout_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) Return(layout Layout, err error) *layoutMgtStoreInterfaceMock_GetLayout_Call {
-	_c.Call.Return(layout, err)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) RunAndReturn(run func(id string) (Layout, error)) *layoutMgtStoreInterfaceMock_GetLayout_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetLayoutList provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) GetLayoutList(limit int, offset int) ([]Layout, error) {
-	ret := _mock.Called(limit, offset)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetLayoutList")
-	}
-
-	var r0 []Layout
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]Layout, error)); ok {
-		return returnFunc(limit, offset)
-	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []Layout); ok {
-		r0 = returnFunc(limit, offset)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]Layout)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(limit, offset)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// layoutMgtStoreInterfaceMock_GetLayoutList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayoutList'
-type layoutMgtStoreInterfaceMock_GetLayoutList_Call struct {
-	*mock.Call
-}
-
-// GetLayoutList is a helper method to define mock.On call
-//   - limit int
-//   - offset int
-func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayoutList(limit interface{}, offset interface{}) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
-	return &layoutMgtStoreInterfaceMock_GetLayoutList_Call{Call: _e.mock.On("GetLayoutList", limit, offset)}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) Run(run func(limit int, offset int)) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
-		if args[0] != nil {
-			arg0 = args[0].(int)
-		}
-		var arg1 int
-		if args[1] != nil {
-			arg1 = args[1].(int)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) Return(layouts []Layout, err error) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
-	_c.Call.Return(layouts, err)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) RunAndReturn(run func(limit int, offset int) ([]Layout, error)) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetLayoutListCount provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) GetLayoutListCount() (int, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetLayoutListCount")
-	}
-
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// layoutMgtStoreInterfaceMock_GetLayoutListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayoutListCount'
-type layoutMgtStoreInterfaceMock_GetLayoutListCount_Call struct {
-	*mock.Call
-}
-
-// GetLayoutListCount is a helper method to define mock.On call
-func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayoutListCount() *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
-	return &layoutMgtStoreInterfaceMock_GetLayoutListCount_Call{Call: _e.mock.On("GetLayoutListCount")}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) Run(run func()) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) Return(n int, err error) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) RunAndReturn(run func() (int, error)) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsLayoutDeclarative provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) IsLayoutDeclarative(id string) bool {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsLayoutDeclarative")
-	}
-
-	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	return r0
-}
-
-// layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutDeclarative'
-type layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call struct {
-	*mock.Call
-}
-
-// IsLayoutDeclarative is a helper method to define mock.On call
-//   - id string
-func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutDeclarative(id interface{}) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
-	return &layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call{Call: _e.mock.On("IsLayoutDeclarative", id)}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) Run(run func(id string)) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) Return(b bool) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
-	_c.Call.Return(b)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) RunAndReturn(run func(id string) bool) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsLayoutExist provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) IsLayoutExist(id string) (bool, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsLayoutExist")
-	}
-
-	var r0 bool
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// layoutMgtStoreInterfaceMock_IsLayoutExist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutExist'
-type layoutMgtStoreInterfaceMock_IsLayoutExist_Call struct {
-	*mock.Call
-}
-
-// IsLayoutExist is a helper method to define mock.On call
-//   - id string
-func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutExist(id interface{}) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
-	return &layoutMgtStoreInterfaceMock_IsLayoutExist_Call{Call: _e.mock.On("IsLayoutExist", id)}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) Run(run func(id string)) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) Return(b bool, err error) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
-	_c.Call.Return(b, err)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) RunAndReturn(run func(id string) (bool, error)) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsLayoutHandleConflict provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) IsLayoutHandleConflict(handle string, excludeID string) (bool, error) {
-	ret := _mock.Called(handle, excludeID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsLayoutHandleConflict")
-	}
-
-	var r0 bool
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (bool, error)); ok {
-		return returnFunc(handle, excludeID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) bool); ok {
-		r0 = returnFunc(handle, excludeID)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = returnFunc(handle, excludeID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutHandleConflict'
-type layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call struct {
-	*mock.Call
-}
-
-// IsLayoutHandleConflict is a helper method to define mock.On call
-//   - handle string
-//   - excludeID string
-func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutHandleConflict(handle interface{}, excludeID interface{}) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
-	return &layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call{Call: _e.mock.On("IsLayoutHandleConflict", handle, excludeID)}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) Run(run func(handle string, excludeID string)) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -491,27 +147,422 @@ func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) Run(run func(
 	return _c
 }
 
+func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) Return(err error) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) RunAndReturn(run func(ctx context.Context, id string) error) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLayout provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) GetLayout(ctx context.Context, id string) (Layout, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLayout")
+	}
+
+	var r0 Layout
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (Layout, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) Layout); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(Layout)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// layoutMgtStoreInterfaceMock_GetLayout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayout'
+type layoutMgtStoreInterfaceMock_GetLayout_Call struct {
+	*mock.Call
+}
+
+// GetLayout is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayout(ctx interface{}, id interface{}) *layoutMgtStoreInterfaceMock_GetLayout_Call {
+	return &layoutMgtStoreInterfaceMock_GetLayout_Call{Call: _e.mock.On("GetLayout", ctx, id)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) Run(run func(ctx context.Context, id string)) *layoutMgtStoreInterfaceMock_GetLayout_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) Return(layout Layout, err error) *layoutMgtStoreInterfaceMock_GetLayout_Call {
+	_c.Call.Return(layout, err)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) RunAndReturn(run func(ctx context.Context, id string) (Layout, error)) *layoutMgtStoreInterfaceMock_GetLayout_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLayoutList provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) GetLayoutList(ctx context.Context, limit int, offset int) ([]Layout, error) {
+	ret := _mock.Called(ctx, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLayoutList")
+	}
+
+	var r0 []Layout
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]Layout, error)); ok {
+		return returnFunc(ctx, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []Layout); ok {
+		r0 = returnFunc(ctx, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]Layout)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// layoutMgtStoreInterfaceMock_GetLayoutList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayoutList'
+type layoutMgtStoreInterfaceMock_GetLayoutList_Call struct {
+	*mock.Call
+}
+
+// GetLayoutList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - limit int
+//   - offset int
+func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayoutList(ctx interface{}, limit interface{}, offset interface{}) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
+	return &layoutMgtStoreInterfaceMock_GetLayoutList_Call{Call: _e.mock.On("GetLayoutList", ctx, limit, offset)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) Run(run func(ctx context.Context, limit int, offset int)) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) Return(layouts []Layout, err error) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
+	_c.Call.Return(layouts, err)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]Layout, error)) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLayoutListCount provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) GetLayoutListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLayoutListCount")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// layoutMgtStoreInterfaceMock_GetLayoutListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayoutListCount'
+type layoutMgtStoreInterfaceMock_GetLayoutListCount_Call struct {
+	*mock.Call
+}
+
+// GetLayoutListCount is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayoutListCount(ctx interface{}) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
+	return &layoutMgtStoreInterfaceMock_GetLayoutListCount_Call{Call: _e.mock.On("GetLayoutListCount", ctx)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) Run(run func(ctx context.Context)) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) Return(n int, err error) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsLayoutDeclarative provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) IsLayoutDeclarative(ctx context.Context, id string) bool {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsLayoutDeclarative")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutDeclarative'
+type layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call struct {
+	*mock.Call
+}
+
+// IsLayoutDeclarative is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutDeclarative(ctx interface{}, id interface{}) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
+	return &layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call{Call: _e.mock.On("IsLayoutDeclarative", ctx, id)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) Run(run func(ctx context.Context, id string)) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) Return(b bool) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) RunAndReturn(run func(ctx context.Context, id string) bool) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsLayoutExist provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) IsLayoutExist(ctx context.Context, id string) (bool, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsLayoutExist")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// layoutMgtStoreInterfaceMock_IsLayoutExist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutExist'
+type layoutMgtStoreInterfaceMock_IsLayoutExist_Call struct {
+	*mock.Call
+}
+
+// IsLayoutExist is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutExist(ctx interface{}, id interface{}) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
+	return &layoutMgtStoreInterfaceMock_IsLayoutExist_Call{Call: _e.mock.On("IsLayoutExist", ctx, id)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) Run(run func(ctx context.Context, id string)) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) Return(b bool, err error) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) RunAndReturn(run func(ctx context.Context, id string) (bool, error)) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsLayoutHandleConflict provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) IsLayoutHandleConflict(ctx context.Context, handle string, excludeID string) (bool, error) {
+	ret := _mock.Called(ctx, handle, excludeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsLayoutHandleConflict")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (bool, error)); ok {
+		return returnFunc(ctx, handle, excludeID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = returnFunc(ctx, handle, excludeID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, handle, excludeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutHandleConflict'
+type layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call struct {
+	*mock.Call
+}
+
+// IsLayoutHandleConflict is a helper method to define mock.On call
+//   - ctx context.Context
+//   - handle string
+//   - excludeID string
+func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutHandleConflict(ctx interface{}, handle interface{}, excludeID interface{}) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
+	return &layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call{Call: _e.mock.On("IsLayoutHandleConflict", ctx, handle, excludeID)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) Run(run func(ctx context.Context, handle string, excludeID string)) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
 func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) Return(b bool, err error) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
 	_c.Call.Return(b, err)
 	return _c
 }
 
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) RunAndReturn(run func(handle string, excludeID string) (bool, error)) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) RunAndReturn(run func(ctx context.Context, handle string, excludeID string) (bool, error)) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateLayout provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) UpdateLayout(id string, layout UpdateLayoutRequest) error {
-	ret := _mock.Called(id, layout)
+func (_mock *layoutMgtStoreInterfaceMock) UpdateLayout(ctx context.Context, id string, layout UpdateLayoutRequest) error {
+	ret := _mock.Called(ctx, id, layout)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateLayout")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, UpdateLayoutRequest) error); ok {
-		r0 = returnFunc(id, layout)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, UpdateLayoutRequest) error); ok {
+		r0 = returnFunc(ctx, id, layout)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -524,25 +575,31 @@ type layoutMgtStoreInterfaceMock_UpdateLayout_Call struct {
 }
 
 // UpdateLayout is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - layout UpdateLayoutRequest
-func (_e *layoutMgtStoreInterfaceMock_Expecter) UpdateLayout(id interface{}, layout interface{}) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
-	return &layoutMgtStoreInterfaceMock_UpdateLayout_Call{Call: _e.mock.On("UpdateLayout", id, layout)}
+func (_e *layoutMgtStoreInterfaceMock_Expecter) UpdateLayout(ctx interface{}, id interface{}, layout interface{}) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
+	return &layoutMgtStoreInterfaceMock_UpdateLayout_Call{Call: _e.mock.On("UpdateLayout", ctx, id, layout)}
 }
 
-func (_c *layoutMgtStoreInterfaceMock_UpdateLayout_Call) Run(run func(id string, layout UpdateLayoutRequest)) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
+func (_c *layoutMgtStoreInterfaceMock_UpdateLayout_Call) Run(run func(ctx context.Context, id string, layout UpdateLayoutRequest)) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 UpdateLayoutRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(UpdateLayoutRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 UpdateLayoutRequest
+		if args[2] != nil {
+			arg2 = args[2].(UpdateLayoutRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -553,7 +610,7 @@ func (_c *layoutMgtStoreInterfaceMock_UpdateLayout_Call) Return(err error) *layo
 	return _c
 }
 
-func (_c *layoutMgtStoreInterfaceMock_UpdateLayout_Call) RunAndReturn(run func(id string, layout UpdateLayoutRequest) error) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
+func (_c *layoutMgtStoreInterfaceMock_UpdateLayout_Call) RunAndReturn(run func(ctx context.Context, id string, layout UpdateLayoutRequest) error) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/design/layout/mgt/service.go
+++ b/backend/internal/design/layout/mgt/service.go
@@ -51,19 +51,19 @@ func newLayoutMgtService(layoutMgtStore layoutMgtStoreInterface) LayoutMgtServic
 }
 
 // GetLayoutList retrieves a list of layout configurations.
-func (ls *layoutMgtService) GetLayoutList(
-	ctx context.Context, limit, offset int) (*LayoutList, *tidcommon.ServiceError) {
+func (ls *layoutMgtService) GetLayoutList(ctx context.Context, limit, offset int) (*LayoutList,
+	*tidcommon.ServiceError) {
 	if err := validatePaginationParams(limit, offset); err != nil {
 		return nil, err
 	}
 
-	totalCount, err := ls.layoutMgtStore.GetLayoutListCount()
+	totalCount, err := ls.layoutMgtStore.GetLayoutListCount(ctx)
 	if err != nil {
 		ls.logger.Error(ctx, "Failed to get layout count", log.Error(err))
 		return nil, &tidcommon.InternalServerError
 	}
 
-	layouts, err := ls.layoutMgtStore.GetLayoutList(limit, offset)
+	layouts, err := ls.layoutMgtStore.GetLayoutList(ctx, limit, offset)
 	if err != nil {
 		ls.logger.Error(ctx, "Failed to list layouts", log.Error(err))
 		return nil, &tidcommon.InternalServerError
@@ -81,8 +81,8 @@ func (ls *layoutMgtService) GetLayoutList(
 }
 
 // CreateLayout creates a new layout configuration.
-func (ls *layoutMgtService) CreateLayout(
-	ctx context.Context, layout CreateLayoutRequestWithID) (*Layout, *tidcommon.ServiceError) {
+func (ls *layoutMgtService) CreateLayout(ctx context.Context, layout CreateLayoutRequestWithID) (*Layout,
+	*tidcommon.ServiceError) {
 	ls.logger.Debug(ctx, "Creating layout configuration")
 
 	if layout.DisplayName == "" {
@@ -98,7 +98,7 @@ func (ls *layoutMgtService) CreateLayout(
 		return nil, &ErrorCannotModifyDeclarativeResource
 	}
 
-	conflict, err := ls.layoutMgtStore.IsLayoutHandleConflict(layout.Handle, "")
+	conflict, err := ls.layoutMgtStore.IsLayoutHandleConflict(ctx, layout.Handle, "")
 	if err != nil {
 		ls.logger.Error(ctx, "Failed to check layout handle conflict", log.Error(err))
 		return nil, &tidcommon.InternalServerError
@@ -128,7 +128,7 @@ func (ls *layoutMgtService) CreateLayout(
 		Layout:      layout.Layout,
 	}
 
-	if err := ls.layoutMgtStore.CreateLayout(id, storeReq); err != nil {
+	if err := ls.layoutMgtStore.CreateLayout(ctx, id, storeReq); err != nil {
 		ls.logger.Error(ctx, "Failed to create layout", log.Error(err))
 		return nil, &tidcommon.InternalServerError
 	}
@@ -153,7 +153,7 @@ func (ls *layoutMgtService) GetLayout(ctx context.Context, id string) (*Layout, 
 		return nil, &ErrorInvalidLayoutID
 	}
 
-	layout, err := ls.layoutMgtStore.GetLayout(id)
+	layout, err := ls.layoutMgtStore.GetLayout(ctx, id)
 	if err != nil {
 		if errors.Is(err, errLayoutNotFound) {
 			ls.logger.Debug(ctx, "Layout not found", log.String("id", id))
@@ -181,12 +181,12 @@ func (ls *layoutMgtService) UpdateLayout(ctx context.Context,
 	}
 
 	// Check if the layout is declarative (read-only)
-	if ls.layoutMgtStore.IsLayoutDeclarative(id) {
+	if ls.layoutMgtStore.IsLayoutDeclarative(ctx, id) {
 		return nil, &ErrorCannotModifyDeclarativeResource
 	}
 
 	// Fetch existing layout to enforce handle immutability
-	existingLayout, err := ls.layoutMgtStore.GetLayout(id)
+	existingLayout, err := ls.layoutMgtStore.GetLayout(ctx, id)
 	if err != nil {
 		if errors.Is(err, errLayoutNotFound) {
 			return nil, &ErrorLayoutNotFound
@@ -204,7 +204,7 @@ func (ls *layoutMgtService) UpdateLayout(ctx context.Context,
 		return nil, err
 	}
 
-	if err := ls.layoutMgtStore.UpdateLayout(id, layout); err != nil {
+	if err := ls.layoutMgtStore.UpdateLayout(ctx, id, layout); err != nil {
 		ls.logger.Error(ctx, "Failed to update layout", log.String("id", id), log.Error(err))
 		return nil, &tidcommon.InternalServerError
 	}
@@ -230,12 +230,12 @@ func (ls *layoutMgtService) DeleteLayout(ctx context.Context, id string) *tidcom
 	}
 
 	// Check if the layout is declarative (read-only)
-	if ls.layoutMgtStore.IsLayoutDeclarative(id) {
+	if ls.layoutMgtStore.IsLayoutDeclarative(ctx, id) {
 		return &ErrorCannotModifyDeclarativeResource
 	}
 
 	// Check if layout exists. Return success for non-existing layouts (idempotent delete).
-	exists, err := ls.layoutMgtStore.IsLayoutExist(id)
+	exists, err := ls.layoutMgtStore.IsLayoutExist(ctx, id)
 	if err != nil {
 		ls.logger.Error(ctx, "Failed to check layout existence", log.String("id", id), log.Error(err))
 		return &tidcommon.InternalServerError
@@ -249,7 +249,7 @@ func (ls *layoutMgtService) DeleteLayout(ctx context.Context, id string) *tidcom
 	// A layout can be deleted even while applications reference it: those applications keep their
 	// reference and fall back to the system default layout at read time (see the design resolve
 	// service). References are surfaced informationally through GetLayoutUsages.
-	if err := ls.layoutMgtStore.DeleteLayout(id); err != nil {
+	if err := ls.layoutMgtStore.DeleteLayout(ctx, id); err != nil {
 		ls.logger.Error(ctx, "Failed to delete layout", log.String("id", id), log.Error(err))
 		return &tidcommon.InternalServerError
 	}
@@ -264,7 +264,7 @@ func (ls *layoutMgtService) IsLayoutExist(ctx context.Context, id string) (bool,
 		return false, &ErrorInvalidLayoutID
 	}
 
-	exists, err := ls.layoutMgtStore.IsLayoutExist(id)
+	exists, err := ls.layoutMgtStore.IsLayoutExist(ctx, id)
 	if err != nil {
 		ls.logger.Error(ctx, "Failed to check layout existence", log.String("id", id), log.Error(err))
 		return false, &tidcommon.InternalServerError
@@ -291,7 +291,7 @@ func (ls *layoutMgtService) GetLayoutUsages(
 		return nil, err
 	}
 
-	exists, err := ls.layoutMgtStore.IsLayoutExist(id)
+	exists, err := ls.layoutMgtStore.IsLayoutExist(ctx, id)
 	if err != nil {
 		ls.logger.Error(ctx, "Failed to check layout existence", log.String("id", id), log.Error(err))
 		return nil, &tidcommon.InternalServerError

--- a/backend/internal/design/layout/mgt/service_test.go
+++ b/backend/internal/design/layout/mgt/service_test.go
@@ -63,10 +63,10 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutList_Success() {
 		},
 	}
 
-	suite.mockStore.On("GetLayoutListCount").Return(2, nil)
-	suite.mockStore.On("GetLayoutList", 10, 0).Return(layouts, nil)
+	suite.mockStore.On("GetLayoutListCount", testCtx()).Return(2, nil)
+	suite.mockStore.On("GetLayoutList", testCtx(), 10, 0).Return(layouts, nil)
 
-	result, err := suite.service.GetLayoutList(context.Background(), 10, 0)
+	result, err := suite.service.GetLayoutList(testCtx(), 10, 0)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -78,9 +78,9 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutList_Success() {
 
 // Test GetLayoutList - Store Count Error
 func (suite *LayoutServiceTestSuite) TestGetLayoutList_CountError() {
-	suite.mockStore.On("GetLayoutListCount").Return(0, errors.New("database error"))
+	suite.mockStore.On("GetLayoutListCount", testCtx()).Return(0, errors.New("database error"))
 
-	result, err := suite.service.GetLayoutList(context.Background(), 10, 0)
+	result, err := suite.service.GetLayoutList(testCtx(), 10, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -88,10 +88,10 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutList_CountError() {
 
 // Test GetLayoutList - Store Error
 func (suite *LayoutServiceTestSuite) TestGetLayoutList_StoreError() {
-	suite.mockStore.On("GetLayoutListCount").Return(2, nil)
-	suite.mockStore.On("GetLayoutList", 10, 0).Return(nil, errors.New("database error"))
+	suite.mockStore.On("GetLayoutListCount", testCtx()).Return(2, nil)
+	suite.mockStore.On("GetLayoutList", testCtx(), 10, 0).Return(nil, errors.New("database error"))
 
-	result, err := suite.service.GetLayoutList(context.Background(), 10, 0)
+	result, err := suite.service.GetLayoutList(testCtx(), 10, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -99,7 +99,7 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutList_StoreError() {
 
 // Test GetLayoutList - Invalid Pagination
 func (suite *LayoutServiceTestSuite) TestGetLayoutList_InvalidLimit() {
-	result, err := suite.service.GetLayoutList(context.Background(), -1, 0)
+	result, err := suite.service.GetLayoutList(testCtx(), -1, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -107,7 +107,7 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutList_InvalidLimit() {
 }
 
 func (suite *LayoutServiceTestSuite) TestGetLayoutList_InvalidOffset() {
-	result, err := suite.service.GetLayoutList(context.Background(), 10, -1)
+	result, err := suite.service.GetLayoutList(testCtx(), 10, -1)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -123,11 +123,11 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_Success() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	suite.mockStore.On("IsLayoutHandleConflict", "new-layout", "").Return(false, nil)
-	suite.mockStore.On("CreateLayout", mock.AnythingOfType("string"),
+	suite.mockStore.On("IsLayoutHandleConflict", testCtx(), "new-layout", "").Return(false, nil)
+	suite.mockStore.On("CreateLayout", testCtx(), mock.AnythingOfType("string"),
 		mock.AnythingOfType("CreateLayoutRequest")).Return(nil)
 
-	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
+	result, err := suite.service.CreateLayout(testCtx(), layoutRequest)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -147,11 +147,11 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_HonorsProvidedID() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	suite.mockStore.On("IsLayoutHandleConflict", "new-layout", "").Return(false, nil)
-	suite.mockStore.On("CreateLayout", "provided-layout-id",
+	suite.mockStore.On("IsLayoutHandleConflict", testCtx(), "new-layout", "").Return(false, nil)
+	suite.mockStore.On("CreateLayout", testCtx(), "provided-layout-id",
 		mock.AnythingOfType("CreateLayoutRequest")).Return(nil)
 
-	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
+	result, err := suite.service.CreateLayout(testCtx(), layoutRequest)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -167,7 +167,7 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_MissingDisplayName() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
+	result, err := suite.service.CreateLayout(testCtx(), layoutRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -183,7 +183,7 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_MissingHandle() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
+	result, err := suite.service.CreateLayout(testCtx(), layoutRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -199,9 +199,9 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_DuplicateHandle() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	suite.mockStore.On("IsLayoutHandleConflict", "existing-layout", "").Return(true, nil)
+	suite.mockStore.On("IsLayoutHandleConflict", testCtx(), "existing-layout", "").Return(true, nil)
 
-	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
+	result, err := suite.service.CreateLayout(testCtx(), layoutRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -220,7 +220,7 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_DeclarativeModeEnabled() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
+	result, err := suite.service.CreateLayout(testCtx(), layoutRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -236,9 +236,9 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_InvalidJSON() {
 		Layout:      json.RawMessage(`{invalid json}`),
 	}
 
-	suite.mockStore.On("IsLayoutHandleConflict", "my-layout", "").Return(false, nil)
+	suite.mockStore.On("IsLayoutHandleConflict", testCtx(), "my-layout", "").Return(false, nil)
 
-	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
+	result, err := suite.service.CreateLayout(testCtx(), layoutRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -254,12 +254,12 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_StoreError() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	suite.mockStore.On("IsLayoutHandleConflict", "my-layout", "").Return(false, nil)
-	suite.mockStore.On("CreateLayout", mock.AnythingOfType("string"),
+	suite.mockStore.On("IsLayoutHandleConflict", testCtx(), "my-layout", "").Return(false, nil)
+	suite.mockStore.On("CreateLayout", testCtx(), mock.AnythingOfType("string"),
 		mock.AnythingOfType("CreateLayoutRequest")).
 		Return(errors.New("database error"))
 
-	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
+	result, err := suite.service.CreateLayout(testCtx(), layoutRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -274,9 +274,9 @@ func (suite *LayoutServiceTestSuite) TestGetLayout_Success() {
 		Layout:      json.RawMessage(`{"structure": "centered"}`),
 	}
 
-	suite.mockStore.On("GetLayout", "layout-123").Return(layout, nil)
+	suite.mockStore.On("GetLayout", testCtx(), "layout-123").Return(layout, nil)
 
-	result, err := suite.service.GetLayout(context.Background(), "layout-123")
+	result, err := suite.service.GetLayout(testCtx(), "layout-123")
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -286,7 +286,7 @@ func (suite *LayoutServiceTestSuite) TestGetLayout_Success() {
 
 // Test GetLayout - Invalid ID
 func (suite *LayoutServiceTestSuite) TestGetLayout_InvalidID() {
-	result, err := suite.service.GetLayout(context.Background(), "")
+	result, err := suite.service.GetLayout(testCtx(), "")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -295,9 +295,9 @@ func (suite *LayoutServiceTestSuite) TestGetLayout_InvalidID() {
 
 // Test GetLayout - Not Found
 func (suite *LayoutServiceTestSuite) TestGetLayout_NotFound() {
-	suite.mockStore.On("GetLayout", "non-existent").Return(Layout{}, errLayoutNotFound)
+	suite.mockStore.On("GetLayout", testCtx(), "non-existent").Return(Layout{}, errLayoutNotFound)
 
-	result, err := suite.service.GetLayout(context.Background(), "non-existent")
+	result, err := suite.service.GetLayout(testCtx(), "non-existent")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -306,9 +306,9 @@ func (suite *LayoutServiceTestSuite) TestGetLayout_NotFound() {
 
 // Test GetLayout - Store Error
 func (suite *LayoutServiceTestSuite) TestGetLayout_StoreError() {
-	suite.mockStore.On("GetLayout", "layout-123").Return(Layout{}, errors.New("database error"))
+	suite.mockStore.On("GetLayout", testCtx(), "layout-123").Return(Layout{}, errors.New("database error"))
 
-	result, err := suite.service.GetLayout(context.Background(), "layout-123")
+	result, err := suite.service.GetLayout(testCtx(), "layout-123")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -327,11 +327,11 @@ func (suite *LayoutServiceTestSuite) TestUpdateLayout_Success() {
 		Handle: "my-layout",
 	}
 
-	suite.mockStore.On("IsLayoutDeclarative", "layout-123").Return(false)
-	suite.mockStore.On("GetLayout", "layout-123").Return(existingLayout, nil)
-	suite.mockStore.On("UpdateLayout", "layout-123", updateRequest).Return(nil)
+	suite.mockStore.On("IsLayoutDeclarative", testCtx(), "layout-123").Return(false)
+	suite.mockStore.On("GetLayout", testCtx(), "layout-123").Return(existingLayout, nil)
+	suite.mockStore.On("UpdateLayout", testCtx(), "layout-123", updateRequest).Return(nil)
 
-	result, err := suite.service.UpdateLayout(context.Background(), "layout-123", updateRequest)
+	result, err := suite.service.UpdateLayout(testCtx(), "layout-123", updateRequest)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -353,11 +353,11 @@ func (suite *LayoutServiceTestSuite) TestUpdateLayout_OmittedHandle_UsesExisting
 		Handle: "existing-handle",
 	}
 
-	suite.mockStore.On("IsLayoutDeclarative", "layout-123").Return(false)
-	suite.mockStore.On("GetLayout", "layout-123").Return(existingLayout, nil)
-	suite.mockStore.On("UpdateLayout", "layout-123", updateRequest).Return(nil)
+	suite.mockStore.On("IsLayoutDeclarative", testCtx(), "layout-123").Return(false)
+	suite.mockStore.On("GetLayout", testCtx(), "layout-123").Return(existingLayout, nil)
+	suite.mockStore.On("UpdateLayout", testCtx(), "layout-123", updateRequest).Return(nil)
 
-	result, err := suite.service.UpdateLayout(context.Background(), "layout-123", updateRequest)
+	result, err := suite.service.UpdateLayout(testCtx(), "layout-123", updateRequest)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -373,7 +373,7 @@ func (suite *LayoutServiceTestSuite) TestUpdateLayout_InvalidID() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	result, err := suite.service.UpdateLayout(context.Background(), "", updateRequest)
+	result, err := suite.service.UpdateLayout(testCtx(), "", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -389,7 +389,7 @@ func (suite *LayoutServiceTestSuite) TestUpdateLayout_MissingDisplayName() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	result, err := suite.service.UpdateLayout(context.Background(), "layout-123", updateRequest)
+	result, err := suite.service.UpdateLayout(testCtx(), "layout-123", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -409,10 +409,10 @@ func (suite *LayoutServiceTestSuite) TestUpdateLayout_ImmutableHandle() {
 		Handle: "my-layout",
 	}
 
-	suite.mockStore.On("IsLayoutDeclarative", "layout-123").Return(false)
-	suite.mockStore.On("GetLayout", "layout-123").Return(existingLayout, nil)
+	suite.mockStore.On("IsLayoutDeclarative", testCtx(), "layout-123").Return(false)
+	suite.mockStore.On("GetLayout", testCtx(), "layout-123").Return(existingLayout, nil)
 
-	result, err := suite.service.UpdateLayout(context.Background(), "layout-123", updateRequest)
+	result, err := suite.service.UpdateLayout(testCtx(), "layout-123", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -428,10 +428,10 @@ func (suite *LayoutServiceTestSuite) TestUpdateLayout_NotFound() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	suite.mockStore.On("IsLayoutDeclarative", "non-existent").Return(false)
-	suite.mockStore.On("GetLayout", "non-existent").Return(Layout{}, errLayoutNotFound)
+	suite.mockStore.On("IsLayoutDeclarative", testCtx(), "non-existent").Return(false)
+	suite.mockStore.On("GetLayout", testCtx(), "non-existent").Return(Layout{}, errLayoutNotFound)
 
-	result, err := suite.service.UpdateLayout(context.Background(), "non-existent", updateRequest)
+	result, err := suite.service.UpdateLayout(testCtx(), "non-existent", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -450,9 +450,9 @@ func (suite *LayoutServiceTestSuite) TestUpdateLayout_InvalidJSON() {
 		ID:     "layout-123",
 		Handle: "my-layout",
 	}
-	suite.mockStore.On("IsLayoutDeclarative", "layout-123").Return(false)
-	suite.mockStore.On("GetLayout", "layout-123").Return(existingLayout, nil)
-	result, err := suite.service.UpdateLayout(context.Background(), "layout-123", updateRequest)
+	suite.mockStore.On("IsLayoutDeclarative", testCtx(), "layout-123").Return(false)
+	suite.mockStore.On("GetLayout", testCtx(), "layout-123").Return(existingLayout, nil)
+	result, err := suite.service.UpdateLayout(testCtx(), "layout-123", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -461,18 +461,18 @@ func (suite *LayoutServiceTestSuite) TestUpdateLayout_InvalidJSON() {
 
 // Test DeleteLayout - Success
 func (suite *LayoutServiceTestSuite) TestDeleteLayout_Success() {
-	suite.mockStore.On("IsLayoutDeclarative", "layout-123").Return(false)
-	suite.mockStore.On("IsLayoutExist", "layout-123").Return(true, nil)
-	suite.mockStore.On("DeleteLayout", "layout-123").Return(nil)
+	suite.mockStore.On("IsLayoutDeclarative", testCtx(), "layout-123").Return(false)
+	suite.mockStore.On("IsLayoutExist", testCtx(), "layout-123").Return(true, nil)
+	suite.mockStore.On("DeleteLayout", testCtx(), "layout-123").Return(nil)
 
-	err := suite.service.DeleteLayout(context.Background(), "layout-123")
+	err := suite.service.DeleteLayout(testCtx(), "layout-123")
 
 	assert.Nil(suite.T(), err)
 }
 
 // Test DeleteLayout - Invalid ID
 func (suite *LayoutServiceTestSuite) TestDeleteLayout_InvalidID() {
-	err := suite.service.DeleteLayout(context.Background(), "")
+	err := suite.service.DeleteLayout(testCtx(), "")
 
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "LAY-1002", err.Code)
@@ -480,30 +480,30 @@ func (suite *LayoutServiceTestSuite) TestDeleteLayout_InvalidID() {
 
 // Test DeleteLayout - Not Found (idempotent delete returns success)
 func (suite *LayoutServiceTestSuite) TestDeleteLayout_NotFound() {
-	suite.mockStore.On("IsLayoutDeclarative", "non-existent").Return(false)
-	suite.mockStore.On("IsLayoutExist", "non-existent").Return(false, nil)
+	suite.mockStore.On("IsLayoutDeclarative", testCtx(), "non-existent").Return(false)
+	suite.mockStore.On("IsLayoutExist", testCtx(), "non-existent").Return(false, nil)
 
-	err := suite.service.DeleteLayout(context.Background(), "non-existent")
+	err := suite.service.DeleteLayout(testCtx(), "non-existent")
 
 	assert.Nil(suite.T(), err)
 }
 
 // Test DeleteLayout - Store Error
 func (suite *LayoutServiceTestSuite) TestDeleteLayout_StoreError() {
-	suite.mockStore.On("IsLayoutDeclarative", "layout-123").Return(false)
-	suite.mockStore.On("IsLayoutExist", "layout-123").Return(true, nil)
-	suite.mockStore.On("DeleteLayout", "layout-123").Return(errors.New("database error"))
+	suite.mockStore.On("IsLayoutDeclarative", testCtx(), "layout-123").Return(false)
+	suite.mockStore.On("IsLayoutExist", testCtx(), "layout-123").Return(true, nil)
+	suite.mockStore.On("DeleteLayout", testCtx(), "layout-123").Return(errors.New("database error"))
 
-	err := suite.service.DeleteLayout(context.Background(), "layout-123")
+	err := suite.service.DeleteLayout(testCtx(), "layout-123")
 
 	assert.NotNil(suite.T(), err)
 }
 
 // Test IsLayoutExist - Exists
 func (suite *LayoutServiceTestSuite) TestIsLayoutExist_True() {
-	suite.mockStore.On("IsLayoutExist", "layout-123").Return(true, nil)
+	suite.mockStore.On("IsLayoutExist", testCtx(), "layout-123").Return(true, nil)
 
-	exists, err := suite.service.IsLayoutExist(context.Background(), "layout-123")
+	exists, err := suite.service.IsLayoutExist(testCtx(), "layout-123")
 
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), exists)
@@ -511,9 +511,9 @@ func (suite *LayoutServiceTestSuite) TestIsLayoutExist_True() {
 
 // Test IsLayoutExist - Not Exists
 func (suite *LayoutServiceTestSuite) TestIsLayoutExist_False() {
-	suite.mockStore.On("IsLayoutExist", "non-existent").Return(false, nil)
+	suite.mockStore.On("IsLayoutExist", testCtx(), "non-existent").Return(false, nil)
 
-	exists, err := suite.service.IsLayoutExist(context.Background(), "non-existent")
+	exists, err := suite.service.IsLayoutExist(testCtx(), "non-existent")
 
 	assert.Nil(suite.T(), err)
 	assert.False(suite.T(), exists)
@@ -521,9 +521,9 @@ func (suite *LayoutServiceTestSuite) TestIsLayoutExist_False() {
 
 // Test IsLayoutExist - Store Error
 func (suite *LayoutServiceTestSuite) TestIsLayoutExist_StoreError() {
-	suite.mockStore.On("IsLayoutExist", "layout-123").Return(false, errors.New("database error"))
+	suite.mockStore.On("IsLayoutExist", testCtx(), "layout-123").Return(false, errors.New("database error"))
 
-	exists, err := suite.service.IsLayoutExist(context.Background(), "layout-123")
+	exists, err := suite.service.IsLayoutExist(testCtx(), "layout-123")
 
 	assert.NotNil(suite.T(), err)
 	assert.False(suite.T(), exists)
@@ -538,9 +538,10 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_HandleConflictError() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	suite.mockStore.On("IsLayoutHandleConflict", "my-layout", "").Return(false, errors.New("database error"))
+	suite.mockStore.On("IsLayoutHandleConflict", testCtx(), "my-layout", "").Return(false,
+		errors.New("database error"))
 
-	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
+	result, err := suite.service.CreateLayout(testCtx(), layoutRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -555,10 +556,10 @@ func (suite *LayoutServiceTestSuite) TestUpdateLayout_GetLayoutError() {
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
 	}
 
-	suite.mockStore.On("IsLayoutDeclarative", "layout-123").Return(false)
-	suite.mockStore.On("GetLayout", "layout-123").Return(Layout{}, errors.New("database error"))
+	suite.mockStore.On("IsLayoutDeclarative", testCtx(), "layout-123").Return(false)
+	suite.mockStore.On("GetLayout", testCtx(), "layout-123").Return(Layout{}, errors.New("database error"))
 
-	result, err := suite.service.UpdateLayout(context.Background(), "layout-123", updateRequest)
+	result, err := suite.service.UpdateLayout(testCtx(), "layout-123", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -590,7 +591,7 @@ func (s *stubUsageRegistry) ValidateReferenceUpdate(
 
 // Test GetLayoutUsages - Empty ID
 func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_EmptyID() {
-	result, err := suite.service.GetLayoutUsages(context.Background(), "", 10, 0)
+	result, err := suite.service.GetLayoutUsages(testCtx(), "", 10, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -599,9 +600,9 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_EmptyID() {
 
 // Test GetLayoutUsages - Layout not found
 func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_NotFound() {
-	suite.mockStore.On("IsLayoutExist", "missing").Return(false, nil)
+	suite.mockStore.On("IsLayoutExist", testCtx(), "missing").Return(false, nil)
 
-	result, err := suite.service.GetLayoutUsages(context.Background(), "missing", 10, 0)
+	result, err := suite.service.GetLayoutUsages(testCtx(), "missing", 10, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -610,9 +611,9 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_NotFound() {
 
 // Test GetLayoutUsages - registry not set returns unknown (nil totalResults)
 func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_RegistryNotSet() {
-	suite.mockStore.On("IsLayoutExist", "layout-123").Return(true, nil)
+	suite.mockStore.On("IsLayoutExist", testCtx(), "layout-123").Return(true, nil)
 
-	result, err := suite.service.GetLayoutUsages(context.Background(), "layout-123", 10, 0)
+	result, err := suite.service.GetLayoutUsages(testCtx(), "layout-123", 10, 0)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -622,7 +623,7 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_RegistryNotSet() {
 
 // Test GetLayoutUsages - registry returns usages
 func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_WithUsages() {
-	suite.mockStore.On("IsLayoutExist", "layout-123").Return(true, nil)
+	suite.mockStore.On("IsLayoutExist", testCtx(), "layout-123").Return(true, nil)
 	total := 1
 	suite.service.SetDependencyRegistry(&stubUsageRegistry{
 		resp: &resourcedependency.DependenciesResponse{
@@ -636,7 +637,7 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_WithUsages() {
 		},
 	})
 
-	result, err := suite.service.GetLayoutUsages(context.Background(), "layout-123", 10, 0)
+	result, err := suite.service.GetLayoutUsages(testCtx(), "layout-123", 10, 0)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -647,7 +648,7 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_WithUsages() {
 
 // Test GetLayoutUsages - pagination narrows the usages window while keeping the full total
 func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_Pagination() {
-	suite.mockStore.On("IsLayoutExist", "layout-123").Return(true, nil)
+	suite.mockStore.On("IsLayoutExist", testCtx(), "layout-123").Return(true, nil)
 	total := 3
 	suite.service.SetDependencyRegistry(&stubUsageRegistry{
 		resp: &resourcedependency.DependenciesResponse{
@@ -665,7 +666,7 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_Pagination() {
 		},
 	})
 
-	result, err := suite.service.GetLayoutUsages(context.Background(), "layout-123", 1, 1)
+	result, err := suite.service.GetLayoutUsages(testCtx(), "layout-123", 1, 1)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -678,11 +679,20 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_Pagination() {
 
 // Test GetLayoutUsages - registry returns error
 func (suite *LayoutServiceTestSuite) TestGetLayoutUsages_RegistryError() {
-	suite.mockStore.On("IsLayoutExist", "layout-123").Return(true, nil)
+	suite.mockStore.On("IsLayoutExist", testCtx(), "layout-123").Return(true, nil)
 	suite.service.SetDependencyRegistry(&stubUsageRegistry{err: errors.New("registry error")})
 
-	result, err := suite.service.GetLayoutUsages(context.Background(), "layout-123", 10, 0)
+	result, err := suite.service.GetLayoutUsages(testCtx(), "layout-123", 10, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
+}
+
+// ctxKeyForTest marks a context so a store expectation can assert the service carried the caller's
+// context through, rather than substituting one of its own.
+type ctxKeyForTest struct{}
+
+// testCtx returns a context distinguishable from any other, including context.Background().
+func testCtx() context.Context {
+	return context.WithValue(context.Background(), ctxKeyForTest{}, "carried")
 }

--- a/backend/internal/design/layout/mgt/store.go
+++ b/backend/internal/design/layout/mgt/store.go
@@ -4,6 +4,7 @@
 package layoutmgt
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,15 +18,15 @@ var errLayoutNotFound = errors.New("layout not found")
 
 // layoutMgtStoreInterface defines the interface for layout management store operations.
 type layoutMgtStoreInterface interface {
-	GetLayoutListCount() (int, error)
-	GetLayoutList(limit, offset int) ([]Layout, error)
-	CreateLayout(id string, layout CreateLayoutRequest) error
-	GetLayout(id string) (Layout, error)
-	IsLayoutExist(id string) (bool, error)
-	UpdateLayout(id string, layout UpdateLayoutRequest) error
-	DeleteLayout(id string) error
-	IsLayoutDeclarative(id string) bool
-	IsLayoutHandleConflict(handle string, excludeID string) (bool, error)
+	GetLayoutListCount(ctx context.Context) (int, error)
+	GetLayoutList(ctx context.Context, limit, offset int) ([]Layout, error)
+	CreateLayout(ctx context.Context, id string, layout CreateLayoutRequest) error
+	GetLayout(ctx context.Context, id string) (Layout, error)
+	IsLayoutExist(ctx context.Context, id string) (bool, error)
+	UpdateLayout(ctx context.Context, id string, layout UpdateLayoutRequest) error
+	DeleteLayout(ctx context.Context, id string) error
+	IsLayoutDeclarative(ctx context.Context, id string) bool
+	IsLayoutHandleConflict(ctx context.Context, handle string, excludeID string) (bool, error)
 }
 
 // layoutMgtStore is the default implementation of layoutMgtStoreInterface.
@@ -43,7 +44,7 @@ func newLayoutMgtStore() layoutMgtStoreInterface {
 }
 
 // GetLayoutListCount retrieves the total count of layout configurations.
-func (s *layoutMgtStore) GetLayoutListCount() (int, error) {
+func (s *layoutMgtStore) GetLayoutListCount(ctx context.Context) (int, error) {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return 0, err
@@ -58,7 +59,7 @@ func (s *layoutMgtStore) GetLayoutListCount() (int, error) {
 }
 
 // GetLayoutList retrieves layout configurations with pagination.
-func (s *layoutMgtStore) GetLayoutList(limit, offset int) ([]Layout, error) {
+func (s *layoutMgtStore) GetLayoutList(ctx context.Context, limit, offset int) ([]Layout, error) {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return nil, err
@@ -82,7 +83,7 @@ func (s *layoutMgtStore) GetLayoutList(limit, offset int) ([]Layout, error) {
 }
 
 // CreateLayout creates a new layout configuration in the database.
-func (s *layoutMgtStore) CreateLayout(id string, layout CreateLayoutRequest) error {
+func (s *layoutMgtStore) CreateLayout(ctx context.Context, id string, layout CreateLayoutRequest) error {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return err
@@ -103,7 +104,7 @@ func (s *layoutMgtStore) CreateLayout(id string, layout CreateLayoutRequest) err
 }
 
 // GetLayout retrieves a layout configuration by its id.
-func (s *layoutMgtStore) GetLayout(id string) (Layout, error) {
+func (s *layoutMgtStore) GetLayout(ctx context.Context, id string) (Layout, error) {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return Layout{}, err
@@ -126,7 +127,7 @@ func (s *layoutMgtStore) GetLayout(id string) (Layout, error) {
 }
 
 // IsLayoutExist checks if a layout configuration exists by its ID.
-func (s *layoutMgtStore) IsLayoutExist(id string) (bool, error) {
+func (s *layoutMgtStore) IsLayoutExist(ctx context.Context, id string) (bool, error) {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return false, err
@@ -150,7 +151,7 @@ func (s *layoutMgtStore) IsLayoutExist(id string) (bool, error) {
 }
 
 // UpdateLayout updates a layout configuration.
-func (s *layoutMgtStore) UpdateLayout(id string, layout UpdateLayoutRequest) error {
+func (s *layoutMgtStore) UpdateLayout(ctx context.Context, id string, layout UpdateLayoutRequest) error {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return err
@@ -170,7 +171,7 @@ func (s *layoutMgtStore) UpdateLayout(id string, layout UpdateLayoutRequest) err
 }
 
 // DeleteLayout deletes a layout configuration.
-func (s *layoutMgtStore) DeleteLayout(id string) error {
+func (s *layoutMgtStore) DeleteLayout(ctx context.Context, id string) error {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return err
@@ -185,7 +186,7 @@ func (s *layoutMgtStore) DeleteLayout(id string) error {
 }
 
 // IsLayoutDeclarative checks if a layout is immutable (in database store, all layouts are mutable).
-func (s *layoutMgtStore) IsLayoutDeclarative(id string) bool {
+func (s *layoutMgtStore) IsLayoutDeclarative(ctx context.Context, id string) bool {
 	return false
 }
 
@@ -337,7 +338,7 @@ func (s *layoutMgtStore) buildLayoutFromResultRow(row map[string]interface{}) (L
 }
 
 // IsLayoutHandleConflict checks if a layout handle already exists for the deployment, excluding a specific ID.
-func (s *layoutMgtStore) IsLayoutHandleConflict(handle string, excludeID string) (bool, error) {
+func (s *layoutMgtStore) IsLayoutHandleConflict(ctx context.Context, handle string, excludeID string) (bool, error) {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return false, err

--- a/backend/internal/design/layout/mgt/store_test.go
+++ b/backend/internal/design/layout/mgt/store_test.go
@@ -4,6 +4,7 @@
 package layoutmgt
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -44,7 +45,7 @@ func (suite *LayoutStoreTestSuite) TestGetLayoutListCount_Success() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "test-deployment").Return(results, nil)
 
-	count, err := suite.store.GetLayoutListCount()
+	count, err := suite.store.GetLayoutListCount(context.Background())
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 5, count)
@@ -54,7 +55,7 @@ func (suite *LayoutStoreTestSuite) TestGetLayoutListCount_Success() {
 func (suite *LayoutStoreTestSuite) TestGetLayoutListCount_DBClientError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("connection error"))
 
-	count, err := suite.store.GetLayoutListCount()
+	count, err := suite.store.GetLayoutListCount(context.Background())
 
 	assert.Error(suite.T(), err)
 	assert.Equal(suite.T(), 0, count)
@@ -66,7 +67,7 @@ func (suite *LayoutStoreTestSuite) TestGetLayoutListCount_QueryError() {
 	suite.mockDBClient.On("Query", mock.Anything, "test-deployment").
 		Return(nil, errors.New("query error"))
 
-	count, err := suite.store.GetLayoutListCount()
+	count, err := suite.store.GetLayoutListCount(context.Background())
 
 	assert.Error(suite.T(), err)
 	assert.Equal(suite.T(), 0, count)
@@ -95,7 +96,7 @@ func (suite *LayoutStoreTestSuite) TestGetLayoutList_Success() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, 10, 0, "test-deployment").Return(results, nil)
 
-	layouts, err := suite.store.GetLayoutList(10, 0)
+	layouts, err := suite.store.GetLayoutList(context.Background(), 10, 0)
 
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), layouts, 2)
@@ -107,7 +108,7 @@ func (suite *LayoutStoreTestSuite) TestGetLayoutList_Success() {
 func (suite *LayoutStoreTestSuite) TestGetLayoutList_DBClientError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("connection error"))
 
-	layouts, err := suite.store.GetLayoutList(10, 0)
+	layouts, err := suite.store.GetLayoutList(context.Background(), 10, 0)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), layouts)
@@ -119,7 +120,7 @@ func (suite *LayoutStoreTestSuite) TestCreateLayout_Success() {
 	suite.mockDBClient.On("Execute", mock.Anything, "layout-1", "classic", "Test", "Desc",
 		mock.Anything, "test-deployment").Return(int64(1), nil)
 
-	err := suite.store.CreateLayout("layout-1", CreateLayoutRequest{
+	err := suite.store.CreateLayout(context.Background(), "layout-1", CreateLayoutRequest{
 		Handle:      "classic",
 		DisplayName: "Test",
 		Description: "Desc",
@@ -145,7 +146,7 @@ func (suite *LayoutStoreTestSuite) TestGetLayout_Success() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "layout-123", "test-deployment").Return(results, nil)
 
-	layout, err := suite.store.GetLayout("layout-123")
+	layout, err := suite.store.GetLayout(context.Background(), "layout-123")
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "layout-123", layout.ID)
@@ -158,7 +159,7 @@ func (suite *LayoutStoreTestSuite) TestGetLayout_NotFound() {
 	suite.mockDBClient.On("Query", mock.Anything, "non-existent", "test-deployment").
 		Return([]map[string]interface{}{}, nil)
 
-	_, err := suite.store.GetLayout("non-existent")
+	_, err := suite.store.GetLayout(context.Background(), "non-existent")
 
 	assert.Error(suite.T(), err)
 	assert.True(suite.T(), errors.Is(err, errLayoutNotFound))
@@ -173,7 +174,7 @@ func (suite *LayoutStoreTestSuite) TestGetLayout_MultipleResults() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "layout-123", "test-deployment").Return(results, nil)
 
-	_, err := suite.store.GetLayout("layout-123")
+	_, err := suite.store.GetLayout(context.Background(), "layout-123")
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "unexpected number of results")
@@ -187,7 +188,7 @@ func (suite *LayoutStoreTestSuite) TestIsLayoutExist_True() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "layout-123", "test-deployment").Return(results, nil)
 
-	exists, err := suite.store.IsLayoutExist("layout-123")
+	exists, err := suite.store.IsLayoutExist(context.Background(), "layout-123")
 
 	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), exists)
@@ -199,7 +200,7 @@ func (suite *LayoutStoreTestSuite) TestIsLayoutExist_False() {
 	suite.mockDBClient.On("Query", mock.Anything, "non-existent", "test-deployment").
 		Return([]map[string]interface{}{}, nil)
 
-	exists, err := suite.store.IsLayoutExist("non-existent")
+	exists, err := suite.store.IsLayoutExist(context.Background(), "non-existent")
 
 	assert.NoError(suite.T(), err)
 	assert.False(suite.T(), exists)
@@ -211,7 +212,7 @@ func (suite *LayoutStoreTestSuite) TestDeleteLayout_Success() {
 	suite.mockDBClient.On("Execute", mock.Anything, "layout-123", "test-deployment").
 		Return(int64(1), nil)
 
-	err := suite.store.DeleteLayout("layout-123")
+	err := suite.store.DeleteLayout(context.Background(), "layout-123")
 
 	assert.NoError(suite.T(), err)
 }
@@ -369,7 +370,7 @@ func (suite *LayoutStoreTestSuite) TestIsLayoutHandleConflict_Conflict() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "classic", "test-deployment", "").Return(results, nil)
 
-	conflict, err := suite.store.IsLayoutHandleConflict("classic", "")
+	conflict, err := suite.store.IsLayoutHandleConflict(context.Background(), "classic", "")
 
 	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), conflict)
@@ -383,7 +384,7 @@ func (suite *LayoutStoreTestSuite) TestIsLayoutHandleConflict_NoConflict() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "unique-handle", "test-deployment", "layout-1").Return(results, nil)
 
-	conflict, err := suite.store.IsLayoutHandleConflict("unique-handle", "layout-1")
+	conflict, err := suite.store.IsLayoutHandleConflict(context.Background(), "unique-handle", "layout-1")
 
 	assert.NoError(suite.T(), err)
 	assert.False(suite.T(), conflict)
@@ -393,7 +394,7 @@ func (suite *LayoutStoreTestSuite) TestIsLayoutHandleConflict_NoConflict() {
 func (suite *LayoutStoreTestSuite) TestIsLayoutHandleConflict_DBClientError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("connection error"))
 
-	conflict, err := suite.store.IsLayoutHandleConflict("classic", "")
+	conflict, err := suite.store.IsLayoutHandleConflict(context.Background(), "classic", "")
 
 	assert.Error(suite.T(), err)
 	assert.False(suite.T(), conflict)
@@ -405,7 +406,7 @@ func (suite *LayoutStoreTestSuite) TestIsLayoutHandleConflict_QueryError() {
 	suite.mockDBClient.On("Query", mock.Anything, "classic", "test-deployment", "").
 		Return(nil, errors.New("query error"))
 
-	conflict, err := suite.store.IsLayoutHandleConflict("classic", "")
+	conflict, err := suite.store.IsLayoutHandleConflict(context.Background(), "classic", "")
 
 	assert.Error(suite.T(), err)
 	assert.False(suite.T(), conflict)
@@ -415,7 +416,7 @@ func (suite *LayoutStoreTestSuite) TestIsLayoutHandleConflict_QueryError() {
 func (suite *LayoutStoreTestSuite) TestUpdateLayout_DBClientError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("connection error"))
 
-	err := suite.store.UpdateLayout("layout-1", UpdateLayoutRequest{
+	err := suite.store.UpdateLayout(context.Background(), "layout-1", UpdateLayoutRequest{
 		DisplayName: "Updated",
 		Description: "Updated Desc",
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
@@ -428,7 +429,7 @@ func (suite *LayoutStoreTestSuite) TestUpdateLayout_DBClientError() {
 func (suite *LayoutStoreTestSuite) TestDeleteLayout_DBClientError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("connection error"))
 
-	err := suite.store.DeleteLayout("layout-1")
+	err := suite.store.DeleteLayout(context.Background(), "layout-1")
 
 	assert.Error(suite.T(), err)
 }

--- a/backend/internal/design/theme/mgt/composite_store.go
+++ b/backend/internal/design/theme/mgt/composite_store.go
@@ -4,6 +4,8 @@
 package thememgt
 
 import (
+	"context"
+
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 )
@@ -27,22 +29,22 @@ func newCompositeThemeStore(fileStore, dbStore themeMgtStoreInterface) *composit
 }
 
 // GetThemeListCount retrieves the total count of themes from both stores.
-func (c *compositeThemeStore) GetThemeListCount() (int, error) {
+func (c *compositeThemeStore) GetThemeListCount(ctx context.Context) (int, error) {
 	return declarativeresource.CompositeMergeCountHelper(
-		func() (int, error) { return c.dbStore.GetThemeListCount() },
-		func() (int, error) { return c.fileStore.GetThemeListCount() },
+		func() (int, error) { return c.dbStore.GetThemeListCount(ctx) },
+		func() (int, error) { return c.fileStore.GetThemeListCount(ctx) },
 	)
 }
 
 // GetThemeList retrieves themes from both stores with pagination.
 // Applies the 1000-record limit in composite mode to prevent memory exhaustion.
 // Returns errResultLimitExceededInCompositeMode if the limit is exceeded.
-func (c *compositeThemeStore) GetThemeList(limit, offset int) ([]Theme, error) {
+func (c *compositeThemeStore) GetThemeList(ctx context.Context, limit, offset int) ([]Theme, error) {
 	items, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
-		func() (int, error) { return c.dbStore.GetThemeListCount() },
-		func() (int, error) { return c.fileStore.GetThemeListCount() },
-		func(count int) ([]Theme, error) { return c.dbStore.GetThemeList(count, 0) },
-		func(count int) ([]Theme, error) { return c.fileStore.GetThemeList(count, 0) },
+		func() (int, error) { return c.dbStore.GetThemeListCount(ctx) },
+		func() (int, error) { return c.fileStore.GetThemeListCount(ctx) },
+		func(count int) ([]Theme, error) { return c.dbStore.GetThemeList(ctx, count, 0) },
+		func(count int) ([]Theme, error) { return c.fileStore.GetThemeList(ctx, count, 0) },
 		mergeAndDeduplicateThemes,
 		limit,
 		offset,
@@ -60,16 +62,16 @@ func (c *compositeThemeStore) GetThemeList(limit, offset int) ([]Theme, error) {
 
 // CreateTheme creates a new theme in the database store only.
 // Conflict checking is handled at the service layer.
-func (c *compositeThemeStore) CreateTheme(id string, theme CreateThemeRequest) error {
-	return c.dbStore.CreateTheme(id, theme)
+func (c *compositeThemeStore) CreateTheme(ctx context.Context, id string, theme CreateThemeRequest) error {
+	return c.dbStore.CreateTheme(ctx, id, theme)
 }
 
 // GetTheme retrieves a theme by ID from either store.
 // Checks database store first, then falls back to file store (declarative).
-func (c *compositeThemeStore) GetTheme(id string) (Theme, error) {
+func (c *compositeThemeStore) GetTheme(ctx context.Context, id string) (Theme, error) {
 	theme, err := declarativeresource.CompositeGetHelper(
 		func() (Theme, error) {
-			theme, err := c.dbStore.GetTheme(id)
+			theme, err := c.dbStore.GetTheme(ctx, id)
 			if err != nil {
 				return Theme{}, err
 			}
@@ -77,7 +79,7 @@ func (c *compositeThemeStore) GetTheme(id string) (Theme, error) {
 			return theme, nil
 		},
 		func() (Theme, error) {
-			theme, err := c.fileStore.GetTheme(id)
+			theme, err := c.fileStore.GetTheme(ctx, id)
 			if err != nil {
 				return Theme{}, err
 			}
@@ -90,9 +92,9 @@ func (c *compositeThemeStore) GetTheme(id string) (Theme, error) {
 }
 
 // IsThemeExist checks if a theme exists in either store.
-func (c *compositeThemeStore) IsThemeExist(id string) (bool, error) {
+func (c *compositeThemeStore) IsThemeExist(ctx context.Context, id string) (bool, error) {
 	// Check database store first
-	exists, err := c.dbStore.IsThemeExist(id)
+	exists, err := c.dbStore.IsThemeExist(ctx, id)
 	if err != nil {
 		return false, err
 	}
@@ -101,42 +103,43 @@ func (c *compositeThemeStore) IsThemeExist(id string) (bool, error) {
 	}
 
 	// Check file store
-	return c.fileStore.IsThemeExist(id)
+	return c.fileStore.IsThemeExist(ctx, id)
 }
 
 // UpdateTheme updates a theme in the database store only.
 // Returns an error if the theme is declarative (immutable).
-func (c *compositeThemeStore) UpdateTheme(id string, theme UpdateThemeRequest) error {
+func (c *compositeThemeStore) UpdateTheme(ctx context.Context, id string, theme UpdateThemeRequest) error {
 	return declarativeresource.CompositeUpdateHelper(
 		theme,
 		func(UpdateThemeRequest) string { return id },
-		func(id string) (bool, error) { return c.fileStore.IsThemeExist(id) },
-		func(UpdateThemeRequest) error { return c.dbStore.UpdateTheme(id, theme) },
+		func(id string) (bool, error) { return c.fileStore.IsThemeExist(ctx, id) },
+		func(UpdateThemeRequest) error { return c.dbStore.UpdateTheme(ctx, id, theme) },
 		errCannotUpdateDeclarativeTheme,
 	)
 }
 
 // DeleteTheme deletes a theme from the database store only.
 // Returns an error if the theme is declarative (immutable).
-func (c *compositeThemeStore) DeleteTheme(id string) error {
+func (c *compositeThemeStore) DeleteTheme(ctx context.Context, id string) error {
 	return declarativeresource.CompositeDeleteHelper(
 		id,
-		func(id string) (bool, error) { return c.fileStore.IsThemeExist(id) },
-		func(id string) error { return c.dbStore.DeleteTheme(id) },
+		func(id string) (bool, error) { return c.fileStore.IsThemeExist(ctx, id) },
+		func(id string) error { return c.dbStore.DeleteTheme(ctx, id) },
 		errCannotDeleteDeclarativeTheme,
 	)
 }
 
 // IsThemeDeclarative checks if a theme is immutable (exists in file store).
-func (c *compositeThemeStore) IsThemeDeclarative(id string) bool {
-	exists, err := c.fileStore.IsThemeExist(id)
+func (c *compositeThemeStore) IsThemeDeclarative(ctx context.Context, id string) bool {
+	exists, err := c.fileStore.IsThemeExist(ctx, id)
 	return err == nil && exists
 }
 
 // IsThemeHandleConflict checks if a theme handle conflicts in either store.
-func (c *compositeThemeStore) IsThemeHandleConflict(handle string, excludeID string) (bool, error) {
+func (c *compositeThemeStore) IsThemeHandleConflict(ctx context.Context, handle string, excludeID string) (bool,
+	error) {
 	// Check file store first
-	conflict, err := c.fileStore.IsThemeHandleConflict(handle, excludeID)
+	conflict, err := c.fileStore.IsThemeHandleConflict(ctx, handle, excludeID)
 	if err != nil {
 		return false, err
 	}
@@ -144,7 +147,7 @@ func (c *compositeThemeStore) IsThemeHandleConflict(handle string, excludeID str
 		return true, nil
 	}
 	// Then check db store
-	return c.dbStore.IsThemeHandleConflict(handle, excludeID)
+	return c.dbStore.IsThemeHandleConflict(ctx, handle, excludeID)
 }
 
 // mergeAndDeduplicateThemes merges themes from DB and file stores, removing duplicates.

--- a/backend/internal/design/theme/mgt/composite_store_test.go
+++ b/backend/internal/design/theme/mgt/composite_store_test.go
@@ -31,10 +31,10 @@ func (suite *CompositeThemeStoreTestSuite) SetupTest() {
 
 // Test GetThemeListCount - Adds counts from both stores
 func (suite *CompositeThemeStoreTestSuite) TestGetThemeListCount_AddsCounts() {
-	suite.mockDBStore.On("GetThemeListCount").Return(2, nil)
-	suite.mockFileStore.On("GetThemeListCount").Return(3, nil)
+	suite.mockDBStore.On("GetThemeListCount", testCtx()).Return(2, nil)
+	suite.mockFileStore.On("GetThemeListCount", testCtx()).Return(3, nil)
 
-	count, err := suite.store.GetThemeListCount()
+	count, err := suite.store.GetThemeListCount(testCtx())
 
 	suite.NoError(err)
 	suite.Equal(5, count) // 2 + 3 = 5 (no deduplication in count)
@@ -43,9 +43,9 @@ func (suite *CompositeThemeStoreTestSuite) TestGetThemeListCount_AddsCounts() {
 // Test GetThemeListCount - DB store error
 func (suite *CompositeThemeStoreTestSuite) TestGetThemeListCount_DBStoreError() {
 	testErr := errors.New("db error")
-	suite.mockDBStore.On("GetThemeListCount").Return(0, testErr)
+	suite.mockDBStore.On("GetThemeListCount", testCtx()).Return(0, testErr)
 
-	_, err := suite.store.GetThemeListCount()
+	_, err := suite.store.GetThemeListCount(testCtx())
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -54,10 +54,10 @@ func (suite *CompositeThemeStoreTestSuite) TestGetThemeListCount_DBStoreError() 
 // Test GetThemeListCount - File store count error
 func (suite *CompositeThemeStoreTestSuite) TestGetThemeListCount_FileStoreCountError() {
 	testErr := errors.New("file store error")
-	suite.mockDBStore.On("GetThemeListCount").Return(2, nil)
-	suite.mockFileStore.On("GetThemeListCount").Return(0, testErr)
+	suite.mockDBStore.On("GetThemeListCount", testCtx()).Return(2, nil)
+	suite.mockFileStore.On("GetThemeListCount", testCtx()).Return(0, testErr)
 
-	_, err := suite.store.GetThemeListCount()
+	_, err := suite.store.GetThemeListCount(testCtx())
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -65,10 +65,10 @@ func (suite *CompositeThemeStoreTestSuite) TestGetThemeListCount_FileStoreCountE
 
 // Test GetThemeListCount - Empty stores
 func (suite *CompositeThemeStoreTestSuite) TestGetThemeListCount_EmptyStores() {
-	suite.mockDBStore.On("GetThemeListCount").Return(0, nil)
-	suite.mockFileStore.On("GetThemeListCount").Return(0, nil)
+	suite.mockDBStore.On("GetThemeListCount", testCtx()).Return(0, nil)
+	suite.mockFileStore.On("GetThemeListCount", testCtx()).Return(0, nil)
 
-	count, err := suite.store.GetThemeListCount()
+	count, err := suite.store.GetThemeListCount(testCtx())
 
 	suite.NoError(err)
 	suite.Equal(0, count)
@@ -79,12 +79,12 @@ func (suite *CompositeThemeStoreTestSuite) TestGetThemeList_Pagination() {
 	dbThemes := []Theme{{ID: "theme1"}, {ID: "theme2"}}
 	fileThemes := []Theme{{ID: "theme2"}, {ID: "theme3"}}
 
-	suite.mockDBStore.On("GetThemeListCount").Return(2, nil)
-	suite.mockFileStore.On("GetThemeListCount").Return(2, nil)
-	suite.mockDBStore.On("GetThemeList", 2, 0).Return(dbThemes, nil)
-	suite.mockFileStore.On("GetThemeList", 2, 0).Return(fileThemes, nil)
+	suite.mockDBStore.On("GetThemeListCount", testCtx()).Return(2, nil)
+	suite.mockFileStore.On("GetThemeListCount", testCtx()).Return(2, nil)
+	suite.mockDBStore.On("GetThemeList", testCtx(), 2, 0).Return(dbThemes, nil)
+	suite.mockFileStore.On("GetThemeList", testCtx(), 2, 0).Return(fileThemes, nil)
 
-	themes, err := suite.store.GetThemeList(2, 1)
+	themes, err := suite.store.GetThemeList(testCtx(), 2, 1)
 
 	suite.NoError(err)
 	suite.Len(themes, 2) // Should get 2 themes from offset 1
@@ -93,10 +93,10 @@ func (suite *CompositeThemeStoreTestSuite) TestGetThemeList_Pagination() {
 // Test GetThemeList - Returns limit exceeded error
 func (suite *CompositeThemeStoreTestSuite) TestGetThemeList_LimitExceeded() {
 	// Create more themes than the max composite store limit (1000)
-	suite.mockDBStore.On("GetThemeListCount").Return(1001, nil)
-	suite.mockFileStore.On("GetThemeListCount").Return(0, nil)
+	suite.mockDBStore.On("GetThemeListCount", testCtx()).Return(1001, nil)
+	suite.mockFileStore.On("GetThemeListCount", testCtx()).Return(0, nil)
 
-	_, err := suite.store.GetThemeList(100, 0)
+	_, err := suite.store.GetThemeList(testCtx(), 100, 0)
 
 	suite.Error(err)
 	suite.Equal(errResultLimitExceededInCompositeMode, err)
@@ -105,9 +105,9 @@ func (suite *CompositeThemeStoreTestSuite) TestGetThemeList_LimitExceeded() {
 // Test GetThemeList - DB store error
 func (suite *CompositeThemeStoreTestSuite) TestGetThemeList_DBStoreError() {
 	testErr := errors.New("db error")
-	suite.mockDBStore.On("GetThemeListCount").Return(0, testErr)
+	suite.mockDBStore.On("GetThemeListCount", testCtx()).Return(0, testErr)
 
-	_, err := suite.store.GetThemeList(10, 0)
+	_, err := suite.store.GetThemeList(testCtx(), 10, 0)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -116,10 +116,10 @@ func (suite *CompositeThemeStoreTestSuite) TestGetThemeList_DBStoreError() {
 // Test GetThemeList - File store count error
 func (suite *CompositeThemeStoreTestSuite) TestGetThemeList_FileStoreCountError() {
 	testErr := errors.New("file store error")
-	suite.mockDBStore.On("GetThemeListCount").Return(2, nil)
-	suite.mockFileStore.On("GetThemeListCount").Return(0, testErr)
+	suite.mockDBStore.On("GetThemeListCount", testCtx()).Return(2, nil)
+	suite.mockFileStore.On("GetThemeListCount", testCtx()).Return(0, testErr)
 
-	_, err := suite.store.GetThemeList(10, 0)
+	_, err := suite.store.GetThemeList(testCtx(), 10, 0)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -128,11 +128,11 @@ func (suite *CompositeThemeStoreTestSuite) TestGetThemeList_FileStoreCountError(
 // Test GetThemeList - DB themes list error
 func (suite *CompositeThemeStoreTestSuite) TestGetThemeList_DBThemesListError() {
 	testErr := errors.New("db list error")
-	suite.mockDBStore.On("GetThemeListCount").Return(2, nil)
-	suite.mockFileStore.On("GetThemeListCount").Return(2, nil)
-	suite.mockDBStore.On("GetThemeList", 2, 0).Return(nil, testErr)
+	suite.mockDBStore.On("GetThemeListCount", testCtx()).Return(2, nil)
+	suite.mockFileStore.On("GetThemeListCount", testCtx()).Return(2, nil)
+	suite.mockDBStore.On("GetThemeList", testCtx(), 2, 0).Return(nil, testErr)
 
-	_, err := suite.store.GetThemeList(10, 0)
+	_, err := suite.store.GetThemeList(testCtx(), 10, 0)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -142,12 +142,12 @@ func (suite *CompositeThemeStoreTestSuite) TestGetThemeList_DBThemesListError() 
 func (suite *CompositeThemeStoreTestSuite) TestGetThemeList_FileThemesListError() {
 	testErr := errors.New("file list error")
 	dbThemes := []Theme{{ID: "theme1"}}
-	suite.mockDBStore.On("GetThemeListCount").Return(1, nil)
-	suite.mockFileStore.On("GetThemeListCount").Return(2, nil)
-	suite.mockDBStore.On("GetThemeList", 1, 0).Return(dbThemes, nil)
-	suite.mockFileStore.On("GetThemeList", 2, 0).Return(nil, testErr)
+	suite.mockDBStore.On("GetThemeListCount", testCtx()).Return(1, nil)
+	suite.mockFileStore.On("GetThemeListCount", testCtx()).Return(2, nil)
+	suite.mockDBStore.On("GetThemeList", testCtx(), 1, 0).Return(dbThemes, nil)
+	suite.mockFileStore.On("GetThemeList", testCtx(), 2, 0).Return(nil, testErr)
 
-	_, err := suite.store.GetThemeList(10, 0)
+	_, err := suite.store.GetThemeList(testCtx(), 10, 0)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -160,9 +160,9 @@ func (suite *CompositeThemeStoreTestSuite) TestCreateTheme_Success() {
 		Description: "Test Description",
 		Theme:       json.RawMessage(`{"colors": {}}`),
 	}
-	suite.mockDBStore.On("CreateTheme", "theme1", createReq).Return(nil)
+	suite.mockDBStore.On("CreateTheme", testCtx(), "theme1", createReq).Return(nil)
 
-	err := suite.store.CreateTheme("theme1", createReq)
+	err := suite.store.CreateTheme(testCtx(), "theme1", createReq)
 
 	suite.NoError(err)
 	suite.mockDBStore.AssertExpectations(suite.T())
@@ -174,9 +174,9 @@ func (suite *CompositeThemeStoreTestSuite) TestCreateTheme_DBStoreError() {
 	createReq := CreateThemeRequest{
 		DisplayName: "Test Theme",
 	}
-	suite.mockDBStore.On("CreateTheme", "theme1", createReq).Return(testErr)
+	suite.mockDBStore.On("CreateTheme", testCtx(), "theme1", createReq).Return(testErr)
 
-	err := suite.store.CreateTheme("theme1", createReq)
+	err := suite.store.CreateTheme(testCtx(), "theme1", createReq)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -185,9 +185,9 @@ func (suite *CompositeThemeStoreTestSuite) TestCreateTheme_DBStoreError() {
 // Test GetTheme - From DB store (DB takes precedence)
 func (suite *CompositeThemeStoreTestSuite) TestGetTheme_FromDBStore() {
 	expectedTheme := Theme{ID: "theme1", DisplayName: "DB Theme"}
-	suite.mockDBStore.On("GetTheme", "theme1").Return(expectedTheme, nil)
+	suite.mockDBStore.On("GetTheme", testCtx(), "theme1").Return(expectedTheme, nil)
 
-	theme, err := suite.store.GetTheme("theme1")
+	theme, err := suite.store.GetTheme(testCtx(), "theme1")
 
 	suite.NoError(err)
 	suite.Equal(expectedTheme.ID, theme.ID)
@@ -198,10 +198,10 @@ func (suite *CompositeThemeStoreTestSuite) TestGetTheme_FromDBStore() {
 // Test GetTheme - From file store (fallback when not in DB store)
 func (suite *CompositeThemeStoreTestSuite) TestGetTheme_FromFileStore() {
 	expectedTheme := Theme{ID: "theme1", DisplayName: "File Theme"}
-	suite.mockDBStore.On("GetTheme", "theme1").Return(Theme{}, errThemeNotFound)
-	suite.mockFileStore.On("GetTheme", "theme1").Return(expectedTheme, nil)
+	suite.mockDBStore.On("GetTheme", testCtx(), "theme1").Return(Theme{}, errThemeNotFound)
+	suite.mockFileStore.On("GetTheme", testCtx(), "theme1").Return(expectedTheme, nil)
 
-	theme, err := suite.store.GetTheme("theme1")
+	theme, err := suite.store.GetTheme(testCtx(), "theme1")
 
 	suite.NoError(err)
 	suite.Equal(expectedTheme.ID, theme.ID)
@@ -211,10 +211,10 @@ func (suite *CompositeThemeStoreTestSuite) TestGetTheme_FromFileStore() {
 
 // Test GetTheme - Not found in either store
 func (suite *CompositeThemeStoreTestSuite) TestGetTheme_NotFound() {
-	suite.mockFileStore.On("GetTheme", "theme1").Return(Theme{}, errThemeNotFound)
-	suite.mockDBStore.On("GetTheme", "theme1").Return(Theme{}, errThemeNotFound)
+	suite.mockFileStore.On("GetTheme", testCtx(), "theme1").Return(Theme{}, errThemeNotFound)
+	suite.mockDBStore.On("GetTheme", testCtx(), "theme1").Return(Theme{}, errThemeNotFound)
 
-	_, err := suite.store.GetTheme("theme1")
+	_, err := suite.store.GetTheme(testCtx(), "theme1")
 
 	suite.Error(err)
 	suite.Equal(errThemeNotFound, err)
@@ -222,9 +222,9 @@ func (suite *CompositeThemeStoreTestSuite) TestGetTheme_NotFound() {
 
 // Test IsThemeExist - Exists in DB store
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeExist_InDBStore() {
-	suite.mockDBStore.On("IsThemeExist", "theme1").Return(true, nil)
+	suite.mockDBStore.On("IsThemeExist", testCtx(), "theme1").Return(true, nil)
 
-	exists, err := suite.store.IsThemeExist("theme1")
+	exists, err := suite.store.IsThemeExist(testCtx(), "theme1")
 
 	suite.NoError(err)
 	suite.True(exists)
@@ -232,10 +232,10 @@ func (suite *CompositeThemeStoreTestSuite) TestIsThemeExist_InDBStore() {
 
 // Test IsThemeExist - Exists in file store
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeExist_InFileStore() {
-	suite.mockDBStore.On("IsThemeExist", "theme1").Return(false, nil)
-	suite.mockFileStore.On("IsThemeExist", "theme1").Return(true, nil)
+	suite.mockDBStore.On("IsThemeExist", testCtx(), "theme1").Return(false, nil)
+	suite.mockFileStore.On("IsThemeExist", testCtx(), "theme1").Return(true, nil)
 
-	exists, err := suite.store.IsThemeExist("theme1")
+	exists, err := suite.store.IsThemeExist(testCtx(), "theme1")
 
 	suite.NoError(err)
 	suite.True(exists)
@@ -243,10 +243,10 @@ func (suite *CompositeThemeStoreTestSuite) TestIsThemeExist_InFileStore() {
 
 // Test IsThemeExist - Not found
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeExist_NotFound() {
-	suite.mockDBStore.On("IsThemeExist", "theme1").Return(false, nil)
-	suite.mockFileStore.On("IsThemeExist", "theme1").Return(false, nil)
+	suite.mockDBStore.On("IsThemeExist", testCtx(), "theme1").Return(false, nil)
+	suite.mockFileStore.On("IsThemeExist", testCtx(), "theme1").Return(false, nil)
 
-	exists, err := suite.store.IsThemeExist("theme1")
+	exists, err := suite.store.IsThemeExist(testCtx(), "theme1")
 
 	suite.NoError(err)
 	suite.False(exists)
@@ -255,9 +255,9 @@ func (suite *CompositeThemeStoreTestSuite) TestIsThemeExist_NotFound() {
 // Test IsThemeExist - DB store error
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeExist_DBStoreError() {
 	testErr := errors.New("db error")
-	suite.mockDBStore.On("IsThemeExist", "theme1").Return(false, testErr)
+	suite.mockDBStore.On("IsThemeExist", testCtx(), "theme1").Return(false, testErr)
 
-	_, err := suite.store.IsThemeExist("theme1")
+	_, err := suite.store.IsThemeExist(testCtx(), "theme1")
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -268,10 +268,10 @@ func (suite *CompositeThemeStoreTestSuite) TestUpdateTheme_Success() {
 	updateReq := UpdateThemeRequest{
 		DisplayName: "Updated Theme",
 	}
-	suite.mockFileStore.On("IsThemeExist", "theme1").Return(false, nil)
-	suite.mockDBStore.On("UpdateTheme", "theme1", updateReq).Return(nil)
+	suite.mockFileStore.On("IsThemeExist", testCtx(), "theme1").Return(false, nil)
+	suite.mockDBStore.On("UpdateTheme", testCtx(), "theme1", updateReq).Return(nil)
 
-	err := suite.store.UpdateTheme("theme1", updateReq)
+	err := suite.store.UpdateTheme(testCtx(), "theme1", updateReq)
 
 	suite.NoError(err)
 }
@@ -281,9 +281,9 @@ func (suite *CompositeThemeStoreTestSuite) TestUpdateTheme_RejectsDeclarative() 
 	updateReq := UpdateThemeRequest{
 		DisplayName: "Updated Theme",
 	}
-	suite.mockFileStore.On("IsThemeExist", "theme1").Return(true, nil)
+	suite.mockFileStore.On("IsThemeExist", testCtx(), "theme1").Return(true, nil)
 
-	err := suite.store.UpdateTheme("theme1", updateReq)
+	err := suite.store.UpdateTheme(testCtx(), "theme1", updateReq)
 
 	suite.Error(err)
 	suite.Equal(errCannotUpdateDeclarativeTheme, err)
@@ -295,9 +295,9 @@ func (suite *CompositeThemeStoreTestSuite) TestUpdateTheme_FileStoreCheckError()
 	updateReq := UpdateThemeRequest{
 		DisplayName: "Updated Theme",
 	}
-	suite.mockFileStore.On("IsThemeExist", "theme1").Return(false, testErr)
+	suite.mockFileStore.On("IsThemeExist", testCtx(), "theme1").Return(false, testErr)
 
-	err := suite.store.UpdateTheme("theme1", updateReq)
+	err := suite.store.UpdateTheme(testCtx(), "theme1", updateReq)
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -305,19 +305,19 @@ func (suite *CompositeThemeStoreTestSuite) TestUpdateTheme_FileStoreCheckError()
 
 // Test DeleteTheme - Success (DB theme)
 func (suite *CompositeThemeStoreTestSuite) TestDeleteTheme_Success() {
-	suite.mockFileStore.On("IsThemeExist", "theme1").Return(false, nil)
-	suite.mockDBStore.On("DeleteTheme", "theme1").Return(nil)
+	suite.mockFileStore.On("IsThemeExist", testCtx(), "theme1").Return(false, nil)
+	suite.mockDBStore.On("DeleteTheme", testCtx(), "theme1").Return(nil)
 
-	err := suite.store.DeleteTheme("theme1")
+	err := suite.store.DeleteTheme(testCtx(), "theme1")
 
 	suite.NoError(err)
 }
 
 // Test DeleteTheme - Rejects declarative theme
 func (suite *CompositeThemeStoreTestSuite) TestDeleteTheme_RejectsDeclarative() {
-	suite.mockFileStore.On("IsThemeExist", "theme1").Return(true, nil)
+	suite.mockFileStore.On("IsThemeExist", testCtx(), "theme1").Return(true, nil)
 
-	err := suite.store.DeleteTheme("theme1")
+	err := suite.store.DeleteTheme(testCtx(), "theme1")
 
 	suite.Error(err)
 	suite.Equal(errCannotDeleteDeclarativeTheme, err)
@@ -326,9 +326,9 @@ func (suite *CompositeThemeStoreTestSuite) TestDeleteTheme_RejectsDeclarative() 
 // Test DeleteTheme - File store check error
 func (suite *CompositeThemeStoreTestSuite) TestDeleteTheme_FileStoreCheckError() {
 	testErr := errors.New("file store error")
-	suite.mockFileStore.On("IsThemeExist", "theme1").Return(false, testErr)
+	suite.mockFileStore.On("IsThemeExist", testCtx(), "theme1").Return(false, testErr)
 
-	err := suite.store.DeleteTheme("theme1")
+	err := suite.store.DeleteTheme(testCtx(), "theme1")
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -336,27 +336,27 @@ func (suite *CompositeThemeStoreTestSuite) TestDeleteTheme_FileStoreCheckError()
 
 // Test IsThemeDeclarative - True for file-based theme
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeDeclarative_True() {
-	suite.mockFileStore.On("IsThemeExist", "theme1").Return(true, nil)
+	suite.mockFileStore.On("IsThemeExist", testCtx(), "theme1").Return(true, nil)
 
-	isDeclarative := suite.store.IsThemeDeclarative("theme1")
+	isDeclarative := suite.store.IsThemeDeclarative(testCtx(), "theme1")
 
 	suite.True(isDeclarative)
 }
 
 // Test IsThemeDeclarative - False for DB theme
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeDeclarative_False() {
-	suite.mockFileStore.On("IsThemeExist", "theme1").Return(false, nil)
+	suite.mockFileStore.On("IsThemeExist", testCtx(), "theme1").Return(false, nil)
 
-	isDeclarative := suite.store.IsThemeDeclarative("theme1")
+	isDeclarative := suite.store.IsThemeDeclarative(testCtx(), "theme1")
 
 	suite.False(isDeclarative)
 }
 
 // Test IsThemeDeclarative - False on error
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeDeclarative_Error() {
-	suite.mockFileStore.On("IsThemeExist", "theme1").Return(false, errors.New("error"))
+	suite.mockFileStore.On("IsThemeExist", testCtx(), "theme1").Return(false, errors.New("error"))
 
-	isDeclarative := suite.store.IsThemeDeclarative("theme1")
+	isDeclarative := suite.store.IsThemeDeclarative(testCtx(), "theme1")
 
 	suite.False(isDeclarative)
 }
@@ -390,9 +390,9 @@ func (suite *CompositeThemeStoreTestSuite) TestMergeAndDeduplicateThemes_EmptySt
 
 // Test IsThemeHandleConflict - Conflict in file store (returns early)
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeHandleConflict_ConflictInFileStore() {
-	suite.mockFileStore.On("IsThemeHandleConflict", "classic", "").Return(true, nil)
+	suite.mockFileStore.On("IsThemeHandleConflict", testCtx(), "classic", "").Return(true, nil)
 
-	conflict, err := suite.store.IsThemeHandleConflict("classic", "")
+	conflict, err := suite.store.IsThemeHandleConflict(testCtx(), "classic", "")
 
 	suite.NoError(err)
 	suite.True(conflict)
@@ -400,10 +400,10 @@ func (suite *CompositeThemeStoreTestSuite) TestIsThemeHandleConflict_ConflictInF
 
 // Test IsThemeHandleConflict - No conflict in file, conflict in DB store
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeHandleConflict_ConflictInDBStore() {
-	suite.mockFileStore.On("IsThemeHandleConflict", "classic", "theme1").Return(false, nil)
-	suite.mockDBStore.On("IsThemeHandleConflict", "classic", "theme1").Return(true, nil)
+	suite.mockFileStore.On("IsThemeHandleConflict", testCtx(), "classic", "theme1").Return(false, nil)
+	suite.mockDBStore.On("IsThemeHandleConflict", testCtx(), "classic", "theme1").Return(true, nil)
 
-	conflict, err := suite.store.IsThemeHandleConflict("classic", "theme1")
+	conflict, err := suite.store.IsThemeHandleConflict(testCtx(), "classic", "theme1")
 
 	suite.NoError(err)
 	suite.True(conflict)
@@ -411,10 +411,10 @@ func (suite *CompositeThemeStoreTestSuite) TestIsThemeHandleConflict_ConflictInD
 
 // Test IsThemeHandleConflict - No conflict in either store
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeHandleConflict_NoConflict() {
-	suite.mockFileStore.On("IsThemeHandleConflict", "unique-handle", "theme1").Return(false, nil)
-	suite.mockDBStore.On("IsThemeHandleConflict", "unique-handle", "theme1").Return(false, nil)
+	suite.mockFileStore.On("IsThemeHandleConflict", testCtx(), "unique-handle", "theme1").Return(false, nil)
+	suite.mockDBStore.On("IsThemeHandleConflict", testCtx(), "unique-handle", "theme1").Return(false, nil)
 
-	conflict, err := suite.store.IsThemeHandleConflict("unique-handle", "theme1")
+	conflict, err := suite.store.IsThemeHandleConflict(testCtx(), "unique-handle", "theme1")
 
 	suite.NoError(err)
 	suite.False(conflict)
@@ -423,9 +423,9 @@ func (suite *CompositeThemeStoreTestSuite) TestIsThemeHandleConflict_NoConflict(
 // Test IsThemeHandleConflict - File store error
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeHandleConflict_FileStoreError() {
 	testErr := errors.New("file store error")
-	suite.mockFileStore.On("IsThemeHandleConflict", "classic", "").Return(false, testErr)
+	suite.mockFileStore.On("IsThemeHandleConflict", testCtx(), "classic", "").Return(false, testErr)
 
-	conflict, err := suite.store.IsThemeHandleConflict("classic", "")
+	conflict, err := suite.store.IsThemeHandleConflict(testCtx(), "classic", "")
 
 	suite.Error(err)
 	suite.Equal(testErr, err)
@@ -435,10 +435,10 @@ func (suite *CompositeThemeStoreTestSuite) TestIsThemeHandleConflict_FileStoreEr
 // Test IsThemeHandleConflict - DB store error
 func (suite *CompositeThemeStoreTestSuite) TestIsThemeHandleConflict_DBStoreError() {
 	testErr := errors.New("db store error")
-	suite.mockFileStore.On("IsThemeHandleConflict", "classic", "theme1").Return(false, nil)
-	suite.mockDBStore.On("IsThemeHandleConflict", "classic", "theme1").Return(false, testErr)
+	suite.mockFileStore.On("IsThemeHandleConflict", testCtx(), "classic", "theme1").Return(false, nil)
+	suite.mockDBStore.On("IsThemeHandleConflict", testCtx(), "classic", "theme1").Return(false, testErr)
 
-	conflict, err := suite.store.IsThemeHandleConflict("classic", "theme1")
+	conflict, err := suite.store.IsThemeHandleConflict(testCtx(), "classic", "theme1")
 
 	suite.Error(err)
 	suite.Equal(testErr, err)

--- a/backend/internal/design/theme/mgt/declarative_resource.go
+++ b/backend/internal/design/theme/mgt/declarative_resource.go
@@ -191,6 +191,9 @@ func parseToTheme(data []byte) (*Theme, error) {
 // validateThemeWrapper wraps validateThemeForDeclarativeResource to match ResourceConfig.Validator signature.
 // It also checks for duplicates across database stores in composite mode.
 func validateThemeWrapper(dto interface{}, dbStore themeMgtStoreInterface) error {
+	// Declarative resources are validated as they are loaded, outside any request, so there
+	// is no context to carry a deployment id and the configured identifier applies.
+	ctx := context.Background()
 	theme, ok := dto.(*Theme)
 	if !ok {
 		return fmt.Errorf("invalid type: expected *Theme")
@@ -203,7 +206,7 @@ func validateThemeWrapper(dto interface{}, dbStore themeMgtStoreInterface) error
 
 	// In composite mode, check for duplicates in database store
 	if dbStore != nil {
-		exists, err := dbStore.IsThemeExist(theme.ID)
+		exists, err := dbStore.IsThemeExist(ctx, theme.ID)
 		if err != nil {
 			return fmt.Errorf("failed to check for duplicate theme ID '%s': %w", theme.ID, err)
 		}

--- a/backend/internal/design/theme/mgt/declarative_resource_test.go
+++ b/backend/internal/design/theme/mgt/declarative_resource_test.go
@@ -313,7 +313,7 @@ func (s *ThemeDeclarativeSuite) TestLoadDeclarativeResources_WithDBStore() {
 	store := &themeFileBasedStore{GenericFileBasedStore: genericStore}
 
 	dbStore := newThemeMgtStoreInterfaceMock(s.T())
-	dbStore.On("IsThemeExist", "theme-dup").Return(false, nil)
+	dbStore.On("IsThemeExist", context.Background(), "theme-dup").Return(false, nil)
 
 	err = loadDeclarativeResources(store, dbStore)
 	s.NoError(err)
@@ -379,7 +379,7 @@ func (s *ThemeDeclarativeSuite) TestValidateThemeWrapper_DBStoreDuplicate() {
 	}
 
 	dbStore := newThemeMgtStoreInterfaceMock(s.T())
-	dbStore.On("IsThemeExist", "theme1").Return(true, nil)
+	dbStore.On("IsThemeExist", context.Background(), "theme1").Return(true, nil)
 
 	err := validateThemeWrapper(theme, dbStore)
 	s.Error(err)
@@ -394,7 +394,7 @@ func (s *ThemeDeclarativeSuite) TestValidateThemeWrapper_DBStoreError() {
 	}
 
 	dbStore := newThemeMgtStoreInterfaceMock(s.T())
-	dbStore.On("IsThemeExist", "theme1").Return(false, errors.New("db error"))
+	dbStore.On("IsThemeExist", context.Background(), "theme1").Return(false, errors.New("db error"))
 
 	err := validateThemeWrapper(theme, dbStore)
 	s.Error(err)

--- a/backend/internal/design/theme/mgt/file_based_store.go
+++ b/backend/internal/design/theme/mgt/file_based_store.go
@@ -4,6 +4,7 @@
 package thememgt
 
 import (
+	"context"
 	"errors"
 
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
@@ -16,6 +17,8 @@ type themeFileBasedStore struct {
 
 // Create implements declarativeresource.Storer interface for resource loader
 func (f *themeFileBasedStore) Create(id string, data interface{}) error {
+	// The declarative loader has no request behind it, so the configured identifier applies.
+	ctx := context.Background()
 	theme, ok := data.(*Theme)
 	if !ok {
 		declarativeresource.LogTypeAssertionError("theme", id)
@@ -27,11 +30,11 @@ func (f *themeFileBasedStore) Create(id string, data interface{}) error {
 		Description: theme.Description,
 		Theme:       theme.Theme,
 	}
-	return f.CreateTheme(id, createReq)
+	return f.CreateTheme(ctx, id, createReq)
 }
 
 // CreateTheme implements themeMgtStoreInterface.
-func (f *themeFileBasedStore) CreateTheme(id string, theme CreateThemeRequest) error {
+func (f *themeFileBasedStore) CreateTheme(ctx context.Context, id string, theme CreateThemeRequest) error {
 	themeData := &Theme{
 		ID:          id,
 		Handle:      theme.Handle,
@@ -45,12 +48,12 @@ func (f *themeFileBasedStore) CreateTheme(id string, theme CreateThemeRequest) e
 }
 
 // DeleteTheme implements themeMgtStoreInterface.
-func (f *themeFileBasedStore) DeleteTheme(id string) error {
+func (f *themeFileBasedStore) DeleteTheme(ctx context.Context, id string) error {
 	return errors.New("deleteTheme is not supported in file-based store")
 }
 
 // GetTheme implements themeMgtStoreInterface.
-func (f *themeFileBasedStore) GetTheme(id string) (Theme, error) {
+func (f *themeFileBasedStore) GetTheme(ctx context.Context, id string) (Theme, error) {
 	data, err := f.GenericFileBasedStore.Get(id)
 	if err != nil {
 		return Theme{}, errThemeNotFound
@@ -64,7 +67,7 @@ func (f *themeFileBasedStore) GetTheme(id string) (Theme, error) {
 }
 
 // GetThemeList implements themeMgtStoreInterface.
-func (f *themeFileBasedStore) GetThemeList(limit, offset int) ([]Theme, error) {
+func (f *themeFileBasedStore) GetThemeList(ctx context.Context, limit, offset int) ([]Theme, error) {
 	// Validate input parameters to prevent panics
 	if offset < 0 {
 		offset = 0
@@ -99,7 +102,7 @@ func (f *themeFileBasedStore) GetThemeList(limit, offset int) ([]Theme, error) {
 }
 
 // GetThemeListCount implements themeMgtStoreInterface.
-func (f *themeFileBasedStore) GetThemeListCount() (int, error) {
+func (f *themeFileBasedStore) GetThemeListCount(ctx context.Context) (int, error) {
 	count, err := f.GenericFileBasedStore.Count()
 	if err != nil {
 		return 0, err
@@ -108,8 +111,8 @@ func (f *themeFileBasedStore) GetThemeListCount() (int, error) {
 }
 
 // IsThemeExist implements themeMgtStoreInterface.
-func (f *themeFileBasedStore) IsThemeExist(id string) (bool, error) {
-	_, err := f.GetTheme(id)
+func (f *themeFileBasedStore) IsThemeExist(ctx context.Context, id string) (bool, error) {
+	_, err := f.GetTheme(ctx, id)
 	if err != nil {
 		return false, nil
 	}
@@ -117,17 +120,18 @@ func (f *themeFileBasedStore) IsThemeExist(id string) (bool, error) {
 }
 
 // UpdateTheme implements themeMgtStoreInterface.
-func (f *themeFileBasedStore) UpdateTheme(id string, theme UpdateThemeRequest) error {
+func (f *themeFileBasedStore) UpdateTheme(ctx context.Context, id string, theme UpdateThemeRequest) error {
 	return errors.New("updateTheme is not supported in file-based store")
 }
 
 // IsThemeDeclarative checks if a theme is immutable (in file-based store, all themes are immutable).
-func (f *themeFileBasedStore) IsThemeDeclarative(id string) bool {
+func (f *themeFileBasedStore) IsThemeDeclarative(ctx context.Context, id string) bool {
 	return true
 }
 
 // IsThemeHandleConflict checks if a theme handle already exists (excluding a specific ID).
-func (f *themeFileBasedStore) IsThemeHandleConflict(handle string, excludeID string) (bool, error) {
+func (f *themeFileBasedStore) IsThemeHandleConflict(ctx context.Context, handle string, excludeID string) (bool,
+	error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return false, err

--- a/backend/internal/design/theme/mgt/file_based_store_test.go
+++ b/backend/internal/design/theme/mgt/file_based_store_test.go
@@ -4,6 +4,7 @@
 package thememgt
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -74,13 +75,13 @@ func (suite *ThemeFileBasedStoreTestSuite) TestCreateTheme_Success() {
 	themeReq := suite.createTestTheme("Blue Theme")
 
 	// Act
-	err := suite.store.CreateTheme("theme-001", themeReq)
+	err := suite.store.CreateTheme(context.Background(), "theme-001", themeReq)
 
 	// Assert
 	suite.NoError(err)
 
 	// Verify theme was created
-	retrieved, err := suite.store.GetTheme("theme-001")
+	retrieved, err := suite.store.GetTheme(context.Background(), "theme-001")
 	suite.NoError(err)
 	suite.Equal("theme-001", retrieved.ID)
 	suite.Equal("Blue Theme", retrieved.DisplayName)
@@ -91,10 +92,10 @@ func (suite *ThemeFileBasedStoreTestSuite) TestCreateTheme_Success() {
 func (suite *ThemeFileBasedStoreTestSuite) TestGetTheme_Success() {
 	// Arrange
 	themeReq := suite.createTestTheme("Red Theme")
-	_ = suite.store.CreateTheme("theme-002", themeReq)
+	_ = suite.store.CreateTheme(context.Background(), "theme-002", themeReq)
 
 	// Act
-	retrieved, err := suite.store.GetTheme("theme-002")
+	retrieved, err := suite.store.GetTheme(context.Background(), "theme-002")
 
 	// Assert
 	suite.NoError(err)
@@ -104,7 +105,7 @@ func (suite *ThemeFileBasedStoreTestSuite) TestGetTheme_Success() {
 
 func (suite *ThemeFileBasedStoreTestSuite) TestGetTheme_NotFound() {
 	// Act
-	retrieved, err := suite.store.GetTheme("non-existent")
+	retrieved, err := suite.store.GetTheme(context.Background(), "non-existent")
 
 	// Assert
 	suite.Error(err)
@@ -116,12 +117,12 @@ func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_Success() {
 	theme1 := suite.createTestTheme("Theme 1")
 	theme2 := suite.createTestTheme("Theme 2")
 	theme3 := suite.createTestTheme("Theme 3")
-	_ = suite.store.CreateTheme("theme-003", theme1)
-	_ = suite.store.CreateTheme("theme-004", theme2)
-	_ = suite.store.CreateTheme("theme-005", theme3)
+	_ = suite.store.CreateTheme(context.Background(), "theme-003", theme1)
+	_ = suite.store.CreateTheme(context.Background(), "theme-004", theme2)
+	_ = suite.store.CreateTheme(context.Background(), "theme-005", theme3)
 
 	// Act
-	themes, err := suite.store.GetThemeList(10, 0)
+	themes, err := suite.store.GetThemeList(context.Background(), 10, 0)
 
 	// Assert
 	suite.NoError(err)
@@ -132,18 +133,18 @@ func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_WithPagination() {
 	// Arrange
 	for i := 1; i <= 5; i++ {
 		themeReq := suite.createTestTheme(fmt.Sprintf("Theme %d", i))
-		_ = suite.store.CreateTheme(fmt.Sprintf("theme-%03d", i), themeReq)
+		_ = suite.store.CreateTheme(context.Background(), fmt.Sprintf("theme-%03d", i), themeReq)
 	}
 
 	// Act - Get first 2 themes
-	themes, err := suite.store.GetThemeList(2, 0)
+	themes, err := suite.store.GetThemeList(context.Background(), 2, 0)
 
 	// Assert
 	suite.NoError(err)
 	suite.Len(themes, 2)
 
 	// Act - Get next 2 themes
-	themes, err = suite.store.GetThemeList(2, 2)
+	themes, err = suite.store.GetThemeList(context.Background(), 2, 2)
 
 	// Assert
 	suite.NoError(err)
@@ -152,7 +153,7 @@ func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_WithPagination() {
 
 func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_EmptyStore() {
 	// Act
-	themes, err := suite.store.GetThemeList(10, 0)
+	themes, err := suite.store.GetThemeList(context.Background(), 10, 0)
 
 	// Assert
 	suite.NoError(err)
@@ -163,11 +164,11 @@ func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeListCount_Success() {
 	// Arrange
 	theme1 := suite.createTestTheme("Theme 6")
 	theme2 := suite.createTestTheme("Theme 7")
-	_ = suite.store.CreateTheme("theme-006", theme1)
-	_ = suite.store.CreateTheme("theme-007", theme2)
+	_ = suite.store.CreateTheme(context.Background(), "theme-006", theme1)
+	_ = suite.store.CreateTheme(context.Background(), "theme-007", theme2)
 
 	// Act
-	count, err := suite.store.GetThemeListCount()
+	count, err := suite.store.GetThemeListCount(context.Background())
 
 	// Assert
 	suite.NoError(err)
@@ -177,10 +178,10 @@ func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeListCount_Success() {
 func (suite *ThemeFileBasedStoreTestSuite) TestIsThemeExist_True() {
 	// Arrange
 	themeReq := suite.createTestTheme("Existing Theme")
-	_ = suite.store.CreateTheme("theme-008", themeReq)
+	_ = suite.store.CreateTheme(context.Background(), "theme-008", themeReq)
 
 	// Act
-	exists, err := suite.store.IsThemeExist("theme-008")
+	exists, err := suite.store.IsThemeExist(context.Background(), "theme-008")
 
 	// Assert
 	suite.NoError(err)
@@ -189,7 +190,7 @@ func (suite *ThemeFileBasedStoreTestSuite) TestIsThemeExist_True() {
 
 func (suite *ThemeFileBasedStoreTestSuite) TestIsThemeExist_False() {
 	// Act
-	exists, err := suite.store.IsThemeExist("non-existent")
+	exists, err := suite.store.IsThemeExist(context.Background(), "non-existent")
 
 	// Assert
 	suite.NoError(err)
@@ -201,7 +202,7 @@ func (suite *ThemeFileBasedStoreTestSuite) TestUpdateTheme_NotSupported() {
 	themeReq := suite.createTestTheme("Update Test")
 
 	// Act
-	err := suite.store.UpdateTheme("theme-009", UpdateThemeRequest{
+	err := suite.store.UpdateTheme(context.Background(), "theme-009", UpdateThemeRequest{
 		DisplayName: "Updated Name",
 		Description: "Updated description",
 		Theme:       themeReq.Theme,
@@ -214,7 +215,7 @@ func (suite *ThemeFileBasedStoreTestSuite) TestUpdateTheme_NotSupported() {
 
 func (suite *ThemeFileBasedStoreTestSuite) TestDeleteTheme_NotSupported() {
 	// Act
-	err := suite.store.DeleteTheme("theme-001")
+	err := suite.store.DeleteTheme(context.Background(), "theme-001")
 
 	// Assert
 	suite.Error(err)
@@ -241,7 +242,7 @@ func (suite *ThemeFileBasedStoreTestSuite) TestCreate_StorerInterface() {
 	suite.NoError(err)
 
 	// Verify
-	retrieved, err := suite.store.GetTheme("theme-010")
+	retrieved, err := suite.store.GetTheme(context.Background(), "theme-010")
 	suite.NoError(err)
 	suite.Equal("theme-010", retrieved.ID)
 }
@@ -262,11 +263,11 @@ func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_NegativeOffset() {
 	// Arrange
 	theme1 := suite.createTestTheme("Theme A")
 	theme2 := suite.createTestTheme("Theme B")
-	_ = suite.store.CreateTheme("theme-a", theme1)
-	_ = suite.store.CreateTheme("theme-b", theme2)
+	_ = suite.store.CreateTheme(context.Background(), "theme-a", theme1)
+	_ = suite.store.CreateTheme(context.Background(), "theme-b", theme2)
 
 	// Act - negative offset should be clamped to 0
-	themes, err := suite.store.GetThemeList(10, -5)
+	themes, err := suite.store.GetThemeList(context.Background(), 10, -5)
 
 	// Assert
 	suite.NoError(err)
@@ -276,10 +277,10 @@ func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_NegativeOffset() {
 func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_ZeroLimit() {
 	// Arrange
 	theme1 := suite.createTestTheme("Theme C")
-	_ = suite.store.CreateTheme("theme-c", theme1)
+	_ = suite.store.CreateTheme(context.Background(), "theme-c", theme1)
 
 	// Act - zero limit should return empty slice
-	themes, err := suite.store.GetThemeList(0, 0)
+	themes, err := suite.store.GetThemeList(context.Background(), 0, 0)
 
 	// Assert
 	suite.NoError(err)
@@ -289,10 +290,10 @@ func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_ZeroLimit() {
 func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_NegativeLimit() {
 	// Arrange
 	theme1 := suite.createTestTheme("Theme D")
-	_ = suite.store.CreateTheme("theme-d", theme1)
+	_ = suite.store.CreateTheme(context.Background(), "theme-d", theme1)
 
 	// Act - negative limit should return empty slice
-	themes, err := suite.store.GetThemeList(-10, 0)
+	themes, err := suite.store.GetThemeList(context.Background(), -10, 0)
 
 	// Assert
 	suite.NoError(err)
@@ -302,10 +303,10 @@ func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_NegativeLimit() {
 func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_OffsetBeyondList() {
 	// Arrange
 	theme1 := suite.createTestTheme("Theme E")
-	_ = suite.store.CreateTheme("theme-e", theme1)
+	_ = suite.store.CreateTheme(context.Background(), "theme-e", theme1)
 
 	// Act - offset beyond list length should return empty slice
-	themes, err := suite.store.GetThemeList(10, 100)
+	themes, err := suite.store.GetThemeList(context.Background(), 10, 100)
 
 	// Assert
 	suite.NoError(err)
@@ -316,10 +317,10 @@ func (suite *ThemeFileBasedStoreTestSuite) TestIsThemeHandleConflict_Conflict() 
 	// Arrange
 	themeReq := suite.createTestTheme("Handle Conflict Test")
 	themeReq.Handle = "conflict-handle"
-	_ = suite.store.CreateTheme("theme-hc1", themeReq)
+	_ = suite.store.CreateTheme(context.Background(), "theme-hc1", themeReq)
 
 	// Act - different ID with same handle should conflict
-	conflict, err := suite.store.IsThemeHandleConflict("conflict-handle", "other-id")
+	conflict, err := suite.store.IsThemeHandleConflict(context.Background(), "conflict-handle", "other-id")
 
 	// Assert
 	suite.NoError(err)
@@ -328,7 +329,7 @@ func (suite *ThemeFileBasedStoreTestSuite) TestIsThemeHandleConflict_Conflict() 
 
 func (suite *ThemeFileBasedStoreTestSuite) TestIsThemeHandleConflict_NoConflict() {
 	// Act - non-existent handle should not conflict
-	conflict, err := suite.store.IsThemeHandleConflict("non-existent-handle", "")
+	conflict, err := suite.store.IsThemeHandleConflict(context.Background(), "non-existent-handle", "")
 
 	// Assert
 	suite.NoError(err)
@@ -339,10 +340,10 @@ func (suite *ThemeFileBasedStoreTestSuite) TestIsThemeHandleConflict_SameIDExclu
 	// Arrange
 	themeReq := suite.createTestTheme("Same ID Exclude Test")
 	themeReq.Handle = "same-id-handle"
-	_ = suite.store.CreateTheme("theme-hc2", themeReq)
+	_ = suite.store.CreateTheme(context.Background(), "theme-hc2", themeReq)
 
 	// Act - same ID should be excluded from conflict check
-	conflict, err := suite.store.IsThemeHandleConflict("same-id-handle", "theme-hc2")
+	conflict, err := suite.store.IsThemeHandleConflict(context.Background(), "same-id-handle", "theme-hc2")
 
 	// Assert
 	suite.NoError(err)

--- a/backend/internal/design/theme/mgt/service.go
+++ b/backend/internal/design/theme/mgt/service.go
@@ -51,19 +51,18 @@ func newThemeMgtService(themeMgtStore themeMgtStoreInterface) ThemeMgtServiceInt
 }
 
 // GetThemeList retrieves a list of theme configurations.
-func (ts *themeMgtService) GetThemeList(
-	ctx context.Context, limit, offset int) (*ThemeList, *tidcommon.ServiceError) {
+func (ts *themeMgtService) GetThemeList(ctx context.Context, limit, offset int) (*ThemeList, *tidcommon.ServiceError) {
 	if err := validatePaginationParams(limit, offset); err != nil {
 		return nil, err
 	}
 
-	totalCount, err := ts.themeMgtStore.GetThemeListCount()
+	totalCount, err := ts.themeMgtStore.GetThemeListCount(ctx)
 	if err != nil {
 		ts.logger.Error(ctx, "Failed to get theme count", log.Error(err))
 		return nil, &tidcommon.InternalServerError
 	}
 
-	themes, err := ts.themeMgtStore.GetThemeList(limit, offset)
+	themes, err := ts.themeMgtStore.GetThemeList(ctx, limit, offset)
 	if err != nil {
 		ts.logger.Error(ctx, "Failed to list themes", log.Error(err))
 		return nil, &tidcommon.InternalServerError
@@ -81,8 +80,8 @@ func (ts *themeMgtService) GetThemeList(
 }
 
 // CreateTheme creates a new theme configuration.
-func (ts *themeMgtService) CreateTheme(
-	ctx context.Context, theme CreateThemeRequestWithID) (*Theme, *tidcommon.ServiceError) {
+func (ts *themeMgtService) CreateTheme(ctx context.Context, theme CreateThemeRequestWithID) (*Theme,
+	*tidcommon.ServiceError) {
 	ts.logger.Debug(ctx, "Creating theme configuration")
 
 	if theme.DisplayName == "" {
@@ -98,7 +97,7 @@ func (ts *themeMgtService) CreateTheme(
 		return nil, &ErrorCannotModifyDeclarativeResource
 	}
 
-	conflict, err := ts.themeMgtStore.IsThemeHandleConflict(theme.Handle, "")
+	conflict, err := ts.themeMgtStore.IsThemeHandleConflict(ctx, theme.Handle, "")
 	if err != nil {
 		ts.logger.Error(ctx, "Failed to check theme handle conflict", log.Error(err))
 		return nil, &tidcommon.InternalServerError
@@ -128,7 +127,7 @@ func (ts *themeMgtService) CreateTheme(
 		Theme:       theme.Theme,
 	}
 
-	if err := ts.themeMgtStore.CreateTheme(id, storeReq); err != nil {
+	if err := ts.themeMgtStore.CreateTheme(ctx, id, storeReq); err != nil {
 		ts.logger.Error(ctx, "Failed to create theme", log.Error(err))
 		return nil, &tidcommon.InternalServerError
 	}
@@ -153,7 +152,7 @@ func (ts *themeMgtService) GetTheme(ctx context.Context, id string) (*Theme, *ti
 		return nil, &ErrorInvalidThemeID
 	}
 
-	theme, err := ts.themeMgtStore.GetTheme(id)
+	theme, err := ts.themeMgtStore.GetTheme(ctx, id)
 	if err != nil {
 		if errors.Is(err, errThemeNotFound) {
 			ts.logger.Debug(ctx, "Theme not found", log.String("id", id))
@@ -168,8 +167,8 @@ func (ts *themeMgtService) GetTheme(ctx context.Context, id string) (*Theme, *ti
 }
 
 // UpdateTheme updates an existing theme configuration.
-func (ts *themeMgtService) UpdateTheme(
-	ctx context.Context, id string, theme UpdateThemeRequest) (*Theme, *tidcommon.ServiceError) {
+func (ts *themeMgtService) UpdateTheme(ctx context.Context, id string, theme UpdateThemeRequest) (*Theme,
+	*tidcommon.ServiceError) {
 	ts.logger.Debug(ctx, "Updating theme", log.String("id", id))
 
 	if id == "" {
@@ -181,12 +180,12 @@ func (ts *themeMgtService) UpdateTheme(
 	}
 
 	// Check if the theme is declarative (read-only)
-	if ts.themeMgtStore.IsThemeDeclarative(id) {
+	if ts.themeMgtStore.IsThemeDeclarative(ctx, id) {
 		return nil, &ErrorCannotModifyDeclarativeResource
 	}
 
 	// Fetch existing theme to enforce handle immutability
-	existingTheme, err := ts.themeMgtStore.GetTheme(id)
+	existingTheme, err := ts.themeMgtStore.GetTheme(ctx, id)
 	if err != nil {
 		if errors.Is(err, errThemeNotFound) {
 			return nil, &ErrorThemeNotFound
@@ -204,7 +203,7 @@ func (ts *themeMgtService) UpdateTheme(
 		return nil, err
 	}
 
-	if err := ts.themeMgtStore.UpdateTheme(id, theme); err != nil {
+	if err := ts.themeMgtStore.UpdateTheme(ctx, id, theme); err != nil {
 		ts.logger.Error(ctx, "Failed to update theme", log.String("id", id), log.Error(err))
 		return nil, &tidcommon.InternalServerError
 	}
@@ -230,12 +229,12 @@ func (ts *themeMgtService) DeleteTheme(ctx context.Context, id string) *tidcommo
 	}
 
 	// Check if the theme is declarative (read-only)
-	if ts.themeMgtStore.IsThemeDeclarative(id) {
+	if ts.themeMgtStore.IsThemeDeclarative(ctx, id) {
 		return &ErrorCannotModifyDeclarativeResource
 	}
 
 	// Check if theme exists. Return success for non-existing themes (idempotent delete).
-	exists, err := ts.themeMgtStore.IsThemeExist(id)
+	exists, err := ts.themeMgtStore.IsThemeExist(ctx, id)
 	if err != nil {
 		ts.logger.Error(ctx, "Failed to check theme existence", log.String("id", id), log.Error(err))
 		return &tidcommon.InternalServerError
@@ -249,7 +248,7 @@ func (ts *themeMgtService) DeleteTheme(ctx context.Context, id string) *tidcommo
 	// A theme can be deleted even while applications reference it: those applications keep their
 	// reference and fall back to the system default theme at read time (see the design resolve
 	// service). References are surfaced informationally through GetThemeUsages.
-	if err := ts.themeMgtStore.DeleteTheme(id); err != nil {
+	if err := ts.themeMgtStore.DeleteTheme(ctx, id); err != nil {
 		ts.logger.Error(ctx, "Failed to delete theme", log.String("id", id), log.Error(err))
 		return &tidcommon.InternalServerError
 	}
@@ -264,7 +263,7 @@ func (ts *themeMgtService) IsThemeExist(ctx context.Context, id string) (bool, *
 		return false, &ErrorInvalidThemeID
 	}
 
-	exists, err := ts.themeMgtStore.IsThemeExist(id)
+	exists, err := ts.themeMgtStore.IsThemeExist(ctx, id)
 	if err != nil {
 		ts.logger.Error(ctx, "Failed to check theme existence", log.String("id", id), log.Error(err))
 		return false, &tidcommon.InternalServerError
@@ -291,7 +290,7 @@ func (ts *themeMgtService) GetThemeUsages(
 		return nil, err
 	}
 
-	exists, err := ts.themeMgtStore.IsThemeExist(id)
+	exists, err := ts.themeMgtStore.IsThemeExist(ctx, id)
 	if err != nil {
 		ts.logger.Error(ctx, "Failed to check theme existence", log.String("id", id), log.Error(err))
 		return nil, &tidcommon.InternalServerError

--- a/backend/internal/design/theme/mgt/service_test.go
+++ b/backend/internal/design/theme/mgt/service_test.go
@@ -63,10 +63,10 @@ func (suite *ThemeServiceTestSuite) TestGetThemeList_Success() {
 		},
 	}
 
-	suite.mockStore.On("GetThemeListCount").Return(2, nil)
-	suite.mockStore.On("GetThemeList", 10, 0).Return(themes, nil)
+	suite.mockStore.On("GetThemeListCount", testCtx()).Return(2, nil)
+	suite.mockStore.On("GetThemeList", testCtx(), 10, 0).Return(themes, nil)
 
-	result, err := suite.service.GetThemeList(context.Background(), 10, 0)
+	result, err := suite.service.GetThemeList(testCtx(), 10, 0)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -78,9 +78,9 @@ func (suite *ThemeServiceTestSuite) TestGetThemeList_Success() {
 
 // Test GetThemeList - Store Count Error
 func (suite *ThemeServiceTestSuite) TestGetThemeList_CountError() {
-	suite.mockStore.On("GetThemeListCount").Return(0, errors.New("database error"))
+	suite.mockStore.On("GetThemeListCount", testCtx()).Return(0, errors.New("database error"))
 
-	result, err := suite.service.GetThemeList(context.Background(), 10, 0)
+	result, err := suite.service.GetThemeList(testCtx(), 10, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -88,10 +88,10 @@ func (suite *ThemeServiceTestSuite) TestGetThemeList_CountError() {
 
 // Test GetThemeList - Store Error
 func (suite *ThemeServiceTestSuite) TestGetThemeList_StoreError() {
-	suite.mockStore.On("GetThemeListCount").Return(2, nil)
-	suite.mockStore.On("GetThemeList", 10, 0).Return(nil, errors.New("database error"))
+	suite.mockStore.On("GetThemeListCount", testCtx()).Return(2, nil)
+	suite.mockStore.On("GetThemeList", testCtx(), 10, 0).Return(nil, errors.New("database error"))
 
-	result, err := suite.service.GetThemeList(context.Background(), 10, 0)
+	result, err := suite.service.GetThemeList(testCtx(), 10, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -99,7 +99,7 @@ func (suite *ThemeServiceTestSuite) TestGetThemeList_StoreError() {
 
 // Test GetThemeList - Invalid Pagination
 func (suite *ThemeServiceTestSuite) TestGetThemeList_InvalidLimit() {
-	result, err := suite.service.GetThemeList(context.Background(), -1, 0)
+	result, err := suite.service.GetThemeList(testCtx(), -1, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -107,7 +107,7 @@ func (suite *ThemeServiceTestSuite) TestGetThemeList_InvalidLimit() {
 }
 
 func (suite *ThemeServiceTestSuite) TestGetThemeList_InvalidOffset() {
-	result, err := suite.service.GetThemeList(context.Background(), 10, -1)
+	result, err := suite.service.GetThemeList(testCtx(), 10, -1)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -129,10 +129,10 @@ func (suite *ThemeServiceTestSuite) TestCreateTheme_Success() {
 		Theme:       themeRequest.Theme,
 	}
 
-	suite.mockStore.On("IsThemeHandleConflict", "new-theme", "").Return(false, nil)
-	suite.mockStore.On("CreateTheme", mock.AnythingOfType("string"), storeReq).Return(nil)
+	suite.mockStore.On("IsThemeHandleConflict", testCtx(), "new-theme", "").Return(false, nil)
+	suite.mockStore.On("CreateTheme", testCtx(), mock.AnythingOfType("string"), storeReq).Return(nil)
 
-	result, err := suite.service.CreateTheme(context.Background(), themeRequest)
+	result, err := suite.service.CreateTheme(testCtx(), themeRequest)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -151,7 +151,7 @@ func (suite *ThemeServiceTestSuite) TestCreateTheme_MissingDisplayName() {
 		Theme:       json.RawMessage(`{"colors": {"primary": "#ff0000"}}`),
 	}
 
-	result, err := suite.service.CreateTheme(context.Background(), themeRequest)
+	result, err := suite.service.CreateTheme(testCtx(), themeRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -167,7 +167,7 @@ func (suite *ThemeServiceTestSuite) TestCreateTheme_MissingHandle() {
 		Theme:       json.RawMessage(`{"colors": {"primary": "#ff0000"}}`),
 	}
 
-	result, err := suite.service.CreateTheme(context.Background(), themeRequest)
+	result, err := suite.service.CreateTheme(testCtx(), themeRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -183,9 +183,9 @@ func (suite *ThemeServiceTestSuite) TestCreateTheme_DuplicateHandle() {
 		Theme:       json.RawMessage(`{"colors": {"primary": "#ff0000"}}`),
 	}
 
-	suite.mockStore.On("IsThemeHandleConflict", "existing-theme", "").Return(true, nil)
+	suite.mockStore.On("IsThemeHandleConflict", testCtx(), "existing-theme", "").Return(true, nil)
 
-	result, err := suite.service.CreateTheme(context.Background(), themeRequest)
+	result, err := suite.service.CreateTheme(testCtx(), themeRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -204,7 +204,7 @@ func (suite *ThemeServiceTestSuite) TestCreateTheme_DeclarativeModeEnabled() {
 		Theme:       json.RawMessage(`{"colors": {"primary": "#ff0000"}}`),
 	}
 
-	result, err := suite.service.CreateTheme(context.Background(), themeRequest)
+	result, err := suite.service.CreateTheme(testCtx(), themeRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -220,9 +220,9 @@ func (suite *ThemeServiceTestSuite) TestCreateTheme_InvalidJSON() {
 		Theme:       json.RawMessage(`{invalid json}`),
 	}
 
-	suite.mockStore.On("IsThemeHandleConflict", "my-theme", "").Return(false, nil)
+	suite.mockStore.On("IsThemeHandleConflict", testCtx(), "my-theme", "").Return(false, nil)
 
-	result, err := suite.service.CreateTheme(context.Background(), themeRequest)
+	result, err := suite.service.CreateTheme(testCtx(), themeRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -244,10 +244,11 @@ func (suite *ThemeServiceTestSuite) TestCreateTheme_StoreError() {
 		Theme:       themeRequest.Theme,
 	}
 
-	suite.mockStore.On("IsThemeHandleConflict", "my-theme", "").Return(false, nil)
-	suite.mockStore.On("CreateTheme", mock.AnythingOfType("string"), storeReq).Return(errors.New("database error"))
+	suite.mockStore.On("IsThemeHandleConflict", testCtx(), "my-theme", "").Return(false, nil)
+	suite.mockStore.On("CreateTheme", testCtx(), mock.AnythingOfType("string"),
+		storeReq).Return(errors.New("database error"))
 
-	result, err := suite.service.CreateTheme(context.Background(), themeRequest)
+	result, err := suite.service.CreateTheme(testCtx(), themeRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -262,9 +263,9 @@ func (suite *ThemeServiceTestSuite) TestGetTheme_Success() {
 		Theme:       json.RawMessage(`{"colors": {"primary": "#007bff"}}`),
 	}
 
-	suite.mockStore.On("GetTheme", "theme-123").Return(theme, nil)
+	suite.mockStore.On("GetTheme", testCtx(), "theme-123").Return(theme, nil)
 
-	result, err := suite.service.GetTheme(context.Background(), "theme-123")
+	result, err := suite.service.GetTheme(testCtx(), "theme-123")
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -274,7 +275,7 @@ func (suite *ThemeServiceTestSuite) TestGetTheme_Success() {
 
 // Test GetTheme - Invalid ID
 func (suite *ThemeServiceTestSuite) TestGetTheme_InvalidID() {
-	result, err := suite.service.GetTheme(context.Background(), "")
+	result, err := suite.service.GetTheme(testCtx(), "")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -283,9 +284,9 @@ func (suite *ThemeServiceTestSuite) TestGetTheme_InvalidID() {
 
 // Test GetTheme - Not Found
 func (suite *ThemeServiceTestSuite) TestGetTheme_NotFound() {
-	suite.mockStore.On("GetTheme", "non-existent").Return(Theme{}, errThemeNotFound)
+	suite.mockStore.On("GetTheme", testCtx(), "non-existent").Return(Theme{}, errThemeNotFound)
 
-	result, err := suite.service.GetTheme(context.Background(), "non-existent")
+	result, err := suite.service.GetTheme(testCtx(), "non-existent")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -294,9 +295,9 @@ func (suite *ThemeServiceTestSuite) TestGetTheme_NotFound() {
 
 // Test GetTheme - Store Error
 func (suite *ThemeServiceTestSuite) TestGetTheme_StoreError() {
-	suite.mockStore.On("GetTheme", "theme-123").Return(Theme{}, errors.New("database error"))
+	suite.mockStore.On("GetTheme", testCtx(), "theme-123").Return(Theme{}, errors.New("database error"))
 
-	result, err := suite.service.GetTheme(context.Background(), "theme-123")
+	result, err := suite.service.GetTheme(testCtx(), "theme-123")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -315,11 +316,11 @@ func (suite *ThemeServiceTestSuite) TestUpdateTheme_Success() {
 		Handle: "my-theme",
 	}
 
-	suite.mockStore.On("IsThemeDeclarative", "theme-123").Return(false)
-	suite.mockStore.On("GetTheme", "theme-123").Return(existingTheme, nil)
-	suite.mockStore.On("UpdateTheme", "theme-123", updateRequest).Return(nil)
+	suite.mockStore.On("IsThemeDeclarative", testCtx(), "theme-123").Return(false)
+	suite.mockStore.On("GetTheme", testCtx(), "theme-123").Return(existingTheme, nil)
+	suite.mockStore.On("UpdateTheme", testCtx(), "theme-123", updateRequest).Return(nil)
 
-	result, err := suite.service.UpdateTheme(context.Background(), "theme-123", updateRequest)
+	result, err := suite.service.UpdateTheme(testCtx(), "theme-123", updateRequest)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -341,11 +342,11 @@ func (suite *ThemeServiceTestSuite) TestUpdateTheme_OmittedHandle_UsesExisting()
 		Handle: "existing-handle",
 	}
 
-	suite.mockStore.On("IsThemeDeclarative", "theme-123").Return(false)
-	suite.mockStore.On("GetTheme", "theme-123").Return(existingTheme, nil)
-	suite.mockStore.On("UpdateTheme", "theme-123", updateRequest).Return(nil)
+	suite.mockStore.On("IsThemeDeclarative", testCtx(), "theme-123").Return(false)
+	suite.mockStore.On("GetTheme", testCtx(), "theme-123").Return(existingTheme, nil)
+	suite.mockStore.On("UpdateTheme", testCtx(), "theme-123", updateRequest).Return(nil)
 
-	result, err := suite.service.UpdateTheme(context.Background(), "theme-123", updateRequest)
+	result, err := suite.service.UpdateTheme(testCtx(), "theme-123", updateRequest)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -361,7 +362,7 @@ func (suite *ThemeServiceTestSuite) TestUpdateTheme_InvalidID() {
 		Theme:       json.RawMessage(`{"colors": {}}`),
 	}
 
-	result, err := suite.service.UpdateTheme(context.Background(), "", updateRequest)
+	result, err := suite.service.UpdateTheme(testCtx(), "", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -377,7 +378,7 @@ func (suite *ThemeServiceTestSuite) TestUpdateTheme_MissingDisplayName() {
 		Theme:       json.RawMessage(`{"colors": {}}`),
 	}
 
-	result, err := suite.service.UpdateTheme(context.Background(), "theme-123", updateRequest)
+	result, err := suite.service.UpdateTheme(testCtx(), "theme-123", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -397,10 +398,10 @@ func (suite *ThemeServiceTestSuite) TestUpdateTheme_ImmutableHandle() {
 		Handle: "my-theme",
 	}
 
-	suite.mockStore.On("IsThemeDeclarative", "theme-123").Return(false)
-	suite.mockStore.On("GetTheme", "theme-123").Return(existingTheme, nil)
+	suite.mockStore.On("IsThemeDeclarative", testCtx(), "theme-123").Return(false)
+	suite.mockStore.On("GetTheme", testCtx(), "theme-123").Return(existingTheme, nil)
 
-	result, err := suite.service.UpdateTheme(context.Background(), "theme-123", updateRequest)
+	result, err := suite.service.UpdateTheme(testCtx(), "theme-123", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -416,10 +417,10 @@ func (suite *ThemeServiceTestSuite) TestUpdateTheme_NotFound() {
 		Theme:       json.RawMessage(`{"colors": {}}`),
 	}
 
-	suite.mockStore.On("IsThemeDeclarative", "non-existent").Return(false)
-	suite.mockStore.On("GetTheme", "non-existent").Return(Theme{}, errThemeNotFound)
+	suite.mockStore.On("IsThemeDeclarative", testCtx(), "non-existent").Return(false)
+	suite.mockStore.On("GetTheme", testCtx(), "non-existent").Return(Theme{}, errThemeNotFound)
 
-	result, err := suite.service.UpdateTheme(context.Background(), "non-existent", updateRequest)
+	result, err := suite.service.UpdateTheme(testCtx(), "non-existent", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -438,9 +439,9 @@ func (suite *ThemeServiceTestSuite) TestUpdateTheme_InvalidJSON() {
 		ID:     "theme-123",
 		Handle: "my-theme",
 	}
-	suite.mockStore.On("IsThemeDeclarative", "theme-123").Return(false)
-	suite.mockStore.On("GetTheme", "theme-123").Return(existingTheme, nil)
-	result, err := suite.service.UpdateTheme(context.Background(), "theme-123", updateRequest)
+	suite.mockStore.On("IsThemeDeclarative", testCtx(), "theme-123").Return(false)
+	suite.mockStore.On("GetTheme", testCtx(), "theme-123").Return(existingTheme, nil)
+	result, err := suite.service.UpdateTheme(testCtx(), "theme-123", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -449,18 +450,18 @@ func (suite *ThemeServiceTestSuite) TestUpdateTheme_InvalidJSON() {
 
 // Test DeleteTheme - Success
 func (suite *ThemeServiceTestSuite) TestDeleteTheme_Success() {
-	suite.mockStore.On("IsThemeDeclarative", "theme-123").Return(false)
-	suite.mockStore.On("IsThemeExist", "theme-123").Return(true, nil)
-	suite.mockStore.On("DeleteTheme", "theme-123").Return(nil)
+	suite.mockStore.On("IsThemeDeclarative", testCtx(), "theme-123").Return(false)
+	suite.mockStore.On("IsThemeExist", testCtx(), "theme-123").Return(true, nil)
+	suite.mockStore.On("DeleteTheme", testCtx(), "theme-123").Return(nil)
 
-	err := suite.service.DeleteTheme(context.Background(), "theme-123")
+	err := suite.service.DeleteTheme(testCtx(), "theme-123")
 
 	assert.Nil(suite.T(), err)
 }
 
 // Test DeleteTheme - Invalid ID
 func (suite *ThemeServiceTestSuite) TestDeleteTheme_InvalidID() {
-	err := suite.service.DeleteTheme(context.Background(), "")
+	err := suite.service.DeleteTheme(testCtx(), "")
 
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "THM-1002", err.Code)
@@ -468,30 +469,30 @@ func (suite *ThemeServiceTestSuite) TestDeleteTheme_InvalidID() {
 
 // Test DeleteTheme - Not Found (idempotent delete returns success)
 func (suite *ThemeServiceTestSuite) TestDeleteTheme_NotFound() {
-	suite.mockStore.On("IsThemeDeclarative", "non-existent").Return(false)
-	suite.mockStore.On("IsThemeExist", "non-existent").Return(false, nil)
+	suite.mockStore.On("IsThemeDeclarative", testCtx(), "non-existent").Return(false)
+	suite.mockStore.On("IsThemeExist", testCtx(), "non-existent").Return(false, nil)
 
-	err := suite.service.DeleteTheme(context.Background(), "non-existent")
+	err := suite.service.DeleteTheme(testCtx(), "non-existent")
 
 	assert.Nil(suite.T(), err)
 }
 
 // Test DeleteTheme - Store Error
 func (suite *ThemeServiceTestSuite) TestDeleteTheme_StoreError() {
-	suite.mockStore.On("IsThemeDeclarative", "theme-123").Return(false)
-	suite.mockStore.On("IsThemeExist", "theme-123").Return(true, nil)
-	suite.mockStore.On("DeleteTheme", "theme-123").Return(errors.New("database error"))
+	suite.mockStore.On("IsThemeDeclarative", testCtx(), "theme-123").Return(false)
+	suite.mockStore.On("IsThemeExist", testCtx(), "theme-123").Return(true, nil)
+	suite.mockStore.On("DeleteTheme", testCtx(), "theme-123").Return(errors.New("database error"))
 
-	err := suite.service.DeleteTheme(context.Background(), "theme-123")
+	err := suite.service.DeleteTheme(testCtx(), "theme-123")
 
 	assert.NotNil(suite.T(), err)
 }
 
 // Test IsThemeExist - Exists
 func (suite *ThemeServiceTestSuite) TestIsThemeExist_True() {
-	suite.mockStore.On("IsThemeExist", "theme-123").Return(true, nil)
+	suite.mockStore.On("IsThemeExist", testCtx(), "theme-123").Return(true, nil)
 
-	exists, err := suite.service.IsThemeExist(context.Background(), "theme-123")
+	exists, err := suite.service.IsThemeExist(testCtx(), "theme-123")
 
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), exists)
@@ -499,9 +500,9 @@ func (suite *ThemeServiceTestSuite) TestIsThemeExist_True() {
 
 // Test IsThemeExist - Not Exists
 func (suite *ThemeServiceTestSuite) TestIsThemeExist_False() {
-	suite.mockStore.On("IsThemeExist", "non-existent").Return(false, nil)
+	suite.mockStore.On("IsThemeExist", testCtx(), "non-existent").Return(false, nil)
 
-	exists, err := suite.service.IsThemeExist(context.Background(), "non-existent")
+	exists, err := suite.service.IsThemeExist(testCtx(), "non-existent")
 
 	assert.Nil(suite.T(), err)
 	assert.False(suite.T(), exists)
@@ -509,9 +510,9 @@ func (suite *ThemeServiceTestSuite) TestIsThemeExist_False() {
 
 // Test IsThemeExist - Store Error
 func (suite *ThemeServiceTestSuite) TestIsThemeExist_StoreError() {
-	suite.mockStore.On("IsThemeExist", "theme-123").Return(false, errors.New("database error"))
+	suite.mockStore.On("IsThemeExist", testCtx(), "theme-123").Return(false, errors.New("database error"))
 
-	exists, err := suite.service.IsThemeExist(context.Background(), "theme-123")
+	exists, err := suite.service.IsThemeExist(testCtx(), "theme-123")
 
 	assert.NotNil(suite.T(), err)
 	assert.False(suite.T(), exists)
@@ -526,9 +527,10 @@ func (suite *ThemeServiceTestSuite) TestCreateTheme_HandleConflictError() {
 		Theme:       json.RawMessage(`{"colors": {}}`),
 	}
 
-	suite.mockStore.On("IsThemeHandleConflict", "my-theme", "").Return(false, errors.New("database error"))
+	suite.mockStore.On("IsThemeHandleConflict", testCtx(), "my-theme", "").Return(false,
+		errors.New("database error"))
 
-	result, err := suite.service.CreateTheme(context.Background(), themeRequest)
+	result, err := suite.service.CreateTheme(testCtx(), themeRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -543,10 +545,10 @@ func (suite *ThemeServiceTestSuite) TestUpdateTheme_GetThemeError() {
 		Theme:       json.RawMessage(`{"colors": {}}`),
 	}
 
-	suite.mockStore.On("IsThemeDeclarative", "theme-123").Return(false)
-	suite.mockStore.On("GetTheme", "theme-123").Return(Theme{}, errors.New("database error"))
+	suite.mockStore.On("IsThemeDeclarative", testCtx(), "theme-123").Return(false)
+	suite.mockStore.On("GetTheme", testCtx(), "theme-123").Return(Theme{}, errors.New("database error"))
 
-	result, err := suite.service.UpdateTheme(context.Background(), "theme-123", updateRequest)
+	result, err := suite.service.UpdateTheme(testCtx(), "theme-123", updateRequest)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -578,7 +580,7 @@ func (s *stubUsageRegistry) ValidateReferenceUpdate(
 
 // Test GetThemeUsages - Empty ID
 func (suite *ThemeServiceTestSuite) TestGetThemeUsages_EmptyID() {
-	result, err := suite.service.GetThemeUsages(context.Background(), "", 10, 0)
+	result, err := suite.service.GetThemeUsages(testCtx(), "", 10, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -587,9 +589,9 @@ func (suite *ThemeServiceTestSuite) TestGetThemeUsages_EmptyID() {
 
 // Test GetThemeUsages - Theme not found
 func (suite *ThemeServiceTestSuite) TestGetThemeUsages_NotFound() {
-	suite.mockStore.On("IsThemeExist", "missing").Return(false, nil)
+	suite.mockStore.On("IsThemeExist", testCtx(), "missing").Return(false, nil)
 
-	result, err := suite.service.GetThemeUsages(context.Background(), "missing", 10, 0)
+	result, err := suite.service.GetThemeUsages(testCtx(), "missing", 10, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -598,9 +600,9 @@ func (suite *ThemeServiceTestSuite) TestGetThemeUsages_NotFound() {
 
 // Test GetThemeUsages - Store error on existence check
 func (suite *ThemeServiceTestSuite) TestGetThemeUsages_ExistenceCheckError() {
-	suite.mockStore.On("IsThemeExist", "theme-123").Return(false, errors.New("database error"))
+	suite.mockStore.On("IsThemeExist", testCtx(), "theme-123").Return(false, errors.New("database error"))
 
-	result, err := suite.service.GetThemeUsages(context.Background(), "theme-123", 10, 0)
+	result, err := suite.service.GetThemeUsages(testCtx(), "theme-123", 10, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -608,9 +610,9 @@ func (suite *ThemeServiceTestSuite) TestGetThemeUsages_ExistenceCheckError() {
 
 // Test GetThemeUsages - usage registry not set returns unknown (nil totalResults)
 func (suite *ThemeServiceTestSuite) TestGetThemeUsages_RegistryNotSet() {
-	suite.mockStore.On("IsThemeExist", "theme-123").Return(true, nil)
+	suite.mockStore.On("IsThemeExist", testCtx(), "theme-123").Return(true, nil)
 
-	result, err := suite.service.GetThemeUsages(context.Background(), "theme-123", 10, 0)
+	result, err := suite.service.GetThemeUsages(testCtx(), "theme-123", 10, 0)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -621,7 +623,7 @@ func (suite *ThemeServiceTestSuite) TestGetThemeUsages_RegistryNotSet() {
 
 // Test GetThemeUsages - registry returns usages
 func (suite *ThemeServiceTestSuite) TestGetThemeUsages_WithUsages() {
-	suite.mockStore.On("IsThemeExist", "theme-123").Return(true, nil)
+	suite.mockStore.On("IsThemeExist", testCtx(), "theme-123").Return(true, nil)
 	total := 2
 	suite.service.SetDependencyRegistry(&stubUsageRegistry{
 		resp: &resourcedependency.DependenciesResponse{
@@ -637,7 +639,7 @@ func (suite *ThemeServiceTestSuite) TestGetThemeUsages_WithUsages() {
 		},
 	})
 
-	result, err := suite.service.GetThemeUsages(context.Background(), "theme-123", 10, 0)
+	result, err := suite.service.GetThemeUsages(testCtx(), "theme-123", 10, 0)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -652,7 +654,7 @@ func (suite *ThemeServiceTestSuite) TestGetThemeUsages_WithUsages() {
 
 // Test GetThemeUsages - registry returns no usages
 func (suite *ThemeServiceTestSuite) TestGetThemeUsages_NoUsages() {
-	suite.mockStore.On("IsThemeExist", "theme-123").Return(true, nil)
+	suite.mockStore.On("IsThemeExist", testCtx(), "theme-123").Return(true, nil)
 	total := 0
 	suite.service.SetDependencyRegistry(&stubUsageRegistry{
 		resp: &resourcedependency.DependenciesResponse{
@@ -660,7 +662,7 @@ func (suite *ThemeServiceTestSuite) TestGetThemeUsages_NoUsages() {
 		},
 	})
 
-	result, err := suite.service.GetThemeUsages(context.Background(), "theme-123", 10, 0)
+	result, err := suite.service.GetThemeUsages(testCtx(), "theme-123", 10, 0)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -671,11 +673,20 @@ func (suite *ThemeServiceTestSuite) TestGetThemeUsages_NoUsages() {
 
 // Test GetThemeUsages - registry returns error
 func (suite *ThemeServiceTestSuite) TestGetThemeUsages_RegistryError() {
-	suite.mockStore.On("IsThemeExist", "theme-123").Return(true, nil)
+	suite.mockStore.On("IsThemeExist", testCtx(), "theme-123").Return(true, nil)
 	suite.service.SetDependencyRegistry(&stubUsageRegistry{err: errors.New("registry error")})
 
-	result, err := suite.service.GetThemeUsages(context.Background(), "theme-123", 10, 0)
+	result, err := suite.service.GetThemeUsages(testCtx(), "theme-123", 10, 0)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
+}
+
+// ctxKeyForTest marks a context so a store expectation can assert the service carried the caller's
+// context through, rather than substituting one of its own.
+type ctxKeyForTest struct{}
+
+// testCtx returns a context distinguishable from any other, including context.Background().
+func testCtx() context.Context {
+	return context.WithValue(context.Background(), ctxKeyForTest{}, "carried")
 }

--- a/backend/internal/design/theme/mgt/store.go
+++ b/backend/internal/design/theme/mgt/store.go
@@ -4,6 +4,7 @@
 package thememgt
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,15 +18,15 @@ var errThemeNotFound = errors.New("theme not found")
 
 // themeMgtStoreInterface defines the interface for theme management store operations.
 type themeMgtStoreInterface interface {
-	GetThemeListCount() (int, error)
-	GetThemeList(limit, offset int) ([]Theme, error)
-	CreateTheme(id string, theme CreateThemeRequest) error
-	GetTheme(id string) (Theme, error)
-	IsThemeExist(id string) (bool, error)
-	UpdateTheme(id string, theme UpdateThemeRequest) error
-	DeleteTheme(id string) error
-	IsThemeDeclarative(id string) bool
-	IsThemeHandleConflict(handle string, excludeID string) (bool, error)
+	GetThemeListCount(ctx context.Context) (int, error)
+	GetThemeList(ctx context.Context, limit, offset int) ([]Theme, error)
+	CreateTheme(ctx context.Context, id string, theme CreateThemeRequest) error
+	GetTheme(ctx context.Context, id string) (Theme, error)
+	IsThemeExist(ctx context.Context, id string) (bool, error)
+	UpdateTheme(ctx context.Context, id string, theme UpdateThemeRequest) error
+	DeleteTheme(ctx context.Context, id string) error
+	IsThemeDeclarative(ctx context.Context, id string) bool
+	IsThemeHandleConflict(ctx context.Context, handle string, excludeID string) (bool, error)
 }
 
 // themeMgtStore is the default implementation of themeMgtStoreInterface.
@@ -43,7 +44,7 @@ func newThemeMgtStore() themeMgtStoreInterface {
 }
 
 // GetThemeListCount retrieves the total count of theme configurations.
-func (s *themeMgtStore) GetThemeListCount() (int, error) {
+func (s *themeMgtStore) GetThemeListCount(ctx context.Context) (int, error) {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return 0, err
@@ -58,7 +59,7 @@ func (s *themeMgtStore) GetThemeListCount() (int, error) {
 }
 
 // GetThemeList retrieves theme configurations with pagination.
-func (s *themeMgtStore) GetThemeList(limit, offset int) ([]Theme, error) {
+func (s *themeMgtStore) GetThemeList(ctx context.Context, limit, offset int) ([]Theme, error) {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return nil, err
@@ -82,7 +83,7 @@ func (s *themeMgtStore) GetThemeList(limit, offset int) ([]Theme, error) {
 }
 
 // CreateTheme creates a new theme configuration in the database.
-func (s *themeMgtStore) CreateTheme(id string, theme CreateThemeRequest) error {
+func (s *themeMgtStore) CreateTheme(ctx context.Context, id string, theme CreateThemeRequest) error {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return err
@@ -103,7 +104,7 @@ func (s *themeMgtStore) CreateTheme(id string, theme CreateThemeRequest) error {
 }
 
 // GetTheme retrieves a theme configuration by its id.
-func (s *themeMgtStore) GetTheme(id string) (Theme, error) {
+func (s *themeMgtStore) GetTheme(ctx context.Context, id string) (Theme, error) {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return Theme{}, err
@@ -126,7 +127,7 @@ func (s *themeMgtStore) GetTheme(id string) (Theme, error) {
 }
 
 // IsThemeExist checks if a theme configuration exists by its ID.
-func (s *themeMgtStore) IsThemeExist(id string) (bool, error) {
+func (s *themeMgtStore) IsThemeExist(ctx context.Context, id string) (bool, error) {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return false, err
@@ -150,7 +151,7 @@ func (s *themeMgtStore) IsThemeExist(id string) (bool, error) {
 }
 
 // UpdateTheme updates a theme configuration.
-func (s *themeMgtStore) UpdateTheme(id string, theme UpdateThemeRequest) error {
+func (s *themeMgtStore) UpdateTheme(ctx context.Context, id string, theme UpdateThemeRequest) error {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return err
@@ -170,7 +171,7 @@ func (s *themeMgtStore) UpdateTheme(id string, theme UpdateThemeRequest) error {
 }
 
 // DeleteTheme deletes a theme configuration.
-func (s *themeMgtStore) DeleteTheme(id string) error {
+func (s *themeMgtStore) DeleteTheme(ctx context.Context, id string) error {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return err
@@ -185,7 +186,7 @@ func (s *themeMgtStore) DeleteTheme(id string) error {
 }
 
 // IsThemeDeclarative checks if a theme is immutable (in database store, all themes are mutable).
-func (s *themeMgtStore) IsThemeDeclarative(id string) bool {
+func (s *themeMgtStore) IsThemeDeclarative(ctx context.Context, id string) bool {
 	return false
 }
 
@@ -354,7 +355,7 @@ func (s *themeMgtStore) buildThemeFromResultRow(row map[string]interface{}) (The
 }
 
 // IsThemeHandleConflict checks if a theme handle already exists for the deployment, excluding a specific ID.
-func (s *themeMgtStore) IsThemeHandleConflict(handle string, excludeID string) (bool, error) {
+func (s *themeMgtStore) IsThemeHandleConflict(ctx context.Context, handle string, excludeID string) (bool, error) {
 	dbClient, err := s.getConfigDBClient()
 	if err != nil {
 		return false, err

--- a/backend/internal/design/theme/mgt/store_test.go
+++ b/backend/internal/design/theme/mgt/store_test.go
@@ -4,6 +4,7 @@
 package thememgt
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -44,7 +45,7 @@ func (suite *ThemeStoreTestSuite) TestGetThemeListCount_Success() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "test-deployment").Return(results, nil)
 
-	count, err := suite.store.GetThemeListCount()
+	count, err := suite.store.GetThemeListCount(context.Background())
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 5, count)
@@ -54,7 +55,7 @@ func (suite *ThemeStoreTestSuite) TestGetThemeListCount_Success() {
 func (suite *ThemeStoreTestSuite) TestGetThemeListCount_DBClientError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("connection error"))
 
-	count, err := suite.store.GetThemeListCount()
+	count, err := suite.store.GetThemeListCount(context.Background())
 
 	assert.Error(suite.T(), err)
 	assert.Equal(suite.T(), 0, count)
@@ -66,7 +67,7 @@ func (suite *ThemeStoreTestSuite) TestGetThemeListCount_QueryError() {
 	suite.mockDBClient.On("Query", mock.Anything, "test-deployment").
 		Return(nil, errors.New("query error"))
 
-	count, err := suite.store.GetThemeListCount()
+	count, err := suite.store.GetThemeListCount(context.Background())
 
 	assert.Error(suite.T(), err)
 	assert.Equal(suite.T(), 0, count)
@@ -99,7 +100,7 @@ func (suite *ThemeStoreTestSuite) TestGetThemeList_Success() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, 10, 0, "test-deployment").Return(results, nil)
 
-	themes, err := suite.store.GetThemeList(10, 0)
+	themes, err := suite.store.GetThemeList(context.Background(), 10, 0)
 
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), themes, 2)
@@ -112,7 +113,7 @@ func (suite *ThemeStoreTestSuite) TestGetThemeList_Success() {
 func (suite *ThemeStoreTestSuite) TestGetThemeList_DBClientError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("connection error"))
 
-	themes, err := suite.store.GetThemeList(10, 0)
+	themes, err := suite.store.GetThemeList(context.Background(), 10, 0)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), themes)
@@ -124,7 +125,7 @@ func (suite *ThemeStoreTestSuite) TestCreateTheme_Success() {
 	suite.mockDBClient.On("Execute", mock.Anything, "theme-1", "classic", "Test", "Desc",
 		mock.Anything, "test-deployment").Return(int64(1), nil)
 
-	err := suite.store.CreateTheme("theme-1", CreateThemeRequest{
+	err := suite.store.CreateTheme(context.Background(), "theme-1", CreateThemeRequest{
 		Handle:      "classic",
 		DisplayName: "Test",
 		Description: "Desc",
@@ -150,7 +151,7 @@ func (suite *ThemeStoreTestSuite) TestGetTheme_Success() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "theme-123", "test-deployment").Return(results, nil)
 
-	theme, err := suite.store.GetTheme("theme-123")
+	theme, err := suite.store.GetTheme(context.Background(), "theme-123")
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "theme-123", theme.ID)
@@ -163,7 +164,7 @@ func (suite *ThemeStoreTestSuite) TestGetTheme_NotFound() {
 	suite.mockDBClient.On("Query", mock.Anything, "non-existent", "test-deployment").
 		Return([]map[string]interface{}{}, nil)
 
-	_, err := suite.store.GetTheme("non-existent")
+	_, err := suite.store.GetTheme(context.Background(), "non-existent")
 
 	assert.Error(suite.T(), err)
 	assert.True(suite.T(), errors.Is(err, errThemeNotFound))
@@ -178,7 +179,7 @@ func (suite *ThemeStoreTestSuite) TestGetTheme_MultipleResults() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "theme-123", "test-deployment").Return(results, nil)
 
-	_, err := suite.store.GetTheme("theme-123")
+	_, err := suite.store.GetTheme(context.Background(), "theme-123")
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "unexpected number of results")
@@ -192,7 +193,7 @@ func (suite *ThemeStoreTestSuite) TestIsThemeExist_True() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "theme-123", "test-deployment").Return(results, nil)
 
-	exists, err := suite.store.IsThemeExist("theme-123")
+	exists, err := suite.store.IsThemeExist(context.Background(), "theme-123")
 
 	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), exists)
@@ -204,7 +205,7 @@ func (suite *ThemeStoreTestSuite) TestIsThemeExist_False() {
 	suite.mockDBClient.On("Query", mock.Anything, "non-existent", "test-deployment").
 		Return([]map[string]interface{}{}, nil)
 
-	exists, err := suite.store.IsThemeExist("non-existent")
+	exists, err := suite.store.IsThemeExist(context.Background(), "non-existent")
 
 	assert.NoError(suite.T(), err)
 	assert.False(suite.T(), exists)
@@ -216,7 +217,7 @@ func (suite *ThemeStoreTestSuite) TestDeleteTheme_Success() {
 	suite.mockDBClient.On("Execute", mock.Anything, "theme-123", "test-deployment").
 		Return(int64(1), nil)
 
-	err := suite.store.DeleteTheme("theme-123")
+	err := suite.store.DeleteTheme(context.Background(), "theme-123")
 
 	assert.NoError(suite.T(), err)
 }
@@ -465,7 +466,7 @@ func (suite *ThemeStoreTestSuite) TestIsThemeHandleConflict_Conflict() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "classic", "test-deployment", "").Return(results, nil)
 
-	conflict, err := suite.store.IsThemeHandleConflict("classic", "")
+	conflict, err := suite.store.IsThemeHandleConflict(context.Background(), "classic", "")
 
 	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), conflict)
@@ -479,7 +480,7 @@ func (suite *ThemeStoreTestSuite) TestIsThemeHandleConflict_NoConflict() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, "unique-handle", "test-deployment", "theme-1").Return(results, nil)
 
-	conflict, err := suite.store.IsThemeHandleConflict("unique-handle", "theme-1")
+	conflict, err := suite.store.IsThemeHandleConflict(context.Background(), "unique-handle", "theme-1")
 
 	assert.NoError(suite.T(), err)
 	assert.False(suite.T(), conflict)
@@ -489,7 +490,7 @@ func (suite *ThemeStoreTestSuite) TestIsThemeHandleConflict_NoConflict() {
 func (suite *ThemeStoreTestSuite) TestIsThemeHandleConflict_DBClientError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("connection error"))
 
-	conflict, err := suite.store.IsThemeHandleConflict("classic", "")
+	conflict, err := suite.store.IsThemeHandleConflict(context.Background(), "classic", "")
 
 	assert.Error(suite.T(), err)
 	assert.False(suite.T(), conflict)
@@ -501,7 +502,7 @@ func (suite *ThemeStoreTestSuite) TestIsThemeHandleConflict_QueryError() {
 	suite.mockDBClient.On("Query", mock.Anything, "classic", "test-deployment", "").
 		Return(nil, errors.New("query error"))
 
-	conflict, err := suite.store.IsThemeHandleConflict("classic", "")
+	conflict, err := suite.store.IsThemeHandleConflict(context.Background(), "classic", "")
 
 	assert.Error(suite.T(), err)
 	assert.False(suite.T(), conflict)
@@ -511,7 +512,7 @@ func (suite *ThemeStoreTestSuite) TestIsThemeHandleConflict_QueryError() {
 func (suite *ThemeStoreTestSuite) TestUpdateTheme_DBClientError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("connection error"))
 
-	err := suite.store.UpdateTheme("theme-1", UpdateThemeRequest{
+	err := suite.store.UpdateTheme(context.Background(), "theme-1", UpdateThemeRequest{
 		DisplayName: "Updated",
 		Description: "Updated Desc",
 		Theme:       json.RawMessage(`{"colors": {}}`),
@@ -524,7 +525,7 @@ func (suite *ThemeStoreTestSuite) TestUpdateTheme_DBClientError() {
 func (suite *ThemeStoreTestSuite) TestDeleteTheme_DBClientError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("connection error"))
 
-	err := suite.store.DeleteTheme("theme-1")
+	err := suite.store.DeleteTheme(context.Background(), "theme-1")
 
 	assert.Error(suite.T(), err)
 }

--- a/backend/internal/design/theme/mgt/themeMgtStoreInterface_mock_test.go
+++ b/backend/internal/design/theme/mgt/themeMgtStoreInterface_mock_test.go
@@ -5,6 +5,8 @@
 package thememgt
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -36,16 +38,16 @@ func (_m *themeMgtStoreInterfaceMock) EXPECT() *themeMgtStoreInterfaceMock_Expec
 }
 
 // CreateTheme provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) CreateTheme(id string, theme CreateThemeRequest) error {
-	ret := _mock.Called(id, theme)
+func (_mock *themeMgtStoreInterfaceMock) CreateTheme(ctx context.Context, id string, theme CreateThemeRequest) error {
+	ret := _mock.Called(ctx, id, theme)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateTheme")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, CreateThemeRequest) error); ok {
-		r0 = returnFunc(id, theme)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, CreateThemeRequest) error); ok {
+		r0 = returnFunc(ctx, id, theme)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -58,25 +60,31 @@ type themeMgtStoreInterfaceMock_CreateTheme_Call struct {
 }
 
 // CreateTheme is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - theme CreateThemeRequest
-func (_e *themeMgtStoreInterfaceMock_Expecter) CreateTheme(id interface{}, theme interface{}) *themeMgtStoreInterfaceMock_CreateTheme_Call {
-	return &themeMgtStoreInterfaceMock_CreateTheme_Call{Call: _e.mock.On("CreateTheme", id, theme)}
+func (_e *themeMgtStoreInterfaceMock_Expecter) CreateTheme(ctx interface{}, id interface{}, theme interface{}) *themeMgtStoreInterfaceMock_CreateTheme_Call {
+	return &themeMgtStoreInterfaceMock_CreateTheme_Call{Call: _e.mock.On("CreateTheme", ctx, id, theme)}
 }
 
-func (_c *themeMgtStoreInterfaceMock_CreateTheme_Call) Run(run func(id string, theme CreateThemeRequest)) *themeMgtStoreInterfaceMock_CreateTheme_Call {
+func (_c *themeMgtStoreInterfaceMock_CreateTheme_Call) Run(run func(ctx context.Context, id string, theme CreateThemeRequest)) *themeMgtStoreInterfaceMock_CreateTheme_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 CreateThemeRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(CreateThemeRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 CreateThemeRequest
+		if args[2] != nil {
+			arg2 = args[2].(CreateThemeRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -87,22 +95,22 @@ func (_c *themeMgtStoreInterfaceMock_CreateTheme_Call) Return(err error) *themeM
 	return _c
 }
 
-func (_c *themeMgtStoreInterfaceMock_CreateTheme_Call) RunAndReturn(run func(id string, theme CreateThemeRequest) error) *themeMgtStoreInterfaceMock_CreateTheme_Call {
+func (_c *themeMgtStoreInterfaceMock_CreateTheme_Call) RunAndReturn(run func(ctx context.Context, id string, theme CreateThemeRequest) error) *themeMgtStoreInterfaceMock_CreateTheme_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteTheme provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) DeleteTheme(id string) error {
-	ret := _mock.Called(id)
+func (_mock *themeMgtStoreInterfaceMock) DeleteTheme(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteTheme")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -115,369 +123,17 @@ type themeMgtStoreInterfaceMock_DeleteTheme_Call struct {
 }
 
 // DeleteTheme is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *themeMgtStoreInterfaceMock_Expecter) DeleteTheme(id interface{}) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
-	return &themeMgtStoreInterfaceMock_DeleteTheme_Call{Call: _e.mock.On("DeleteTheme", id)}
+func (_e *themeMgtStoreInterfaceMock_Expecter) DeleteTheme(ctx interface{}, id interface{}) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
+	return &themeMgtStoreInterfaceMock_DeleteTheme_Call{Call: _e.mock.On("DeleteTheme", ctx, id)}
 }
 
-func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) Run(run func(id string)) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
+func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) Run(run func(ctx context.Context, id string)) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) Return(err error) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) RunAndReturn(run func(id string) error) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetTheme provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) GetTheme(id string) (Theme, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetTheme")
-	}
-
-	var r0 Theme
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (Theme, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) Theme); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(Theme)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// themeMgtStoreInterfaceMock_GetTheme_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTheme'
-type themeMgtStoreInterfaceMock_GetTheme_Call struct {
-	*mock.Call
-}
-
-// GetTheme is a helper method to define mock.On call
-//   - id string
-func (_e *themeMgtStoreInterfaceMock_Expecter) GetTheme(id interface{}) *themeMgtStoreInterfaceMock_GetTheme_Call {
-	return &themeMgtStoreInterfaceMock_GetTheme_Call{Call: _e.mock.On("GetTheme", id)}
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) Run(run func(id string)) *themeMgtStoreInterfaceMock_GetTheme_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) Return(theme Theme, err error) *themeMgtStoreInterfaceMock_GetTheme_Call {
-	_c.Call.Return(theme, err)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) RunAndReturn(run func(id string) (Theme, error)) *themeMgtStoreInterfaceMock_GetTheme_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetThemeList provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) GetThemeList(limit int, offset int) ([]Theme, error) {
-	ret := _mock.Called(limit, offset)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetThemeList")
-	}
-
-	var r0 []Theme
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]Theme, error)); ok {
-		return returnFunc(limit, offset)
-	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []Theme); ok {
-		r0 = returnFunc(limit, offset)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]Theme)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(limit, offset)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// themeMgtStoreInterfaceMock_GetThemeList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetThemeList'
-type themeMgtStoreInterfaceMock_GetThemeList_Call struct {
-	*mock.Call
-}
-
-// GetThemeList is a helper method to define mock.On call
-//   - limit int
-//   - offset int
-func (_e *themeMgtStoreInterfaceMock_Expecter) GetThemeList(limit interface{}, offset interface{}) *themeMgtStoreInterfaceMock_GetThemeList_Call {
-	return &themeMgtStoreInterfaceMock_GetThemeList_Call{Call: _e.mock.On("GetThemeList", limit, offset)}
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) Run(run func(limit int, offset int)) *themeMgtStoreInterfaceMock_GetThemeList_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
-		if args[0] != nil {
-			arg0 = args[0].(int)
-		}
-		var arg1 int
-		if args[1] != nil {
-			arg1 = args[1].(int)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) Return(themes []Theme, err error) *themeMgtStoreInterfaceMock_GetThemeList_Call {
-	_c.Call.Return(themes, err)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) RunAndReturn(run func(limit int, offset int) ([]Theme, error)) *themeMgtStoreInterfaceMock_GetThemeList_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetThemeListCount provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) GetThemeListCount() (int, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetThemeListCount")
-	}
-
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// themeMgtStoreInterfaceMock_GetThemeListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetThemeListCount'
-type themeMgtStoreInterfaceMock_GetThemeListCount_Call struct {
-	*mock.Call
-}
-
-// GetThemeListCount is a helper method to define mock.On call
-func (_e *themeMgtStoreInterfaceMock_Expecter) GetThemeListCount() *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
-	return &themeMgtStoreInterfaceMock_GetThemeListCount_Call{Call: _e.mock.On("GetThemeListCount")}
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) Run(run func()) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) Return(n int, err error) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) RunAndReturn(run func() (int, error)) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsThemeDeclarative provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) IsThemeDeclarative(id string) bool {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsThemeDeclarative")
-	}
-
-	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	return r0
-}
-
-// themeMgtStoreInterfaceMock_IsThemeDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeDeclarative'
-type themeMgtStoreInterfaceMock_IsThemeDeclarative_Call struct {
-	*mock.Call
-}
-
-// IsThemeDeclarative is a helper method to define mock.On call
-//   - id string
-func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeDeclarative(id interface{}) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
-	return &themeMgtStoreInterfaceMock_IsThemeDeclarative_Call{Call: _e.mock.On("IsThemeDeclarative", id)}
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) Run(run func(id string)) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) Return(b bool) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
-	_c.Call.Return(b)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) RunAndReturn(run func(id string) bool) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsThemeExist provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) IsThemeExist(id string) (bool, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsThemeExist")
-	}
-
-	var r0 bool
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// themeMgtStoreInterfaceMock_IsThemeExist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeExist'
-type themeMgtStoreInterfaceMock_IsThemeExist_Call struct {
-	*mock.Call
-}
-
-// IsThemeExist is a helper method to define mock.On call
-//   - id string
-func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeExist(id interface{}) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
-	return &themeMgtStoreInterfaceMock_IsThemeExist_Call{Call: _e.mock.On("IsThemeExist", id)}
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) Run(run func(id string)) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) Return(b bool, err error) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
-	_c.Call.Return(b, err)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) RunAndReturn(run func(id string) (bool, error)) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsThemeHandleConflict provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) IsThemeHandleConflict(handle string, excludeID string) (bool, error) {
-	ret := _mock.Called(handle, excludeID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsThemeHandleConflict")
-	}
-
-	var r0 bool
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (bool, error)); ok {
-		return returnFunc(handle, excludeID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) bool); ok {
-		r0 = returnFunc(handle, excludeID)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = returnFunc(handle, excludeID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeHandleConflict'
-type themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call struct {
-	*mock.Call
-}
-
-// IsThemeHandleConflict is a helper method to define mock.On call
-//   - handle string
-//   - excludeID string
-func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeHandleConflict(handle interface{}, excludeID interface{}) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
-	return &themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call{Call: _e.mock.On("IsThemeHandleConflict", handle, excludeID)}
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) Run(run func(handle string, excludeID string)) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -491,27 +147,422 @@ func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) Run(run func(ha
 	return _c
 }
 
+func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) Return(err error) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) RunAndReturn(run func(ctx context.Context, id string) error) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTheme provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) GetTheme(ctx context.Context, id string) (Theme, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTheme")
+	}
+
+	var r0 Theme
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (Theme, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) Theme); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(Theme)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// themeMgtStoreInterfaceMock_GetTheme_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTheme'
+type themeMgtStoreInterfaceMock_GetTheme_Call struct {
+	*mock.Call
+}
+
+// GetTheme is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *themeMgtStoreInterfaceMock_Expecter) GetTheme(ctx interface{}, id interface{}) *themeMgtStoreInterfaceMock_GetTheme_Call {
+	return &themeMgtStoreInterfaceMock_GetTheme_Call{Call: _e.mock.On("GetTheme", ctx, id)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) Run(run func(ctx context.Context, id string)) *themeMgtStoreInterfaceMock_GetTheme_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) Return(theme Theme, err error) *themeMgtStoreInterfaceMock_GetTheme_Call {
+	_c.Call.Return(theme, err)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) RunAndReturn(run func(ctx context.Context, id string) (Theme, error)) *themeMgtStoreInterfaceMock_GetTheme_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetThemeList provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) GetThemeList(ctx context.Context, limit int, offset int) ([]Theme, error) {
+	ret := _mock.Called(ctx, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetThemeList")
+	}
+
+	var r0 []Theme
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]Theme, error)); ok {
+		return returnFunc(ctx, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []Theme); ok {
+		r0 = returnFunc(ctx, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]Theme)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// themeMgtStoreInterfaceMock_GetThemeList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetThemeList'
+type themeMgtStoreInterfaceMock_GetThemeList_Call struct {
+	*mock.Call
+}
+
+// GetThemeList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - limit int
+//   - offset int
+func (_e *themeMgtStoreInterfaceMock_Expecter) GetThemeList(ctx interface{}, limit interface{}, offset interface{}) *themeMgtStoreInterfaceMock_GetThemeList_Call {
+	return &themeMgtStoreInterfaceMock_GetThemeList_Call{Call: _e.mock.On("GetThemeList", ctx, limit, offset)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) Run(run func(ctx context.Context, limit int, offset int)) *themeMgtStoreInterfaceMock_GetThemeList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) Return(themes []Theme, err error) *themeMgtStoreInterfaceMock_GetThemeList_Call {
+	_c.Call.Return(themes, err)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]Theme, error)) *themeMgtStoreInterfaceMock_GetThemeList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetThemeListCount provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) GetThemeListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetThemeListCount")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// themeMgtStoreInterfaceMock_GetThemeListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetThemeListCount'
+type themeMgtStoreInterfaceMock_GetThemeListCount_Call struct {
+	*mock.Call
+}
+
+// GetThemeListCount is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *themeMgtStoreInterfaceMock_Expecter) GetThemeListCount(ctx interface{}) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
+	return &themeMgtStoreInterfaceMock_GetThemeListCount_Call{Call: _e.mock.On("GetThemeListCount", ctx)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) Run(run func(ctx context.Context)) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) Return(n int, err error) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsThemeDeclarative provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) IsThemeDeclarative(ctx context.Context, id string) bool {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsThemeDeclarative")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// themeMgtStoreInterfaceMock_IsThemeDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeDeclarative'
+type themeMgtStoreInterfaceMock_IsThemeDeclarative_Call struct {
+	*mock.Call
+}
+
+// IsThemeDeclarative is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeDeclarative(ctx interface{}, id interface{}) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
+	return &themeMgtStoreInterfaceMock_IsThemeDeclarative_Call{Call: _e.mock.On("IsThemeDeclarative", ctx, id)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) Run(run func(ctx context.Context, id string)) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) Return(b bool) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) RunAndReturn(run func(ctx context.Context, id string) bool) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsThemeExist provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) IsThemeExist(ctx context.Context, id string) (bool, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsThemeExist")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// themeMgtStoreInterfaceMock_IsThemeExist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeExist'
+type themeMgtStoreInterfaceMock_IsThemeExist_Call struct {
+	*mock.Call
+}
+
+// IsThemeExist is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeExist(ctx interface{}, id interface{}) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
+	return &themeMgtStoreInterfaceMock_IsThemeExist_Call{Call: _e.mock.On("IsThemeExist", ctx, id)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) Run(run func(ctx context.Context, id string)) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) Return(b bool, err error) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) RunAndReturn(run func(ctx context.Context, id string) (bool, error)) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsThemeHandleConflict provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) IsThemeHandleConflict(ctx context.Context, handle string, excludeID string) (bool, error) {
+	ret := _mock.Called(ctx, handle, excludeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsThemeHandleConflict")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (bool, error)); ok {
+		return returnFunc(ctx, handle, excludeID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = returnFunc(ctx, handle, excludeID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, handle, excludeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeHandleConflict'
+type themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call struct {
+	*mock.Call
+}
+
+// IsThemeHandleConflict is a helper method to define mock.On call
+//   - ctx context.Context
+//   - handle string
+//   - excludeID string
+func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeHandleConflict(ctx interface{}, handle interface{}, excludeID interface{}) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
+	return &themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call{Call: _e.mock.On("IsThemeHandleConflict", ctx, handle, excludeID)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) Run(run func(ctx context.Context, handle string, excludeID string)) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
 func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) Return(b bool, err error) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
 	_c.Call.Return(b, err)
 	return _c
 }
 
-func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) RunAndReturn(run func(handle string, excludeID string) (bool, error)) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
+func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) RunAndReturn(run func(ctx context.Context, handle string, excludeID string) (bool, error)) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateTheme provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) UpdateTheme(id string, theme UpdateThemeRequest) error {
-	ret := _mock.Called(id, theme)
+func (_mock *themeMgtStoreInterfaceMock) UpdateTheme(ctx context.Context, id string, theme UpdateThemeRequest) error {
+	ret := _mock.Called(ctx, id, theme)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateTheme")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, UpdateThemeRequest) error); ok {
-		r0 = returnFunc(id, theme)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, UpdateThemeRequest) error); ok {
+		r0 = returnFunc(ctx, id, theme)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -524,25 +575,31 @@ type themeMgtStoreInterfaceMock_UpdateTheme_Call struct {
 }
 
 // UpdateTheme is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - theme UpdateThemeRequest
-func (_e *themeMgtStoreInterfaceMock_Expecter) UpdateTheme(id interface{}, theme interface{}) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
-	return &themeMgtStoreInterfaceMock_UpdateTheme_Call{Call: _e.mock.On("UpdateTheme", id, theme)}
+func (_e *themeMgtStoreInterfaceMock_Expecter) UpdateTheme(ctx interface{}, id interface{}, theme interface{}) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
+	return &themeMgtStoreInterfaceMock_UpdateTheme_Call{Call: _e.mock.On("UpdateTheme", ctx, id, theme)}
 }
 
-func (_c *themeMgtStoreInterfaceMock_UpdateTheme_Call) Run(run func(id string, theme UpdateThemeRequest)) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
+func (_c *themeMgtStoreInterfaceMock_UpdateTheme_Call) Run(run func(ctx context.Context, id string, theme UpdateThemeRequest)) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 UpdateThemeRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(UpdateThemeRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 UpdateThemeRequest
+		if args[2] != nil {
+			arg2 = args[2].(UpdateThemeRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -553,7 +610,7 @@ func (_c *themeMgtStoreInterfaceMock_UpdateTheme_Call) Return(err error) *themeM
 	return _c
 }
 
-func (_c *themeMgtStoreInterfaceMock_UpdateTheme_Call) RunAndReturn(run func(id string, theme UpdateThemeRequest) error) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
+func (_c *themeMgtStoreInterfaceMock_UpdateTheme_Call) RunAndReturn(run func(ctx context.Context, id string, theme UpdateThemeRequest) error) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/system/i18n/mgt/composite_store.go
+++ b/backend/internal/system/i18n/mgt/composite_store.go
@@ -22,12 +22,12 @@ func newCompositeI18nStore(fileStore, dbStore i18nStoreInterface) i18nStoreInter
 }
 
 // GetDistinctLanguages returns the union of languages from both stores.
-func (c *compositeI18nStore) GetDistinctLanguages() ([]string, error) {
-	dbLangs, err := c.dbStore.GetDistinctLanguages()
+func (c *compositeI18nStore) GetDistinctLanguages(ctx context.Context) ([]string, error) {
+	dbLangs, err := c.dbStore.GetDistinctLanguages(ctx)
 	if err != nil {
 		return nil, err
 	}
-	fileLangs, err := c.fileStore.GetDistinctLanguages()
+	fileLangs, err := c.fileStore.GetDistinctLanguages(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -51,12 +51,12 @@ func (c *compositeI18nStore) GetDistinctLanguages() ([]string, error) {
 
 // GetTranslations merges translations from both stores.
 // DB values (overrides) take precedence over file-based values for the same key+language.
-func (c *compositeI18nStore) GetTranslations() (map[string]map[string]Translation, error) {
-	fileTrans, err := c.fileStore.GetTranslations()
+func (c *compositeI18nStore) GetTranslations(ctx context.Context) (map[string]map[string]Translation, error) {
+	fileTrans, err := c.fileStore.GetTranslations(ctx)
 	if err != nil {
 		return nil, err
 	}
-	dbTrans, err := c.dbStore.GetTranslations()
+	dbTrans, err := c.dbStore.GetTranslations(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -65,14 +65,14 @@ func (c *compositeI18nStore) GetTranslations() (map[string]map[string]Translatio
 
 // GetTranslationsByNamespace merges translations for a namespace from both stores.
 // DB values take precedence over file-based values for the same key+language.
-func (c *compositeI18nStore) GetTranslationsByNamespace(namespace string) (
+func (c *compositeI18nStore) GetTranslationsByNamespace(ctx context.Context, namespace string) (
 	map[string]map[string]Translation, error,
 ) {
-	fileTrans, err := c.fileStore.GetTranslationsByNamespace(namespace)
+	fileTrans, err := c.fileStore.GetTranslationsByNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	dbTrans, err := c.dbStore.GetTranslationsByNamespace(namespace)
+	dbTrans, err := c.dbStore.GetTranslationsByNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -81,14 +81,14 @@ func (c *compositeI18nStore) GetTranslationsByNamespace(namespace string) (
 
 // GetTranslationsByKey retrieves a translation for a specific key and namespace.
 // Returns the DB override if present, otherwise falls back to the file-based value.
-func (c *compositeI18nStore) GetTranslationsByKey(key string, namespace string) (
+func (c *compositeI18nStore) GetTranslationsByKey(ctx context.Context, key string, namespace string) (
 	map[string]Translation, error,
 ) {
-	fileTrans, err := c.fileStore.GetTranslationsByKey(key, namespace)
+	fileTrans, err := c.fileStore.GetTranslationsByKey(ctx, key, namespace)
 	if err != nil {
 		return nil, err
 	}
-	dbTrans, err := c.dbStore.GetTranslationsByKey(key, namespace)
+	dbTrans, err := c.dbStore.GetTranslationsByKey(ctx, key, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -104,24 +104,26 @@ func (c *compositeI18nStore) GetTranslationsByKey(key string, namespace string) 
 	return result, nil
 }
 
-func (c *compositeI18nStore) UpsertTranslationsByLanguage(language string, translations []Translation) error {
-	return c.dbStore.UpsertTranslationsByLanguage(language, translations)
+func (c *compositeI18nStore) UpsertTranslationsByLanguage(ctx context.Context, language string,
+	translations []Translation) error {
+	return c.dbStore.UpsertTranslationsByLanguage(ctx, language, translations)
 }
 
-func (c *compositeI18nStore) UpsertTranslation(trans Translation) error {
-	return c.dbStore.UpsertTranslation(trans)
+func (c *compositeI18nStore) UpsertTranslation(ctx context.Context, trans Translation) error {
+	return c.dbStore.UpsertTranslation(ctx, trans)
 }
 
 func (c *compositeI18nStore) UpsertTranslations(ctx context.Context, translations []Translation) error {
 	return c.dbStore.UpsertTranslations(ctx, translations)
 }
 
-func (c *compositeI18nStore) DeleteTranslationsByLanguage(language string) error {
-	return c.dbStore.DeleteTranslationsByLanguage(language)
+func (c *compositeI18nStore) DeleteTranslationsByLanguage(ctx context.Context, language string) error {
+	return c.dbStore.DeleteTranslationsByLanguage(ctx, language)
 }
 
-func (c *compositeI18nStore) DeleteTranslation(language string, key string, namespace string) error {
-	return c.dbStore.DeleteTranslation(language, key, namespace)
+func (c *compositeI18nStore) DeleteTranslation(ctx context.Context, language string, key string,
+	namespace string) error {
+	return c.dbStore.DeleteTranslation(ctx, language, key, namespace)
 }
 
 func (c *compositeI18nStore) DeleteTranslationsByNamespace(ctx context.Context, namespace string) error {

--- a/backend/internal/system/i18n/mgt/composite_store_test.go
+++ b/backend/internal/system/i18n/mgt/composite_store_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -32,10 +33,10 @@ func (s *CompositeStoreTestSuite) SetupTest() {
 // GetDistinctLanguages
 
 func (s *CompositeStoreTestSuite) TestGetDistinctLanguages_MergesAndDeduplicates() {
-	s.dbStore.EXPECT().GetDistinctLanguages().Return([]string{"en-US", "fr-FR"}, nil)
-	s.fileStore.EXPECT().GetDistinctLanguages().Return([]string{"en-US", "es-ES"}, nil)
+	s.dbStore.EXPECT().GetDistinctLanguages(mock.Anything).Return([]string{"en-US", "fr-FR"}, nil)
+	s.fileStore.EXPECT().GetDistinctLanguages(mock.Anything).Return([]string{"en-US", "es-ES"}, nil)
 
-	langs, err := s.store.GetDistinctLanguages()
+	langs, err := s.store.GetDistinctLanguages(context.Background())
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), langs, 3)
 	assert.Contains(s.T(), langs, "en-US")
@@ -44,18 +45,18 @@ func (s *CompositeStoreTestSuite) TestGetDistinctLanguages_MergesAndDeduplicates
 }
 
 func (s *CompositeStoreTestSuite) TestGetDistinctLanguages_DBStoreError() {
-	s.dbStore.EXPECT().GetDistinctLanguages().Return(nil, errors.New("db error"))
+	s.dbStore.EXPECT().GetDistinctLanguages(mock.Anything).Return(nil, errors.New("db error"))
 
-	langs, err := s.store.GetDistinctLanguages()
+	langs, err := s.store.GetDistinctLanguages(context.Background())
 	assert.Error(s.T(), err)
 	assert.Nil(s.T(), langs)
 }
 
 func (s *CompositeStoreTestSuite) TestGetDistinctLanguages_FileStoreError() {
-	s.dbStore.EXPECT().GetDistinctLanguages().Return([]string{"en-US"}, nil)
-	s.fileStore.EXPECT().GetDistinctLanguages().Return(nil, errors.New("file error"))
+	s.dbStore.EXPECT().GetDistinctLanguages(mock.Anything).Return([]string{"en-US"}, nil)
+	s.fileStore.EXPECT().GetDistinctLanguages(mock.Anything).Return(nil, errors.New("file error"))
 
-	langs, err := s.store.GetDistinctLanguages()
+	langs, err := s.store.GetDistinctLanguages(context.Background())
 	assert.Error(s.T(), err)
 	assert.Nil(s.T(), langs)
 }
@@ -73,10 +74,10 @@ func (s *CompositeStoreTestSuite) TestGetTranslations_DBOverridesFile() {
 			"en-US": {Key: "key1", Namespace: "ns1", Language: "en-US", Value: "db-override"},
 		},
 	}
-	s.fileStore.EXPECT().GetTranslations().Return(fileTrans, nil)
-	s.dbStore.EXPECT().GetTranslations().Return(dbTrans, nil)
+	s.fileStore.EXPECT().GetTranslations(mock.Anything).Return(fileTrans, nil)
+	s.dbStore.EXPECT().GetTranslations(mock.Anything).Return(dbTrans, nil)
 
-	result, err := s.store.GetTranslations()
+	result, err := s.store.GetTranslations(context.Background())
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "db-override", result["ns1|key1"]["en-US"].Value)
 }
@@ -87,10 +88,10 @@ func (s *CompositeStoreTestSuite) TestGetTranslations_FileOnlyKeyPreserved() {
 			"en-US": {Key: "key1", Namespace: "ns1", Language: "en-US", Value: "file-only"},
 		},
 	}
-	s.fileStore.EXPECT().GetTranslations().Return(fileTrans, nil)
-	s.dbStore.EXPECT().GetTranslations().Return(map[string]map[string]Translation{}, nil)
+	s.fileStore.EXPECT().GetTranslations(mock.Anything).Return(fileTrans, nil)
+	s.dbStore.EXPECT().GetTranslations(mock.Anything).Return(map[string]map[string]Translation{}, nil)
 
-	result, err := s.store.GetTranslations()
+	result, err := s.store.GetTranslations(context.Background())
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "file-only", result["ns1|key1"]["en-US"].Value)
 }
@@ -101,27 +102,27 @@ func (s *CompositeStoreTestSuite) TestGetTranslations_DBOnlyKeyPreserved() {
 			"en-US": {Key: "key2", Namespace: "ns1", Language: "en-US", Value: "db-only"},
 		},
 	}
-	s.fileStore.EXPECT().GetTranslations().Return(map[string]map[string]Translation{}, nil)
-	s.dbStore.EXPECT().GetTranslations().Return(dbTrans, nil)
+	s.fileStore.EXPECT().GetTranslations(mock.Anything).Return(map[string]map[string]Translation{}, nil)
+	s.dbStore.EXPECT().GetTranslations(mock.Anything).Return(dbTrans, nil)
 
-	result, err := s.store.GetTranslations()
+	result, err := s.store.GetTranslations(context.Background())
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "db-only", result["ns1|key2"]["en-US"].Value)
 }
 
 func (s *CompositeStoreTestSuite) TestGetTranslations_FileStoreError() {
-	s.fileStore.EXPECT().GetTranslations().Return(nil, errors.New("file error"))
+	s.fileStore.EXPECT().GetTranslations(mock.Anything).Return(nil, errors.New("file error"))
 
-	result, err := s.store.GetTranslations()
+	result, err := s.store.GetTranslations(context.Background())
 	assert.Error(s.T(), err)
 	assert.Nil(s.T(), result)
 }
 
 func (s *CompositeStoreTestSuite) TestGetTranslations_DBStoreError() {
-	s.fileStore.EXPECT().GetTranslations().Return(map[string]map[string]Translation{}, nil)
-	s.dbStore.EXPECT().GetTranslations().Return(nil, errors.New("db error"))
+	s.fileStore.EXPECT().GetTranslations(mock.Anything).Return(map[string]map[string]Translation{}, nil)
+	s.dbStore.EXPECT().GetTranslations(mock.Anything).Return(nil, errors.New("db error"))
 
-	result, err := s.store.GetTranslations()
+	result, err := s.store.GetTranslations(context.Background())
 	assert.Error(s.T(), err)
 	assert.Nil(s.T(), result)
 }
@@ -139,27 +140,28 @@ func (s *CompositeStoreTestSuite) TestGetTranslationsByNamespace_DBOverridesFile
 			"en-US": {Key: "forms.title", Namespace: "signin", Language: "en-US", Value: "Log In"},
 		},
 	}
-	s.fileStore.EXPECT().GetTranslationsByNamespace("signin").Return(fileTrans, nil)
-	s.dbStore.EXPECT().GetTranslationsByNamespace("signin").Return(dbTrans, nil)
+	s.fileStore.EXPECT().GetTranslationsByNamespace(mock.Anything, "signin").Return(fileTrans, nil)
+	s.dbStore.EXPECT().GetTranslationsByNamespace(mock.Anything, "signin").Return(dbTrans, nil)
 
-	result, err := s.store.GetTranslationsByNamespace("signin")
+	result, err := s.store.GetTranslationsByNamespace(context.Background(), "signin")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "Log In", result["signin|forms.title"]["en-US"].Value)
 }
 
 func (s *CompositeStoreTestSuite) TestGetTranslationsByNamespace_FileStoreError() {
-	s.fileStore.EXPECT().GetTranslationsByNamespace("signin").Return(nil, errors.New("file error"))
+	s.fileStore.EXPECT().GetTranslationsByNamespace(mock.Anything, "signin").Return(nil, errors.New("file error"))
 
-	result, err := s.store.GetTranslationsByNamespace("signin")
+	result, err := s.store.GetTranslationsByNamespace(context.Background(), "signin")
 	assert.Error(s.T(), err)
 	assert.Nil(s.T(), result)
 }
 
 func (s *CompositeStoreTestSuite) TestGetTranslationsByNamespace_DBStoreError() {
-	s.fileStore.EXPECT().GetTranslationsByNamespace("signin").Return(map[string]map[string]Translation{}, nil)
-	s.dbStore.EXPECT().GetTranslationsByNamespace("signin").Return(nil, errors.New("db error"))
+	s.fileStore.EXPECT().GetTranslationsByNamespace(mock.Anything, "signin").Return(map[string]map[string]Translation{},
+		nil)
+	s.dbStore.EXPECT().GetTranslationsByNamespace(mock.Anything, "signin").Return(nil, errors.New("db error"))
 
-	result, err := s.store.GetTranslationsByNamespace("signin")
+	result, err := s.store.GetTranslationsByNamespace(context.Background(), "signin")
 	assert.Error(s.T(), err)
 	assert.Nil(s.T(), result)
 }
@@ -174,10 +176,10 @@ func (s *CompositeStoreTestSuite) TestGetTranslationsByKey_DBOverridesFilePerLan
 	dbTrans := map[string]Translation{
 		"en-US": {Key: "forms.title", Namespace: "signin", Language: "en-US", Value: "Log In"},
 	}
-	s.fileStore.EXPECT().GetTranslationsByKey("forms.title", "signin").Return(fileTrans, nil)
-	s.dbStore.EXPECT().GetTranslationsByKey("forms.title", "signin").Return(dbTrans, nil)
+	s.fileStore.EXPECT().GetTranslationsByKey(mock.Anything, "forms.title", "signin").Return(fileTrans, nil)
+	s.dbStore.EXPECT().GetTranslationsByKey(mock.Anything, "forms.title", "signin").Return(dbTrans, nil)
 
-	result, err := s.store.GetTranslationsByKey("forms.title", "signin")
+	result, err := s.store.GetTranslationsByKey(context.Background(), "forms.title", "signin")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "Log In", result["en-US"].Value)
 	assert.Equal(s.T(), "Se connecter", result["fr-FR"].Value)
@@ -187,27 +189,27 @@ func (s *CompositeStoreTestSuite) TestGetTranslationsByKey_FileOnlyLanguagePrese
 	fileTrans := map[string]Translation{
 		"en-US": {Key: "key1", Namespace: "ns1", Language: "en-US", Value: "file-value"},
 	}
-	s.fileStore.EXPECT().GetTranslationsByKey("key1", "ns1").Return(fileTrans, nil)
-	s.dbStore.EXPECT().GetTranslationsByKey("key1", "ns1").Return(map[string]Translation{}, nil)
+	s.fileStore.EXPECT().GetTranslationsByKey(mock.Anything, "key1", "ns1").Return(fileTrans, nil)
+	s.dbStore.EXPECT().GetTranslationsByKey(mock.Anything, "key1", "ns1").Return(map[string]Translation{}, nil)
 
-	result, err := s.store.GetTranslationsByKey("key1", "ns1")
+	result, err := s.store.GetTranslationsByKey(context.Background(), "key1", "ns1")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "file-value", result["en-US"].Value)
 }
 
 func (s *CompositeStoreTestSuite) TestGetTranslationsByKey_FileStoreError() {
-	s.fileStore.EXPECT().GetTranslationsByKey("key1", "ns1").Return(nil, errors.New("file error"))
+	s.fileStore.EXPECT().GetTranslationsByKey(mock.Anything, "key1", "ns1").Return(nil, errors.New("file error"))
 
-	result, err := s.store.GetTranslationsByKey("key1", "ns1")
+	result, err := s.store.GetTranslationsByKey(context.Background(), "key1", "ns1")
 	assert.Error(s.T(), err)
 	assert.Nil(s.T(), result)
 }
 
 func (s *CompositeStoreTestSuite) TestGetTranslationsByKey_DBStoreError() {
-	s.fileStore.EXPECT().GetTranslationsByKey("key1", "ns1").Return(map[string]Translation{}, nil)
-	s.dbStore.EXPECT().GetTranslationsByKey("key1", "ns1").Return(nil, errors.New("db error"))
+	s.fileStore.EXPECT().GetTranslationsByKey(mock.Anything, "key1", "ns1").Return(map[string]Translation{}, nil)
+	s.dbStore.EXPECT().GetTranslationsByKey(mock.Anything, "key1", "ns1").Return(nil, errors.New("db error"))
 
-	result, err := s.store.GetTranslationsByKey("key1", "ns1")
+	result, err := s.store.GetTranslationsByKey(context.Background(), "key1", "ns1")
 	assert.Error(s.T(), err)
 	assert.Nil(s.T(), result)
 }
@@ -216,17 +218,17 @@ func (s *CompositeStoreTestSuite) TestGetTranslationsByKey_DBStoreError() {
 
 func (s *CompositeStoreTestSuite) TestUpsertTranslationsByLanguage_DelegatesToDB() {
 	trans := []Translation{{Key: "key1", Language: "en-US", Namespace: "ns1", Value: "v1"}}
-	s.dbStore.EXPECT().UpsertTranslationsByLanguage("en-US", trans).Return(nil)
+	s.dbStore.EXPECT().UpsertTranslationsByLanguage(mock.Anything, "en-US", trans).Return(nil)
 
-	err := s.store.UpsertTranslationsByLanguage("en-US", trans)
+	err := s.store.UpsertTranslationsByLanguage(context.Background(), "en-US", trans)
 	assert.NoError(s.T(), err)
 }
 
 func (s *CompositeStoreTestSuite) TestUpsertTranslation_DelegatesToDB() {
 	trans := Translation{Key: "key1", Language: "en-US", Namespace: "ns1", Value: "v1"}
-	s.dbStore.EXPECT().UpsertTranslation(trans).Return(nil)
+	s.dbStore.EXPECT().UpsertTranslation(mock.Anything, trans).Return(nil)
 
-	err := s.store.UpsertTranslation(trans)
+	err := s.store.UpsertTranslation(context.Background(), trans)
 	assert.NoError(s.T(), err)
 }
 
@@ -240,16 +242,16 @@ func (s *CompositeStoreTestSuite) TestUpsertTranslations_DelegatesToDB() {
 }
 
 func (s *CompositeStoreTestSuite) TestDeleteTranslationsByLanguage_DelegatesToDB() {
-	s.dbStore.EXPECT().DeleteTranslationsByLanguage("en-US").Return(nil)
+	s.dbStore.EXPECT().DeleteTranslationsByLanguage(mock.Anything, "en-US").Return(nil)
 
-	err := s.store.DeleteTranslationsByLanguage("en-US")
+	err := s.store.DeleteTranslationsByLanguage(context.Background(), "en-US")
 	assert.NoError(s.T(), err)
 }
 
 func (s *CompositeStoreTestSuite) TestDeleteTranslation_DelegatesToDB() {
-	s.dbStore.EXPECT().DeleteTranslation("en-US", "key1", "ns1").Return(nil)
+	s.dbStore.EXPECT().DeleteTranslation(mock.Anything, "en-US", "key1", "ns1").Return(nil)
 
-	err := s.store.DeleteTranslation("en-US", "key1", "ns1")
+	err := s.store.DeleteTranslation(context.Background(), "en-US", "key1", "ns1")
 	assert.NoError(s.T(), err)
 }
 

--- a/backend/internal/system/i18n/mgt/declarative_resource.go
+++ b/backend/internal/system/i18n/mgt/declarative_resource.go
@@ -44,7 +44,7 @@ func (e *translationExporter) GetParameterizerType() string {
 // One file per language.
 func (e *translationExporter) GetAllResourceIDs(ctx context.Context) ([]string, *tidcommon.ServiceError) {
 	// Get all translations from store
-	languages, err := e.store.GetDistinctLanguages()
+	languages, err := e.store.GetDistinctLanguages(ctx)
 	if err != nil {
 		return nil, &tidcommon.ServiceError{
 			Code: "I18N_EXPORT_ERROR",
@@ -62,7 +62,7 @@ func (e *translationExporter) GetAllResourceIDs(ctx context.Context) ([]string, 
 func (e *translationExporter) GetResourceByID(ctx context.Context, id string) (
 	interface{}, string, *tidcommon.ServiceError,
 ) {
-	translations, err := e.store.GetTranslations()
+	translations, err := e.store.GetTranslations(ctx)
 	if err != nil {
 		return nil, "", &tidcommon.ServiceError{
 			Code: "I18N_FETCH_ERROR",

--- a/backend/internal/system/i18n/mgt/declarative_resource_test.go
+++ b/backend/internal/system/i18n/mgt/declarative_resource_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
@@ -63,7 +64,7 @@ func (s *DeclarativeResourceTestSuite) TestGetResourceByID() {
 		},
 	}
 
-	s.mockStore.On("GetTranslations").Return(translations, nil)
+	s.mockStore.On("GetTranslations", mock.Anything).Return(translations, nil)
 
 	resource, name, err := s.exporter.GetResourceByID(context.Background(), "en-US")
 	assert.Nil(s.T(), err)
@@ -78,7 +79,7 @@ func (s *DeclarativeResourceTestSuite) TestGetResourceByID() {
 }
 
 func (s *DeclarativeResourceTestSuite) TestGetResourceByID_NotFound() {
-	s.mockStore.On("GetTranslations").Return(map[string]map[string]Translation{}, nil)
+	s.mockStore.On("GetTranslations", mock.Anything).Return(map[string]map[string]Translation{}, nil)
 
 	_, _, err := s.exporter.GetResourceByID(context.Background(), "fr-FR")
 	assert.NotNil(s.T(), err)
@@ -86,7 +87,7 @@ func (s *DeclarativeResourceTestSuite) TestGetResourceByID_NotFound() {
 }
 
 func (s *DeclarativeResourceTestSuite) TestGetResourceByID_StoreError() {
-	s.mockStore.On("GetTranslations").Return(nil, errors.New("db error"))
+	s.mockStore.On("GetTranslations", mock.Anything).Return(nil, errors.New("db error"))
 
 	_, _, err := s.exporter.GetResourceByID(context.Background(), "en-US")
 	assert.NotNil(s.T(), err)
@@ -141,7 +142,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateResourceMissingTranslations()
 
 func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs() {
 	languages := []string{"en-US", "fr-FR"}
-	s.mockStore.On("GetDistinctLanguages").Return(languages, nil)
+	s.mockStore.On("GetDistinctLanguages", mock.Anything).Return(languages, nil)
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
@@ -151,7 +152,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs() {
 }
 
 func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_StoreError() {
-	s.mockStore.On("GetDistinctLanguages").Return(nil, errors.New("db error"))
+	s.mockStore.On("GetDistinctLanguages", mock.Anything).Return(nil, errors.New("db error"))
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.NotNil(s.T(), err)

--- a/backend/internal/system/i18n/mgt/file_based_store.go
+++ b/backend/internal/system/i18n/mgt/file_based_store.go
@@ -30,7 +30,7 @@ func (f *fileBasedStore) Create(id string, data interface{}) error {
 }
 
 // GetDistinctLanguages retrieves all distinct language codes that have translations.
-func (f *fileBasedStore) GetDistinctLanguages() ([]string, error) {
+func (f *fileBasedStore) GetDistinctLanguages(ctx context.Context) ([]string, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func (f *fileBasedStore) GetDistinctLanguages() ([]string, error) {
 }
 
 // GetTranslations retrieves all translations.
-func (f *fileBasedStore) GetTranslations() (map[string]map[string]Translation, error) {
+func (f *fileBasedStore) GetTranslations(ctx context.Context) (map[string]map[string]Translation, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return nil, err
@@ -75,7 +75,8 @@ func (f *fileBasedStore) GetTranslations() (map[string]map[string]Translation, e
 }
 
 // GetTranslationsByNamespace retrieves all translations for a namespace.
-func (f *fileBasedStore) GetTranslationsByNamespace(namespace string) (map[string]map[string]Translation, error) {
+func (f *fileBasedStore) GetTranslationsByNamespace(ctx context.Context,
+	namespace string) (map[string]map[string]Translation, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return nil, err
@@ -107,7 +108,8 @@ func (f *fileBasedStore) GetTranslationsByNamespace(namespace string) (map[strin
 }
 
 // GetTranslationsByKey retrieves a single translation by key and namespace.
-func (f *fileBasedStore) GetTranslationsByKey(key string, namespace string) (map[string]Translation, error) {
+func (f *fileBasedStore) GetTranslationsByKey(ctx context.Context, key string,
+	namespace string) (map[string]Translation, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return nil, err
@@ -139,12 +141,13 @@ func (f *fileBasedStore) GetTranslationsByKey(key string, namespace string) (map
 }
 
 // UpsertTranslationsByLanguage is not supported in file-based store.
-func (f *fileBasedStore) UpsertTranslationsByLanguage(language string, translations []Translation) error {
+func (f *fileBasedStore) UpsertTranslationsByLanguage(ctx context.Context, language string,
+	translations []Translation) error {
 	return errors.New("UpsertTranslationsByLanguage is not supported in file-based store")
 }
 
 // UpsertTranslation is not supported in file-based store.
-func (f *fileBasedStore) UpsertTranslation(trans Translation) error {
+func (f *fileBasedStore) UpsertTranslation(ctx context.Context, trans Translation) error {
 	return errors.New("UpsertTranslation is not supported in file-based store")
 }
 
@@ -154,12 +157,12 @@ func (f *fileBasedStore) UpsertTranslations(_ context.Context, _ []Translation) 
 }
 
 // DeleteTranslationsByLanguage is not supported in file-based store.
-func (f *fileBasedStore) DeleteTranslationsByLanguage(language string) error {
+func (f *fileBasedStore) DeleteTranslationsByLanguage(ctx context.Context, language string) error {
 	return errors.New("DeleteTranslationsByLanguage is not supported in file-based store")
 }
 
 // DeleteTranslation is not supported in file-based store.
-func (f *fileBasedStore) DeleteTranslation(language string, key string, namespace string) error {
+func (f *fileBasedStore) DeleteTranslation(ctx context.Context, language string, key string, namespace string) error {
 	return errors.New("DeleteTranslation is not supported in file-based store")
 }
 

--- a/backend/internal/system/i18n/mgt/file_based_store_test.go
+++ b/backend/internal/system/i18n/mgt/file_based_store_test.go
@@ -57,7 +57,7 @@ func (s *FileBasedStoreTestSuite) TestCreateAndGetDistinctLanguages() {
 	assert.NoError(s.T(), err)
 
 	// Verify distinct languages
-	languages, err := s.store.GetDistinctLanguages()
+	languages, err := s.store.GetDistinctLanguages(context.Background())
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), languages, 2)
 	assert.Contains(s.T(), languages, "en-US")
@@ -92,7 +92,7 @@ func (s *FileBasedStoreTestSuite) TestGetTranslations() {
 	assert.NoError(s.T(), err)
 
 	// Get all translations
-	translations, err := s.store.GetTranslations()
+	translations, err := s.store.GetTranslations(context.Background())
 	assert.NoError(s.T(), err)
 
 	// Verify structure
@@ -127,7 +127,7 @@ func (s *FileBasedStoreTestSuite) TestGetTranslationsByNamespace() {
 	assert.NoError(s.T(), err)
 
 	// Get translations for ns1
-	translations, err := s.store.GetTranslationsByNamespace("ns1")
+	translations, err := s.store.GetTranslationsByNamespace(context.Background(), "ns1")
 	assert.NoError(s.T(), err)
 
 	assert.Contains(s.T(), translations, "ns1|key1")
@@ -160,7 +160,7 @@ func (s *FileBasedStoreTestSuite) TestGetTranslationsByKey() {
 	assert.NoError(s.T(), err)
 
 	// Get translation for key1 in ns1
-	translations, err := s.store.GetTranslationsByKey("key1", "ns1")
+	translations, err := s.store.GetTranslationsByKey(context.Background(), "key1", "ns1")
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), translations)
 
@@ -185,13 +185,13 @@ func (s *FileBasedStoreTestSuite) TestGetTranslationsByKey_NotFound() {
 	assert.NoError(s.T(), err)
 
 	// Wrong key
-	translations, err := s.store.GetTranslationsByKey("key2", "ns1")
+	translations, err := s.store.GetTranslationsByKey(context.Background(), "key2", "ns1")
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), translations)
 	assert.Empty(s.T(), translations)
 
 	// Wrong namespace
-	translations, err = s.store.GetTranslationsByKey("key1", "ns2")
+	translations, err = s.store.GetTranslationsByKey(context.Background(), "key1", "ns2")
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), translations)
 	assert.Empty(s.T(), translations)
@@ -217,25 +217,25 @@ func (s *FileBasedStoreTestSuite) TestIsTranslationExists() {
 }
 
 func (s *FileBasedStoreTestSuite) TestUpsertTranslationsByLanguage_NotSupported() {
-	err := s.store.UpsertTranslationsByLanguage("en-US", []Translation{})
+	err := s.store.UpsertTranslationsByLanguage(context.Background(), "en-US", []Translation{})
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "not supported")
 }
 
 func (s *FileBasedStoreTestSuite) TestUpsertTranslation_NotSupported() {
-	err := s.store.UpsertTranslation(Translation{})
+	err := s.store.UpsertTranslation(context.Background(), Translation{})
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "not supported")
 }
 
 func (s *FileBasedStoreTestSuite) TestDeleteTranslationsByLanguage_NotSupported() {
-	err := s.store.DeleteTranslationsByLanguage("en-US")
+	err := s.store.DeleteTranslationsByLanguage(context.Background(), "en-US")
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "not supported")
 }
 
 func (s *FileBasedStoreTestSuite) TestDeleteTranslation_NotSupported() {
-	err := s.store.DeleteTranslation("en-US", "key", "ns")
+	err := s.store.DeleteTranslation(context.Background(), "en-US", "key", "ns")
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "not supported")
 }

--- a/backend/internal/system/i18n/mgt/i18nStoreInterface_mock_test.go
+++ b/backend/internal/system/i18n/mgt/i18nStoreInterface_mock_test.go
@@ -38,16 +38,16 @@ func (_m *i18nStoreInterfaceMock) EXPECT() *i18nStoreInterfaceMock_Expecter {
 }
 
 // DeleteTranslation provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) DeleteTranslation(language string, key string, namespace string) error {
-	ret := _mock.Called(language, key, namespace)
+func (_mock *i18nStoreInterfaceMock) DeleteTranslation(ctx context.Context, language string, key string, namespace string) error {
+	ret := _mock.Called(ctx, language, key, namespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteTranslation")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) error); ok {
-		r0 = returnFunc(language, key, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = returnFunc(ctx, language, key, namespace)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -60,18 +60,19 @@ type i18nStoreInterfaceMock_DeleteTranslation_Call struct {
 }
 
 // DeleteTranslation is a helper method to define mock.On call
+//   - ctx context.Context
 //   - language string
 //   - key string
 //   - namespace string
-func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslation(language interface{}, key interface{}, namespace interface{}) *i18nStoreInterfaceMock_DeleteTranslation_Call {
-	return &i18nStoreInterfaceMock_DeleteTranslation_Call{Call: _e.mock.On("DeleteTranslation", language, key, namespace)}
+func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslation(ctx interface{}, language interface{}, key interface{}, namespace interface{}) *i18nStoreInterfaceMock_DeleteTranslation_Call {
+	return &i18nStoreInterfaceMock_DeleteTranslation_Call{Call: _e.mock.On("DeleteTranslation", ctx, language, key, namespace)}
 }
 
-func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) Run(run func(language string, key string, namespace string)) *i18nStoreInterfaceMock_DeleteTranslation_Call {
+func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) Run(run func(ctx context.Context, language string, key string, namespace string)) *i18nStoreInterfaceMock_DeleteTranslation_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -81,10 +82,15 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) Run(run func(language s
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -95,7 +101,7 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) Return(err error) *i18n
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) RunAndReturn(run func(language string, key string, namespace string) error) *i18nStoreInterfaceMock_DeleteTranslation_Call {
+func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) RunAndReturn(run func(ctx context.Context, language string, key string, namespace string) error) *i18nStoreInterfaceMock_DeleteTranslation_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -164,16 +170,16 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call) RunAndReturn(run 
 }
 
 // DeleteTranslationsByLanguage provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) DeleteTranslationsByLanguage(language string) error {
-	ret := _mock.Called(language)
+func (_mock *i18nStoreInterfaceMock) DeleteTranslationsByLanguage(ctx context.Context, language string) error {
+	ret := _mock.Called(ctx, language)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteTranslationsByLanguage")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(language)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, language)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -186,19 +192,25 @@ type i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call struct {
 }
 
 // DeleteTranslationsByLanguage is a helper method to define mock.On call
+//   - ctx context.Context
 //   - language string
-func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslationsByLanguage(language interface{}) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
-	return &i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call{Call: _e.mock.On("DeleteTranslationsByLanguage", language)}
+func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslationsByLanguage(ctx interface{}, language interface{}) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
+	return &i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call{Call: _e.mock.On("DeleteTranslationsByLanguage", ctx, language)}
 }
 
-func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) Run(run func(language string)) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) Run(run func(ctx context.Context, language string)) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -209,7 +221,7 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) Return(err e
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) RunAndReturn(run func(language string) error) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) RunAndReturn(run func(ctx context.Context, language string) error) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -272,8 +284,8 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call) RunAndRetur
 }
 
 // GetDistinctLanguages provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) GetDistinctLanguages() ([]string, error) {
-	ret := _mock.Called()
+func (_mock *i18nStoreInterfaceMock) GetDistinctLanguages(ctx context.Context) ([]string, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDistinctLanguages")
@@ -281,18 +293,18 @@ func (_mock *i18nStoreInterfaceMock) GetDistinctLanguages() ([]string, error) {
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]string, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]string, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() []string); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -305,13 +317,20 @@ type i18nStoreInterfaceMock_GetDistinctLanguages_Call struct {
 }
 
 // GetDistinctLanguages is a helper method to define mock.On call
-func (_e *i18nStoreInterfaceMock_Expecter) GetDistinctLanguages() *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
-	return &i18nStoreInterfaceMock_GetDistinctLanguages_Call{Call: _e.mock.On("GetDistinctLanguages")}
+//   - ctx context.Context
+func (_e *i18nStoreInterfaceMock_Expecter) GetDistinctLanguages(ctx interface{}) *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
+	return &i18nStoreInterfaceMock_GetDistinctLanguages_Call{Call: _e.mock.On("GetDistinctLanguages", ctx)}
 }
 
-func (_c *i18nStoreInterfaceMock_GetDistinctLanguages_Call) Run(run func()) *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
+func (_c *i18nStoreInterfaceMock_GetDistinctLanguages_Call) Run(run func(ctx context.Context)) *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -321,14 +340,14 @@ func (_c *i18nStoreInterfaceMock_GetDistinctLanguages_Call) Return(strings []str
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_GetDistinctLanguages_Call) RunAndReturn(run func() ([]string, error)) *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
+func (_c *i18nStoreInterfaceMock_GetDistinctLanguages_Call) RunAndReturn(run func(ctx context.Context) ([]string, error)) *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetTranslations provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) GetTranslations() (map[string]map[string]Translation, error) {
-	ret := _mock.Called()
+func (_mock *i18nStoreInterfaceMock) GetTranslations(ctx context.Context) (map[string]map[string]Translation, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTranslations")
@@ -336,18 +355,18 @@ func (_mock *i18nStoreInterfaceMock) GetTranslations() (map[string]map[string]Tr
 
 	var r0 map[string]map[string]Translation
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (map[string]map[string]Translation, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (map[string]map[string]Translation, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() map[string]map[string]Translation); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) map[string]map[string]Translation); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]map[string]Translation)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -360,13 +379,20 @@ type i18nStoreInterfaceMock_GetTranslations_Call struct {
 }
 
 // GetTranslations is a helper method to define mock.On call
-func (_e *i18nStoreInterfaceMock_Expecter) GetTranslations() *i18nStoreInterfaceMock_GetTranslations_Call {
-	return &i18nStoreInterfaceMock_GetTranslations_Call{Call: _e.mock.On("GetTranslations")}
+//   - ctx context.Context
+func (_e *i18nStoreInterfaceMock_Expecter) GetTranslations(ctx interface{}) *i18nStoreInterfaceMock_GetTranslations_Call {
+	return &i18nStoreInterfaceMock_GetTranslations_Call{Call: _e.mock.On("GetTranslations", ctx)}
 }
 
-func (_c *i18nStoreInterfaceMock_GetTranslations_Call) Run(run func()) *i18nStoreInterfaceMock_GetTranslations_Call {
+func (_c *i18nStoreInterfaceMock_GetTranslations_Call) Run(run func(ctx context.Context)) *i18nStoreInterfaceMock_GetTranslations_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -376,14 +402,14 @@ func (_c *i18nStoreInterfaceMock_GetTranslations_Call) Return(stringToStringToTr
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_GetTranslations_Call) RunAndReturn(run func() (map[string]map[string]Translation, error)) *i18nStoreInterfaceMock_GetTranslations_Call {
+func (_c *i18nStoreInterfaceMock_GetTranslations_Call) RunAndReturn(run func(ctx context.Context) (map[string]map[string]Translation, error)) *i18nStoreInterfaceMock_GetTranslations_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetTranslationsByKey provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) GetTranslationsByKey(key string, namespace string) (map[string]Translation, error) {
-	ret := _mock.Called(key, namespace)
+func (_mock *i18nStoreInterfaceMock) GetTranslationsByKey(ctx context.Context, key string, namespace string) (map[string]Translation, error) {
+	ret := _mock.Called(ctx, key, namespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTranslationsByKey")
@@ -391,18 +417,18 @@ func (_mock *i18nStoreInterfaceMock) GetTranslationsByKey(key string, namespace 
 
 	var r0 map[string]Translation
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (map[string]Translation, error)); ok {
-		return returnFunc(key, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]Translation, error)); ok {
+		return returnFunc(ctx, key, namespace)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) map[string]Translation); ok {
-		r0 = returnFunc(key, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]Translation); ok {
+		r0 = returnFunc(ctx, key, namespace)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]Translation)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = returnFunc(key, namespace)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, key, namespace)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -415,17 +441,91 @@ type i18nStoreInterfaceMock_GetTranslationsByKey_Call struct {
 }
 
 // GetTranslationsByKey is a helper method to define mock.On call
+//   - ctx context.Context
 //   - key string
 //   - namespace string
-func (_e *i18nStoreInterfaceMock_Expecter) GetTranslationsByKey(key interface{}, namespace interface{}) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
-	return &i18nStoreInterfaceMock_GetTranslationsByKey_Call{Call: _e.mock.On("GetTranslationsByKey", key, namespace)}
+func (_e *i18nStoreInterfaceMock_Expecter) GetTranslationsByKey(ctx interface{}, key interface{}, namespace interface{}) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
+	return &i18nStoreInterfaceMock_GetTranslationsByKey_Call{Call: _e.mock.On("GetTranslationsByKey", ctx, key, namespace)}
 }
 
-func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) Run(run func(key string, namespace string)) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
+func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) Run(run func(ctx context.Context, key string, namespace string)) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) Return(stringToTranslation map[string]Translation, err error) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
+	_c.Call.Return(stringToTranslation, err)
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) RunAndReturn(run func(ctx context.Context, key string, namespace string) (map[string]Translation, error)) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTranslationsByNamespace provides a mock function for the type i18nStoreInterfaceMock
+func (_mock *i18nStoreInterfaceMock) GetTranslationsByNamespace(ctx context.Context, namespace string) (map[string]map[string]Translation, error) {
+	ret := _mock.Called(ctx, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTranslationsByNamespace")
+	}
+
+	var r0 map[string]map[string]Translation
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]map[string]Translation, error)); ok {
+		return returnFunc(ctx, namespace)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]map[string]Translation); ok {
+		r0 = returnFunc(ctx, namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]map[string]Translation)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, namespace)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// i18nStoreInterfaceMock_GetTranslationsByNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTranslationsByNamespace'
+type i18nStoreInterfaceMock_GetTranslationsByNamespace_Call struct {
+	*mock.Call
+}
+
+// GetTranslationsByNamespace is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+func (_e *i18nStoreInterfaceMock_Expecter) GetTranslationsByNamespace(ctx interface{}, namespace interface{}) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
+	return &i18nStoreInterfaceMock_GetTranslationsByNamespace_Call{Call: _e.mock.On("GetTranslationsByNamespace", ctx, namespace)}
+}
+
+func (_c *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call) Run(run func(ctx context.Context, namespace string)) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -439,89 +539,27 @@ func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) Run(run func(key str
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) Return(stringToTranslation map[string]Translation, err error) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
-	_c.Call.Return(stringToTranslation, err)
-	return _c
-}
-
-func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) RunAndReturn(run func(key string, namespace string) (map[string]Translation, error)) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetTranslationsByNamespace provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) GetTranslationsByNamespace(namespace string) (map[string]map[string]Translation, error) {
-	ret := _mock.Called(namespace)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetTranslationsByNamespace")
-	}
-
-	var r0 map[string]map[string]Translation
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (map[string]map[string]Translation, error)); ok {
-		return returnFunc(namespace)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) map[string]map[string]Translation); ok {
-		r0 = returnFunc(namespace)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]map[string]Translation)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(namespace)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// i18nStoreInterfaceMock_GetTranslationsByNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTranslationsByNamespace'
-type i18nStoreInterfaceMock_GetTranslationsByNamespace_Call struct {
-	*mock.Call
-}
-
-// GetTranslationsByNamespace is a helper method to define mock.On call
-//   - namespace string
-func (_e *i18nStoreInterfaceMock_Expecter) GetTranslationsByNamespace(namespace interface{}) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
-	return &i18nStoreInterfaceMock_GetTranslationsByNamespace_Call{Call: _e.mock.On("GetTranslationsByNamespace", namespace)}
-}
-
-func (_c *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call) Run(run func(namespace string)) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
 func (_c *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call) Return(stringToStringToTranslation map[string]map[string]Translation, err error) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
 	_c.Call.Return(stringToStringToTranslation, err)
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call) RunAndReturn(run func(namespace string) (map[string]map[string]Translation, error)) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
+func (_c *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call) RunAndReturn(run func(ctx context.Context, namespace string) (map[string]map[string]Translation, error)) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpsertTranslation provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) UpsertTranslation(trans Translation) error {
-	ret := _mock.Called(trans)
+func (_mock *i18nStoreInterfaceMock) UpsertTranslation(ctx context.Context, trans Translation) error {
+	ret := _mock.Called(ctx, trans)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpsertTranslation")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(Translation) error); ok {
-		r0 = returnFunc(trans)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, Translation) error); ok {
+		r0 = returnFunc(ctx, trans)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -534,19 +572,25 @@ type i18nStoreInterfaceMock_UpsertTranslation_Call struct {
 }
 
 // UpsertTranslation is a helper method to define mock.On call
+//   - ctx context.Context
 //   - trans Translation
-func (_e *i18nStoreInterfaceMock_Expecter) UpsertTranslation(trans interface{}) *i18nStoreInterfaceMock_UpsertTranslation_Call {
-	return &i18nStoreInterfaceMock_UpsertTranslation_Call{Call: _e.mock.On("UpsertTranslation", trans)}
+func (_e *i18nStoreInterfaceMock_Expecter) UpsertTranslation(ctx interface{}, trans interface{}) *i18nStoreInterfaceMock_UpsertTranslation_Call {
+	return &i18nStoreInterfaceMock_UpsertTranslation_Call{Call: _e.mock.On("UpsertTranslation", ctx, trans)}
 }
 
-func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) Run(run func(trans Translation)) *i18nStoreInterfaceMock_UpsertTranslation_Call {
+func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) Run(run func(ctx context.Context, trans Translation)) *i18nStoreInterfaceMock_UpsertTranslation_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 Translation
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(Translation)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 Translation
+		if args[1] != nil {
+			arg1 = args[1].(Translation)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -557,7 +601,7 @@ func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) Return(err error) *i18n
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) RunAndReturn(run func(trans Translation) error) *i18nStoreInterfaceMock_UpsertTranslation_Call {
+func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) RunAndReturn(run func(ctx context.Context, trans Translation) error) *i18nStoreInterfaceMock_UpsertTranslation_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -620,16 +664,16 @@ func (_c *i18nStoreInterfaceMock_UpsertTranslations_Call) RunAndReturn(run func(
 }
 
 // UpsertTranslationsByLanguage provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) UpsertTranslationsByLanguage(language string, translations []Translation) error {
-	ret := _mock.Called(language, translations)
+func (_mock *i18nStoreInterfaceMock) UpsertTranslationsByLanguage(ctx context.Context, language string, translations []Translation) error {
+	ret := _mock.Called(ctx, language, translations)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpsertTranslationsByLanguage")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []Translation) error); ok {
-		r0 = returnFunc(language, translations)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []Translation) error); ok {
+		r0 = returnFunc(ctx, language, translations)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -642,25 +686,31 @@ type i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call struct {
 }
 
 // UpsertTranslationsByLanguage is a helper method to define mock.On call
+//   - ctx context.Context
 //   - language string
 //   - translations []Translation
-func (_e *i18nStoreInterfaceMock_Expecter) UpsertTranslationsByLanguage(language interface{}, translations interface{}) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
-	return &i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call{Call: _e.mock.On("UpsertTranslationsByLanguage", language, translations)}
+func (_e *i18nStoreInterfaceMock_Expecter) UpsertTranslationsByLanguage(ctx interface{}, language interface{}, translations interface{}) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
+	return &i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call{Call: _e.mock.On("UpsertTranslationsByLanguage", ctx, language, translations)}
 }
 
-func (_c *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call) Run(run func(language string, translations []Translation)) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
+func (_c *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call) Run(run func(ctx context.Context, language string, translations []Translation)) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 []Translation
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].([]Translation)
+			arg1 = args[1].(string)
+		}
+		var arg2 []Translation
+		if args[2] != nil {
+			arg2 = args[2].([]Translation)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -671,7 +721,7 @@ func (_c *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call) Return(err e
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call) RunAndReturn(run func(language string, translations []Translation) error) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
+func (_c *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call) RunAndReturn(run func(ctx context.Context, language string, translations []Translation) error) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/system/i18n/mgt/service.go
+++ b/backend/internal/system/i18n/mgt/service.go
@@ -62,7 +62,7 @@ func newI18nService(store i18nStoreInterface) I18nServiceInterface {
 // ListLanguages retrieves all locale codes that have translations in the system.
 // The default locale is always included in the response, even if it has no translations in the DB.
 func (s *i18nService) ListLanguages(ctx context.Context) ([]string, *tidcommon.ServiceError) {
-	localeCodes, err := s.store.GetDistinctLanguages()
+	localeCodes, err := s.store.GetDistinctLanguages(ctx)
 	if err != nil {
 		s.logger.Error(ctx, "Failed to get locales from store", log.Error(err))
 		return nil, &tidcommon.InternalServerError
@@ -92,7 +92,7 @@ func (s *i18nService) ResolveTranslationsForKey(ctx context.Context,
 		return nil, err
 	}
 
-	trans, err := s.store.GetTranslationsByKey(key, namespace)
+	trans, err := s.store.GetTranslationsByKey(ctx, key, namespace)
 	if err != nil {
 		s.logger.Error(ctx, "Failed to get translation from store", log.Error(err))
 		return nil, &tidcommon.InternalServerError
@@ -151,7 +151,7 @@ func (s *i18nService) SetTranslationOverrideForKey(ctx context.Context,
 	}
 
 	// Use upsert to create or update
-	if err := s.store.UpsertTranslation(trans); err != nil {
+	if err := s.store.UpsertTranslation(ctx, trans); err != nil {
 		s.logger.Error(ctx, "Failed to set translation override", log.Error(err))
 		return nil, &tidcommon.InternalServerError
 	}
@@ -218,7 +218,7 @@ func (s *i18nService) ClearTranslationOverrideForKey(ctx context.Context,
 		return err
 	}
 
-	if err := s.store.DeleteTranslation(language, key, namespace); err != nil {
+	if err := s.store.DeleteTranslation(ctx, language, key, namespace); err != nil {
 		s.logger.Error(ctx, "Failed to clear translation override", log.Error(err))
 		return &tidcommon.InternalServerError
 	}
@@ -249,13 +249,13 @@ func (s *i18nService) ResolveTranslations(ctx context.Context,
 
 	if namespace == "" {
 		// Get all namespaces
-		allTranslations, err = s.store.GetTranslations()
+		allTranslations, err = s.store.GetTranslations(ctx)
 		if err != nil {
 			s.logger.Error(ctx, "Failed to get translations from store", log.Error(err))
 			return nil, &tidcommon.InternalServerError
 		}
 	} else {
-		allTranslations, err = s.store.GetTranslationsByNamespace(namespace)
+		allTranslations, err = s.store.GetTranslationsByNamespace(ctx, namespace)
 		if err != nil {
 			s.logger.Error(ctx, "Failed to get translations from store", log.Error(err))
 			return nil, &tidcommon.InternalServerError
@@ -346,7 +346,7 @@ func (s *i18nService) SetTranslationOverrides(ctx context.Context,
 		}
 	}
 
-	if err := s.store.UpsertTranslationsByLanguage(language, flattenedTranslations); err != nil {
+	if err := s.store.UpsertTranslationsByLanguage(ctx, language, flattenedTranslations); err != nil {
 		s.logger.Error(ctx, "Failed to upsert translations", log.Error(err))
 		return nil, &tidcommon.InternalServerError
 	}
@@ -371,7 +371,7 @@ func (s *i18nService) ClearTranslationOverrides(ctx context.Context, language st
 		return &ErrorInvalidLanguage
 	}
 
-	if err := s.clearAllOverrides(language); err != nil {
+	if err := s.clearAllOverrides(ctx, language); err != nil {
 		s.logger.Error(ctx, "Failed to clear overrides", log.Error(err))
 		return &tidcommon.InternalServerError
 	}
@@ -417,7 +417,7 @@ func (s *i18nService) GetTranslationsByNamespace(ctx context.Context,
 	if !ValidateNamespace(namespace) {
 		return nil, &ErrorInvalidNamespace
 	}
-	byNs, err := s.store.GetTranslationsByNamespace(namespace)
+	byNs, err := s.store.GetTranslationsByNamespace(ctx, namespace)
 	if err != nil {
 		s.logger.Error(ctx, "Failed to get translations by namespace", log.Error(err))
 		return nil, &tidcommon.InternalServerError
@@ -440,8 +440,8 @@ func (s *i18nService) GetTranslationsByNamespace(ctx context.Context,
 	return result, nil
 }
 
-func (s *i18nService) clearAllOverrides(language string) error {
-	err := s.store.DeleteTranslationsByLanguage(language)
+func (s *i18nService) clearAllOverrides(ctx context.Context, language string) error {
+	err := s.store.DeleteTranslationsByLanguage(ctx, language)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/system/i18n/mgt/service_test.go
+++ b/backend/internal/system/i18n/mgt/service_test.go
@@ -51,7 +51,7 @@ func (suite *I18nMgtServiceTestSuite) TearDownTest() {
 // ListLanguages Tests
 func (suite *I18nMgtServiceTestSuite) TestListLanguages_Success() {
 	expectedLangs := []string{"en-US", "fr-FR"}
-	suite.mockStore.On("GetDistinctLanguages").Return(expectedLangs, nil)
+	suite.mockStore.On("GetDistinctLanguages", mock.Anything).Return(expectedLangs, nil)
 
 	result, err := suite.service.ListLanguages(context.Background())
 
@@ -62,7 +62,7 @@ func (suite *I18nMgtServiceTestSuite) TestListLanguages_Success() {
 }
 
 func (suite *I18nMgtServiceTestSuite) TestListLanguages_StoreError() {
-	suite.mockStore.On("GetDistinctLanguages").Return(nil, errors.New("db error"))
+	suite.mockStore.On("GetDistinctLanguages", mock.Anything).Return(nil, errors.New("db error"))
 
 	result, err := suite.service.ListLanguages(context.Background())
 
@@ -73,7 +73,7 @@ func (suite *I18nMgtServiceTestSuite) TestListLanguages_StoreError() {
 
 func (suite *I18nMgtServiceTestSuite) TestListLanguages_AddsSystemLanguage() {
 	// If store returns empty or doesn't have system language, it should be added
-	suite.mockStore.On("GetDistinctLanguages").Return([]string{"fr-FR"}, nil)
+	suite.mockStore.On("GetDistinctLanguages", mock.Anything).Return([]string{"fr-FR"}, nil)
 
 	result, err := suite.service.ListLanguages(context.Background())
 
@@ -92,7 +92,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_Success_From
 	}
 	translationsMap := map[string]Translation{"en-US": translation}
 
-	suite.mockStore.On("GetTranslationsByKey", "welcome", "common").Return(translationsMap, nil)
+	suite.mockStore.On("GetTranslationsByKey", mock.Anything, "welcome", "common").Return(translationsMap, nil)
 
 	result, err := suite.service.ResolveTranslationsForKey(context.Background(), "en-US", "common", "welcome")
 
@@ -126,7 +126,8 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_ValidationEr
 }
 
 func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_NotFound() {
-	suite.mockStore.On("GetTranslationsByKey", "unknown", "common").Return((map[string]Translation)(nil), nil)
+	suite.mockStore.On("GetTranslationsByKey", mock.Anything, "unknown", "common").Return((map[string]Translation)(nil),
+		nil)
 
 	result, err := suite.service.ResolveTranslationsForKey(context.Background(), "en-US", "common", "unknown")
 
@@ -136,7 +137,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_NotFound() {
 }
 
 func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_StoreError() {
-	suite.mockStore.On("GetTranslationsByKey", "welcome", "common").Return(nil, errors.New("db error"))
+	suite.mockStore.On("GetTranslationsByKey", mock.Anything, "welcome", "common").Return(nil, errors.New("db error"))
 
 	result, err := suite.service.ResolveTranslationsForKey(context.Background(), "en-US", "common", "welcome")
 
@@ -149,7 +150,8 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_UsesSystemDe
 	key := testErrKey
 	expectedValue := testErrVal
 
-	suite.mockStore.On("GetTranslationsByKey", key, SystemNamespace).Return(make(map[string]Translation), nil)
+	suite.mockStore.On("GetTranslationsByKey", mock.Anything, key, SystemNamespace).Return(make(map[string]Translation),
+		nil)
 
 	// Request en-US, expecting fallback to system default (en)
 	result, err := suite.service.ResolveTranslationsForKey(context.Background(), "en-US", SystemNamespace, key)
@@ -177,7 +179,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_SystemDefaul
 	}
 	dbTranslations := map[string]Translation{"fr-FR": frTranslation}
 
-	suite.mockStore.On("GetTranslationsByKey", key, SystemNamespace).Return(dbTranslations, nil)
+	suite.mockStore.On("GetTranslationsByKey", mock.Anything, key, SystemNamespace).Return(dbTranslations, nil)
 
 	// Request en-US, expecting fallback to system default (en)
 	result, err := suite.service.ResolveTranslationsForKey(context.Background(), "en-US", SystemNamespace, key)
@@ -203,7 +205,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_UsesDBValue_
 	}
 	dbTranslations := map[string]Translation{SystemLanguage: dbTranslation}
 
-	suite.mockStore.On("GetTranslationsByKey", key, SystemNamespace).Return(dbTranslations, nil)
+	suite.mockStore.On("GetTranslationsByKey", mock.Anything, key, SystemNamespace).Return(dbTranslations, nil)
 
 	// Request en-US, expecting fallback to system default (en)
 	result, err := suite.service.ResolveTranslationsForKey(context.Background(), "en-US", SystemNamespace, key)
@@ -218,7 +220,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_UsesDBValue_
 
 // SetTranslationOverrideForKey Tests
 func (suite *I18nMgtServiceTestSuite) TestSetTranslationOverrideForKey_Success() {
-	suite.mockStore.On("UpsertTranslation", mock.AnythingOfType("mgt.Translation")).Return(nil)
+	suite.mockStore.On("UpsertTranslation", mock.Anything, mock.AnythingOfType("mgt.Translation")).Return(nil)
 
 	result, err := suite.service.SetTranslationOverrideForKey(
 		context.Background(), "en-US", "common", "welcome", "Hello")
@@ -265,7 +267,8 @@ func (suite *I18nMgtServiceTestSuite) TestSetTranslationOverrideForKey_Validatio
 }
 
 func (suite *I18nMgtServiceTestSuite) TestSetTranslationOverrideForKey_StoreError() {
-	suite.mockStore.On("UpsertTranslation", mock.AnythingOfType("mgt.Translation")).Return(errors.New("db error"))
+	suite.mockStore.On("UpsertTranslation", mock.Anything,
+		mock.AnythingOfType("mgt.Translation")).Return(errors.New("db error"))
 
 	result, err := suite.service.SetTranslationOverrideForKey(
 		context.Background(), "en-US", "common", "welcome", "Hello")
@@ -300,19 +303,19 @@ func (suite *I18nMgtServiceTestSuite) TestSetTranslationOverrideForKey_Composite
 		config.GetServerRuntime().Config.Translation.Store = ""
 	}()
 
-	suite.mockStore.On("UpsertTranslation", mock.Anything).Return(nil)
+	suite.mockStore.On("UpsertTranslation", mock.Anything, mock.Anything).Return(nil)
 
 	result, err := suite.service.SetTranslationOverrideForKey(
 		context.Background(), "en-US", "common", "welcome", "Hello")
 
 	suite.Nil(err)
 	suite.NotNil(result)
-	suite.mockStore.AssertCalled(suite.T(), "UpsertTranslation", mock.Anything)
+	suite.mockStore.AssertCalled(suite.T(), "UpsertTranslation", mock.Anything, mock.Anything)
 }
 
 // ClearTranslationOverrideForKey Tests
 func (suite *I18nMgtServiceTestSuite) TestClearTranslationOverrideForKey_Success() {
-	suite.mockStore.On("DeleteTranslation", "en-US", "welcome", "common").Return(nil)
+	suite.mockStore.On("DeleteTranslation", mock.Anything, "en-US", "welcome", "common").Return(nil)
 
 	err := suite.service.ClearTranslationOverrideForKey(context.Background(), "en-US", "common", "welcome")
 
@@ -338,7 +341,7 @@ func (suite *I18nMgtServiceTestSuite) TestClearTranslationOverrideForKey_Validat
 }
 
 func (suite *I18nMgtServiceTestSuite) TestClearTranslationOverrideForKey_StoreError() {
-	suite.mockStore.On("DeleteTranslation", "en-US", "welcome", "common").Return(errors.New("db error"))
+	suite.mockStore.On("DeleteTranslation", mock.Anything, "en-US", "welcome", "common").Return(errors.New("db error"))
 
 	err := suite.service.ClearTranslationOverrideForKey(context.Background(), "en-US", "common", "welcome")
 
@@ -369,12 +372,12 @@ func (suite *I18nMgtServiceTestSuite) TestClearTranslationOverrideForKey_Composi
 		config.GetServerRuntime().Config.Translation.Store = ""
 	}()
 
-	suite.mockStore.On("DeleteTranslation", "en-US", "welcome", "common").Return(nil)
+	suite.mockStore.On("DeleteTranslation", mock.Anything, "en-US", "welcome", "common").Return(nil)
 
 	err := suite.service.ClearTranslationOverrideForKey(context.Background(), "en-US", "common", "welcome")
 
 	suite.Nil(err)
-	suite.mockStore.AssertCalled(suite.T(), "DeleteTranslation", "en-US", "welcome", "common")
+	suite.mockStore.AssertCalled(suite.T(), "DeleteTranslation", mock.Anything, "en-US", "welcome", "common")
 }
 
 // ResolveTranslations Tests
@@ -393,7 +396,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_CustomNamespace_Su
 		},
 	}
 
-	suite.mockStore.On("GetTranslationsByNamespace", "console").Return(mockDataCorrect, nil)
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, "console").Return(mockDataCorrect, nil)
 
 	result, err := suite.service.ResolveTranslations(context.Background(), "en-US", "console")
 
@@ -412,7 +415,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_InvalidNamespace()
 }
 
 func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_StoreError() {
-	suite.mockStore.On("GetTranslationsByNamespace", "console").Return(nil, errors.New("db error"))
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, "console").Return(nil, errors.New("db error"))
 
 	result, err := suite.service.ResolveTranslations(context.Background(), "en-US", "console")
 
@@ -423,7 +426,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_StoreError() {
 
 func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_UsesSystemDefaults_WhenKeyMissingInDB() {
 	// Mock: no custom translations in DB
-	suite.mockStore.On("GetTranslationsByNamespace", "system").
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, "system").
 		Return(make(map[string]map[string]Translation), nil)
 
 	key := testErrKey
@@ -453,7 +456,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_UsesSystemDefaults
 		SystemNamespace + "|" + key: {"fr-FR": frTranslation},
 	}
 
-	suite.mockStore.On("GetTranslationsByNamespace", "system").Return(dbTranslations, nil)
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, "system").Return(dbTranslations, nil)
 
 	result, err := suite.service.ResolveTranslations(context.Background(), "en-US", "system")
 
@@ -478,7 +481,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_UsesDBValue_WhenDB
 		SystemNamespace + "|" + key: {SystemLanguage: translationDB},
 	}
 
-	suite.mockStore.On("GetTranslationsByNamespace", "system").Return(dbTranslations, nil)
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, "system").Return(dbTranslations, nil)
 
 	result, err := suite.service.ResolveTranslations(context.Background(), "en-US", "system")
 
@@ -490,7 +493,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_UsesDBValue_WhenDB
 
 func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_DefaultsFallback() {
 	// Mock: no custom translations in DB
-	suite.mockStore.On("GetTranslationsByNamespace", "system").
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, "system").
 		Return(make(map[string]map[string]Translation), nil)
 
 	result, err := suite.service.ResolveTranslations(context.Background(), "fr-FR", "system")
@@ -513,7 +516,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_MergeLogic() {
 		"welcome": {"en-US": translationDB},
 	}
 
-	suite.mockStore.On("GetTranslationsByNamespace", "system").Return(dbTranslations, nil)
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, "system").Return(dbTranslations, nil)
 
 	result, err := suite.service.ResolveTranslations(context.Background(), "en-US", "system")
 
@@ -531,7 +534,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_AllNamespaces() {
 		"k2": {"en-US": {Key: "k2", Namespace: "ns2", Language: "en-US", Value: "v2"}},
 	}
 
-	suite.mockStore.On("GetTranslations").Return(dbTranslations, nil)
+	suite.mockStore.On("GetTranslations", mock.Anything).Return(dbTranslations, nil)
 
 	result, err := suite.service.ResolveTranslations(context.Background(), "en-US", "")
 
@@ -542,7 +545,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_AllNamespaces() {
 }
 
 func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_AllNamespaces_StoreError() {
-	suite.mockStore.On("GetTranslations").Return(nil, errors.New("db error"))
+	suite.mockStore.On("GetTranslations", mock.Anything).Return(nil, errors.New("db error"))
 
 	result, err := suite.service.ResolveTranslations(context.Background(), "en-US", "")
 
@@ -564,7 +567,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_AppNamespace_Exact
 			"fr": {Key: "name", Namespace: ns, Language: "fr", Value: "Mon Application"},
 		},
 	}
-	suite.mockStore.On("GetTranslationsByNamespace", ns).Return(dbTranslations, nil)
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, ns).Return(dbTranslations, nil)
 
 	result, err := suite.service.ResolveTranslations(context.Background(), "fr", ns)
 
@@ -584,7 +587,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_AppNamespace_BestM
 			"fr": {Key: "name", Namespace: ns, Language: "fr", Value: "Mon Application"},
 		},
 	}
-	suite.mockStore.On("GetTranslationsByNamespace", ns).Return(dbTranslations, nil)
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, ns).Return(dbTranslations, nil)
 
 	result, err := suite.service.ResolveTranslations(context.Background(), "en", ns)
 
@@ -602,7 +605,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_SystemNamespace_St
 	dbTranslations := map[string]map[string]Translation{
 		SystemNamespace + "|" + key: {"fr": frTranslation},
 	}
-	suite.mockStore.On("GetTranslationsByNamespace", SystemNamespace).Return(dbTranslations, nil)
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, SystemNamespace).Return(dbTranslations, nil)
 
 	// Request "en-US" — no en-US stored, but system defaults fill it in.
 	result, err := suite.service.ResolveTranslations(context.Background(), "en-US", SystemNamespace)
@@ -621,7 +624,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_SystemNamespace_St
 func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_AppNamespace_ExactMatch() {
 	ns := testAppNamespace
 	key := "name"
-	suite.mockStore.On("GetTranslationsByKey", key, ns).Return(map[string]Translation{
+	suite.mockStore.On("GetTranslationsByKey", mock.Anything, key, ns).Return(map[string]Translation{
 		"fr": {Key: key, Namespace: ns, Language: "fr", Value: "Mon Application"},
 	}, nil)
 
@@ -639,7 +642,7 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_AppNamespace
 	ns := testAppNamespace
 	key := "name"
 	// Only "fr" stored; "en" requested — best-match returns the only available value.
-	suite.mockStore.On("GetTranslationsByKey", key, ns).Return(map[string]Translation{
+	suite.mockStore.On("GetTranslationsByKey", mock.Anything, key, ns).Return(map[string]Translation{
 		"fr": {Key: key, Namespace: ns, Language: "fr", Value: "Mon Application"},
 	}, nil)
 
@@ -711,7 +714,8 @@ func (suite *I18nMgtServiceTestSuite) TestSetTranslationOverrides_Success() {
 		},
 	}
 
-	suite.mockStore.On("UpsertTranslationsByLanguage", "en-US", mock.AnythingOfType("[]mgt.Translation")).Return(nil)
+	suite.mockStore.On("UpsertTranslationsByLanguage", mock.Anything, "en-US",
+		mock.AnythingOfType("[]mgt.Translation")).Return(nil)
 
 	result, err := suite.service.SetTranslationOverrides(context.Background(), "en-US", translations)
 
@@ -761,7 +765,8 @@ func (suite *I18nMgtServiceTestSuite) TestSetTranslationOverrides_StoreError() {
 	translations := map[string]map[string]string{
 		"console": {"k": "v"},
 	}
-	suite.mockStore.On("UpsertTranslationsByLanguage", "en-US", mock.AnythingOfType("[]mgt.Translation")).
+	suite.mockStore.On("UpsertTranslationsByLanguage", mock.Anything, "en-US",
+		mock.AnythingOfType("[]mgt.Translation")).
 		Return(errors.New("db error"))
 
 	result, err := suite.service.SetTranslationOverrides(context.Background(), "en-US", translations)
@@ -790,7 +795,7 @@ func (suite *I18nMgtServiceTestSuite) TestSetTranslationOverrides_Declarative() 
 
 // ClearTranslationOverrides Tests
 func (suite *I18nMgtServiceTestSuite) TestClearTranslationOverrides_Success() {
-	suite.mockStore.On("DeleteTranslationsByLanguage", "en-US").Return(nil)
+	suite.mockStore.On("DeleteTranslationsByLanguage", mock.Anything, "en-US").Return(nil)
 
 	err := suite.service.ClearTranslationOverrides(context.Background(), "en-US")
 
@@ -798,7 +803,7 @@ func (suite *I18nMgtServiceTestSuite) TestClearTranslationOverrides_Success() {
 }
 
 func (suite *I18nMgtServiceTestSuite) TestClearTranslationOverrides_StoreError() {
-	suite.mockStore.On("DeleteTranslationsByLanguage", "en-US").Return(errors.New("db error"))
+	suite.mockStore.On("DeleteTranslationsByLanguage", mock.Anything, "en-US").Return(errors.New("db error"))
 
 	err := suite.service.ClearTranslationOverrides(context.Background(), "en-US")
 
@@ -840,7 +845,7 @@ func (suite *I18nMgtServiceTestSuite) TestGetTranslationsByNamespace_InvalidName
 }
 
 func (suite *I18nMgtServiceTestSuite) TestGetTranslationsByNamespace_StoreError() {
-	suite.mockStore.On("GetTranslationsByNamespace", "app-test").
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, "app-test").
 		Return(nil, errors.New("db error"))
 
 	result, err := suite.service.GetTranslationsByNamespace(context.Background(), "app-test")
@@ -861,7 +866,7 @@ func (suite *I18nMgtServiceTestSuite) TestGetTranslationsByNamespace_Success() {
 			"fr": {Key: "logo_uri", Namespace: ns, Language: "fr", Value: "https://example.com/fr/logo.png"},
 		},
 	}
-	suite.mockStore.On("GetTranslationsByNamespace", ns).Return(dbData, nil)
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, ns).Return(dbData, nil)
 
 	result, err := suite.service.GetTranslationsByNamespace(context.Background(), ns)
 
@@ -883,7 +888,7 @@ func (suite *I18nMgtServiceTestSuite) TestGetTranslationsByNamespace_SkipsMalfor
 			"en": {Key: "name", Namespace: ns, Language: "en", Value: "My App"},
 		},
 	}
-	suite.mockStore.On("GetTranslationsByNamespace", ns).Return(dbData, nil)
+	suite.mockStore.On("GetTranslationsByNamespace", mock.Anything, ns).Return(dbData, nil)
 
 	result, err := suite.service.GetTranslationsByNamespace(context.Background(), ns)
 

--- a/backend/internal/system/i18n/mgt/store.go
+++ b/backend/internal/system/i18n/mgt/store.go
@@ -14,15 +14,15 @@ import (
 
 // i18nStoreInterface defines the interface for i18n store operations.
 type i18nStoreInterface interface {
-	GetDistinctLanguages() ([]string, error)
-	GetTranslations() (map[string]map[string]Translation, error)
-	GetTranslationsByNamespace(namespace string) (map[string]map[string]Translation, error)
-	GetTranslationsByKey(key string, namespace string) (map[string]Translation, error)
-	UpsertTranslationsByLanguage(language string, translations []Translation) error
-	UpsertTranslation(trans Translation) error
+	GetDistinctLanguages(ctx context.Context) ([]string, error)
+	GetTranslations(ctx context.Context) (map[string]map[string]Translation, error)
+	GetTranslationsByNamespace(ctx context.Context, namespace string) (map[string]map[string]Translation, error)
+	GetTranslationsByKey(ctx context.Context, key string, namespace string) (map[string]Translation, error)
+	UpsertTranslationsByLanguage(ctx context.Context, language string, translations []Translation) error
+	UpsertTranslation(ctx context.Context, trans Translation) error
 	UpsertTranslations(ctx context.Context, translations []Translation) error
-	DeleteTranslationsByLanguage(language string) error
-	DeleteTranslation(language string, key string, namespace string) error
+	DeleteTranslationsByLanguage(ctx context.Context, language string) error
+	DeleteTranslation(ctx context.Context, language string, key string, namespace string) error
 	DeleteTranslationsByNamespace(ctx context.Context, namespace string) error
 	DeleteTranslationsByKey(ctx context.Context, namespace string, key string) error
 }
@@ -51,7 +51,7 @@ func (s *i18nStore) getDBClient() (provider.DBClientInterface, error) {
 }
 
 // GetDistinctLanguages retrieves all distinct language codes that have translations.
-func (s *i18nStore) GetDistinctLanguages() ([]string, error) {
+func (s *i18nStore) GetDistinctLanguages(ctx context.Context) ([]string, error) {
 	dbClient, err := s.getDBClient()
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (s *i18nStore) GetDistinctLanguages() ([]string, error) {
 
 // GetTranslations retrieves all translations.
 // This implements TranslationStoreInterface.
-func (s *i18nStore) GetTranslations() (map[string]map[string]Translation, error) {
+func (s *i18nStore) GetTranslations(ctx context.Context) (map[string]map[string]Translation, error) {
 	dbClient, err := s.getDBClient()
 	if err != nil {
 		return nil, err
@@ -92,7 +92,8 @@ func (s *i18nStore) GetTranslations() (map[string]map[string]Translation, error)
 
 // GetTranslations retrieves all translations of the given namespace.
 // This implements TranslationStoreInterface.
-func (s *i18nStore) GetTranslationsByNamespace(namespace string) (map[string]map[string]Translation, error) {
+func (s *i18nStore) GetTranslationsByNamespace(ctx context.Context,
+	namespace string) (map[string]map[string]Translation, error) {
 	dbClient, err := s.getDBClient()
 	if err != nil {
 		return nil, err
@@ -108,7 +109,8 @@ func (s *i18nStore) GetTranslationsByNamespace(namespace string) (map[string]map
 }
 
 // GetTranslationsByKey retrieves a single translation by key, and namespace.
-func (s *i18nStore) GetTranslationsByKey(key string, namespace string) (map[string]Translation, error) {
+func (s *i18nStore) GetTranslationsByKey(ctx context.Context, key string, namespace string) (map[string]Translation,
+	error) {
 	dbClient, err := s.getDBClient()
 	if err != nil {
 		return nil, err
@@ -123,7 +125,8 @@ func (s *i18nStore) GetTranslationsByKey(key string, namespace string) (map[stri
 }
 
 // InsertTranslation inserts a new translation.
-func (s *i18nStore) UpsertTranslationsByLanguage(language string, translations []Translation) error {
+func (s *i18nStore) UpsertTranslationsByLanguage(ctx context.Context, language string,
+	translations []Translation) error {
 	dbClient, err := s.getDBClient()
 	if err != nil {
 		return err
@@ -162,7 +165,7 @@ func (s *i18nStore) UpsertTranslationsByLanguage(language string, translations [
 
 // UpsertTranslation creates or updates a translation.
 // Used for bulk operations where we want to insert or update as needed.
-func (s *i18nStore) UpsertTranslation(trans Translation) error {
+func (s *i18nStore) UpsertTranslation(ctx context.Context, trans Translation) error {
 	dbClient, err := s.getDBClient()
 	if err != nil {
 		return err
@@ -195,7 +198,7 @@ func (s *i18nStore) UpsertTranslations(ctx context.Context, translations []Trans
 }
 
 // DeleteTranslation deletes a translation by language, key, and namespace.
-func (s *i18nStore) DeleteTranslation(language string, key string, namespace string) error {
+func (s *i18nStore) DeleteTranslation(ctx context.Context, language string, key string, namespace string) error {
 	dbClient, err := s.getDBClient()
 	if err != nil {
 		return err
@@ -209,7 +212,7 @@ func (s *i18nStore) DeleteTranslation(language string, key string, namespace str
 }
 
 // DeleteTranslationsByLanguage deletes all translations for the given language.
-func (s *i18nStore) DeleteTranslationsByLanguage(language string) error {
+func (s *i18nStore) DeleteTranslationsByLanguage(ctx context.Context, language string) error {
 	dbClient, err := s.getDBClient()
 	if err != nil {
 		return err

--- a/backend/internal/system/i18n/mgt/store_test.go
+++ b/backend/internal/system/i18n/mgt/store_test.go
@@ -64,7 +64,7 @@ func (suite *I18nStoreTestSuite) TestGetDistinctLanguages_Success() {
 		{"language_code": "fr-FR"},
 	}, nil)
 
-	langs, err := suite.store.GetDistinctLanguages()
+	langs, err := suite.store.GetDistinctLanguages(context.Background())
 
 	suite.NoError(err)
 	suite.Len(langs, 2)
@@ -76,7 +76,7 @@ func (suite *I18nStoreTestSuite) TestGetDistinctLanguages_QueryError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetDistinctLanguages, testDeploymentID).Return(nil, errors.New("db error"))
 
-	langs, err := suite.store.GetDistinctLanguages()
+	langs, err := suite.store.GetDistinctLanguages(context.Background())
 
 	suite.Error(err)
 	suite.Nil(langs)
@@ -91,7 +91,7 @@ func (suite *I18nStoreTestSuite) TestGetTranslations_Success() {
 		},
 	}, nil)
 
-	trans, err := suite.store.GetTranslations()
+	trans, err := suite.store.GetTranslations(context.Background())
 
 	suite.NoError(err)
 	suite.NotNil(trans)
@@ -108,7 +108,7 @@ func (suite *I18nStoreTestSuite) TestGetTranslationsByNamespace_Success() {
 			},
 		}, nil)
 
-	trans, err := suite.store.GetTranslationsByNamespace("ns1")
+	trans, err := suite.store.GetTranslationsByNamespace(context.Background(), "ns1")
 
 	suite.NoError(err)
 	suite.NotNil(trans)
@@ -124,7 +124,7 @@ func (suite *I18nStoreTestSuite) TestGetTranslationsByKey_Success() {
 		},
 	}, nil)
 
-	trans, err := suite.store.GetTranslationsByKey("k1", "ns1")
+	trans, err := suite.store.GetTranslationsByKey(context.Background(), "k1", "ns1")
 
 	suite.NoError(err)
 	suite.NotNil(trans)
@@ -136,7 +136,7 @@ func (suite *I18nStoreTestSuite) TestGetTranslationsByKey_NotFound() {
 	suite.mockDBClient.On("Query", queryGetTranslation, "k1", "ns1", testDeploymentID).
 		Return([]map[string]interface{}{}, nil)
 
-	trans, err := suite.store.GetTranslationsByKey("k1", "ns1")
+	trans, err := suite.store.GetTranslationsByKey(context.Background(), "k1", "ns1")
 	suite.NoError(err)
 	suite.NotNil(trans)
 	suite.Empty(trans)
@@ -150,7 +150,7 @@ func (suite *I18nStoreTestSuite) TestUpsertTranslation_Success() {
 	suite.mockDBClient.On("Execute", queryUpsertTranslation, "k", "en", "ns", "v", testDeploymentID).
 		Return(int64(1), nil)
 
-	err := suite.store.UpsertTranslation(translation)
+	err := suite.store.UpsertTranslation(context.Background(), translation)
 
 	suite.NoError(err)
 }
@@ -161,7 +161,7 @@ func (suite *I18nStoreTestSuite) TestDeleteTranslation_Success() {
 	suite.mockDBClient.On("Execute", queryDeleteTranslation, "en", "k", "ns", testDeploymentID).
 		Return(int64(1), nil)
 
-	err := suite.store.DeleteTranslation("en", "k", "ns")
+	err := suite.store.DeleteTranslation(context.Background(), "en", "k", "ns")
 
 	suite.NoError(err)
 }
@@ -172,7 +172,7 @@ func (suite *I18nStoreTestSuite) TestDeleteTranslationsByLanguage_Success() {
 	suite.mockDBClient.On("Execute", queryDeleteTranslationsByLanguage, "en", testDeploymentID).
 		Return(int64(1), nil)
 
-	err := suite.store.DeleteTranslationsByLanguage("en")
+	err := suite.store.DeleteTranslationsByLanguage(context.Background(), "en")
 
 	suite.NoError(err)
 }
@@ -196,7 +196,7 @@ func (suite *I18nStoreTestSuite) TestUpsertTranslationsByLanguage_Success() {
 
 	suite.mockTx.On("Commit").Return(nil)
 
-	err := suite.store.UpsertTranslationsByLanguage("en", translations)
+	err := suite.store.UpsertTranslationsByLanguage(context.Background(), "en", translations)
 
 	suite.NoError(err)
 }
@@ -217,7 +217,7 @@ func (suite *I18nStoreTestSuite) TestUpsertTranslationsByLanguage_RollbackOnInse
 
 	suite.mockTx.On("Rollback").Return(nil)
 
-	err := suite.store.UpsertTranslationsByLanguage("en", translations)
+	err := suite.store.UpsertTranslationsByLanguage(context.Background(), "en", translations)
 
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to insert translation")
@@ -228,7 +228,7 @@ func (suite *I18nStoreTestSuite) TestUpsertTranslationsByLanguage_BeginTxError()
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(nil, errors.New("begin error"))
 
-	err := suite.store.UpsertTranslationsByLanguage("l", translations)
+	err := suite.store.UpsertTranslationsByLanguage(context.Background(), "l", translations)
 
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to begin transaction")
@@ -242,7 +242,7 @@ func (suite *I18nStoreTestSuite) TestUpsertTranslationsByLanguage_DeleteError() 
 		Return(nil, errors.New("delete error"))
 	suite.mockTx.On("Rollback").Return(nil)
 
-	err := suite.store.UpsertTranslationsByLanguage("l", translations)
+	err := suite.store.UpsertTranslationsByLanguage(context.Background(), "l", translations)
 
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to delete translations")
@@ -256,7 +256,7 @@ func (suite *I18nStoreTestSuite) TestUpsertTranslationsByLanguage_RollbackError(
 		Return(nil, errors.New("delete error"))
 	suite.mockTx.On("Rollback").Return(errors.New("rollback error"))
 
-	err := suite.store.UpsertTranslationsByLanguage("l", translations)
+	err := suite.store.UpsertTranslationsByLanguage(context.Background(), "l", translations)
 
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to delete translations")
@@ -275,7 +275,7 @@ func (suite *I18nStoreTestSuite) TestUpsertTranslationsByLanguage_CommitError() 
 		Return(&mockResult{}, nil)
 	suite.mockTx.On("Commit").Return(errors.New("commit error"))
 
-	err := suite.store.UpsertTranslationsByLanguage("l", translations)
+	err := suite.store.UpsertTranslationsByLanguage(context.Background(), "l", translations)
 
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to commit transaction")
@@ -287,7 +287,7 @@ func (suite *I18nStoreTestSuite) TestUpsertTranslation_Error() {
 	suite.mockDBClient.On("Execute", queryUpsertTranslation, "k", "en", "ns", "v", testDeploymentID).
 		Return(int64(0), errors.New("exec error"))
 
-	err := suite.store.UpsertTranslation(translation)
+	err := suite.store.UpsertTranslation(context.Background(), translation)
 
 	suite.Error(err)
 }
@@ -297,7 +297,7 @@ func (suite *I18nStoreTestSuite) TestDeleteTranslation_Error() {
 	suite.mockDBClient.On("Execute", queryDeleteTranslation, "en", "k", "ns", testDeploymentID).
 		Return(int64(0), errors.New("exec error"))
 
-	err := suite.store.DeleteTranslation("en", "k", "ns")
+	err := suite.store.DeleteTranslation(context.Background(), "en", "k", "ns")
 
 	suite.Error(err)
 }
@@ -307,7 +307,7 @@ func (suite *I18nStoreTestSuite) TestDeleteTranslationsByLanguage_Error() {
 	suite.mockDBClient.On("Execute", queryDeleteTranslationsByLanguage, "en", testDeploymentID).
 		Return(int64(0), errors.New("exec error"))
 
-	err := suite.store.DeleteTranslationsByLanguage("en")
+	err := suite.store.DeleteTranslationsByLanguage(context.Background(), "en")
 
 	suite.Error(err)
 }
@@ -317,7 +317,7 @@ func (suite *I18nStoreTestSuite) TestGetTranslations_QueryError() {
 	suite.mockDBClient.On("Query", queryGetTranslations, testDeploymentID).
 		Return(nil, errors.New("query error"))
 
-	result, err := suite.store.GetTranslations()
+	result, err := suite.store.GetTranslations(context.Background())
 
 	suite.Nil(result)
 	suite.Error(err)
@@ -328,7 +328,7 @@ func (suite *I18nStoreTestSuite) TestGetTranslationsByNamespace_QueryError() {
 	suite.mockDBClient.On("Query", queryGetTranslationsByNamespace, "ns", testDeploymentID).
 		Return(nil, errors.New("query error"))
 
-	result, err := suite.store.GetTranslationsByNamespace("ns")
+	result, err := suite.store.GetTranslationsByNamespace(context.Background(), "ns")
 
 	suite.Nil(result)
 	suite.Error(err)
@@ -339,7 +339,7 @@ func (suite *I18nStoreTestSuite) TestGetTranslationsByKey_QueryError() {
 	suite.mockDBClient.On("Query", queryGetTranslation, "k", "ns", testDeploymentID).
 		Return(nil, errors.New("query error"))
 
-	result, err := suite.store.GetTranslationsByKey("k", "ns")
+	result, err := suite.store.GetTranslationsByKey(context.Background(), "k", "ns")
 
 	suite.Nil(result)
 	suite.Error(err)
@@ -378,7 +378,7 @@ func (suite *I18nStoreTestSuite) TestGetTranslations_ParsingError() {
 		{"message_key": 123}, // Invalid type
 	}, nil)
 
-	result, err := suite.store.GetTranslations()
+	result, err := suite.store.GetTranslations(context.Background())
 
 	suite.Nil(result)
 	suite.Error(err)
@@ -390,7 +390,7 @@ func (suite *I18nStoreTestSuite) TestGetTranslationsByKey_ParsingError() {
 		{"message_key": 123}, // Invalid type
 	}, nil)
 
-	result, err := suite.store.GetTranslationsByKey("k", "ns")
+	result, err := suite.store.GetTranslationsByKey(context.Background(), "k", "ns")
 
 	suite.Nil(result)
 	suite.Error(err)
@@ -402,7 +402,7 @@ func (suite *I18nStoreTestSuite) TestGetDistinctLanguages_ParsingError() {
 		{"language_code": 123}, // Invalid type
 	}, nil)
 
-	result, err := suite.store.GetDistinctLanguages()
+	result, err := suite.store.GetDistinctLanguages(context.Background())
 
 	suite.Nil(result)
 	suite.Error(err)
@@ -413,35 +413,35 @@ func (suite *I18nStoreTestSuite) TestGetDBClient_Error() {
 
 	var err error
 
-	_, err = suite.store.GetDistinctLanguages()
+	_, err = suite.store.GetDistinctLanguages(context.Background())
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to get database client")
 
-	_, err = suite.store.GetTranslations()
+	_, err = suite.store.GetTranslations(context.Background())
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to get database client")
 
-	_, err = suite.store.GetTranslationsByNamespace("ns")
+	_, err = suite.store.GetTranslationsByNamespace(context.Background(), "ns")
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to get database client")
 
-	_, err = suite.store.GetTranslationsByKey("k", "ns")
+	_, err = suite.store.GetTranslationsByKey(context.Background(), "k", "ns")
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to get database client")
 
-	err = suite.store.UpsertTranslationsByLanguage("en", nil)
+	err = suite.store.UpsertTranslationsByLanguage(context.Background(), "en", nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to get database client")
 
-	err = suite.store.UpsertTranslation(Translation{})
+	err = suite.store.UpsertTranslation(context.Background(), Translation{})
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to get database client")
 
-	err = suite.store.DeleteTranslation("en", "k", "ns")
+	err = suite.store.DeleteTranslation(context.Background(), "en", "k", "ns")
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to get database client")
 
-	err = suite.store.DeleteTranslationsByLanguage("en")
+	err = suite.store.DeleteTranslationsByLanguage(context.Background(), "en")
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to get database client")
 

--- a/backend/tests/mocks/design/layoutmock/layoutMgtStoreInterface_mock.go
+++ b/backend/tests/mocks/design/layoutmock/layoutMgtStoreInterface_mock.go
@@ -5,6 +5,8 @@
 package layoutmock
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/design/layout/mgt"
 )
@@ -37,16 +39,16 @@ func (_m *layoutMgtStoreInterfaceMock) EXPECT() *layoutMgtStoreInterfaceMock_Exp
 }
 
 // CreateLayout provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) CreateLayout(id string, layout layoutmgt.CreateLayoutRequest) error {
-	ret := _mock.Called(id, layout)
+func (_mock *layoutMgtStoreInterfaceMock) CreateLayout(ctx context.Context, id string, layout layoutmgt.CreateLayoutRequest) error {
+	ret := _mock.Called(ctx, id, layout)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateLayout")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, layoutmgt.CreateLayoutRequest) error); ok {
-		r0 = returnFunc(id, layout)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, layoutmgt.CreateLayoutRequest) error); ok {
+		r0 = returnFunc(ctx, id, layout)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -59,25 +61,31 @@ type layoutMgtStoreInterfaceMock_CreateLayout_Call struct {
 }
 
 // CreateLayout is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - layout layoutmgt.CreateLayoutRequest
-func (_e *layoutMgtStoreInterfaceMock_Expecter) CreateLayout(id interface{}, layout interface{}) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
-	return &layoutMgtStoreInterfaceMock_CreateLayout_Call{Call: _e.mock.On("CreateLayout", id, layout)}
+func (_e *layoutMgtStoreInterfaceMock_Expecter) CreateLayout(ctx interface{}, id interface{}, layout interface{}) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
+	return &layoutMgtStoreInterfaceMock_CreateLayout_Call{Call: _e.mock.On("CreateLayout", ctx, id, layout)}
 }
 
-func (_c *layoutMgtStoreInterfaceMock_CreateLayout_Call) Run(run func(id string, layout layoutmgt.CreateLayoutRequest)) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
+func (_c *layoutMgtStoreInterfaceMock_CreateLayout_Call) Run(run func(ctx context.Context, id string, layout layoutmgt.CreateLayoutRequest)) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 layoutmgt.CreateLayoutRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(layoutmgt.CreateLayoutRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 layoutmgt.CreateLayoutRequest
+		if args[2] != nil {
+			arg2 = args[2].(layoutmgt.CreateLayoutRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -88,22 +96,22 @@ func (_c *layoutMgtStoreInterfaceMock_CreateLayout_Call) Return(err error) *layo
 	return _c
 }
 
-func (_c *layoutMgtStoreInterfaceMock_CreateLayout_Call) RunAndReturn(run func(id string, layout layoutmgt.CreateLayoutRequest) error) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
+func (_c *layoutMgtStoreInterfaceMock_CreateLayout_Call) RunAndReturn(run func(ctx context.Context, id string, layout layoutmgt.CreateLayoutRequest) error) *layoutMgtStoreInterfaceMock_CreateLayout_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteLayout provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) DeleteLayout(id string) error {
-	ret := _mock.Called(id)
+func (_mock *layoutMgtStoreInterfaceMock) DeleteLayout(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteLayout")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -116,369 +124,17 @@ type layoutMgtStoreInterfaceMock_DeleteLayout_Call struct {
 }
 
 // DeleteLayout is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *layoutMgtStoreInterfaceMock_Expecter) DeleteLayout(id interface{}) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
-	return &layoutMgtStoreInterfaceMock_DeleteLayout_Call{Call: _e.mock.On("DeleteLayout", id)}
+func (_e *layoutMgtStoreInterfaceMock_Expecter) DeleteLayout(ctx interface{}, id interface{}) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
+	return &layoutMgtStoreInterfaceMock_DeleteLayout_Call{Call: _e.mock.On("DeleteLayout", ctx, id)}
 }
 
-func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) Run(run func(id string)) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
+func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) Run(run func(ctx context.Context, id string)) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) Return(err error) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) RunAndReturn(run func(id string) error) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetLayout provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) GetLayout(id string) (layoutmgt.Layout, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetLayout")
-	}
-
-	var r0 layoutmgt.Layout
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (layoutmgt.Layout, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) layoutmgt.Layout); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(layoutmgt.Layout)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// layoutMgtStoreInterfaceMock_GetLayout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayout'
-type layoutMgtStoreInterfaceMock_GetLayout_Call struct {
-	*mock.Call
-}
-
-// GetLayout is a helper method to define mock.On call
-//   - id string
-func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayout(id interface{}) *layoutMgtStoreInterfaceMock_GetLayout_Call {
-	return &layoutMgtStoreInterfaceMock_GetLayout_Call{Call: _e.mock.On("GetLayout", id)}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) Run(run func(id string)) *layoutMgtStoreInterfaceMock_GetLayout_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) Return(layout layoutmgt.Layout, err error) *layoutMgtStoreInterfaceMock_GetLayout_Call {
-	_c.Call.Return(layout, err)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) RunAndReturn(run func(id string) (layoutmgt.Layout, error)) *layoutMgtStoreInterfaceMock_GetLayout_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetLayoutList provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) GetLayoutList(limit int, offset int) ([]layoutmgt.Layout, error) {
-	ret := _mock.Called(limit, offset)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetLayoutList")
-	}
-
-	var r0 []layoutmgt.Layout
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]layoutmgt.Layout, error)); ok {
-		return returnFunc(limit, offset)
-	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []layoutmgt.Layout); ok {
-		r0 = returnFunc(limit, offset)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]layoutmgt.Layout)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(limit, offset)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// layoutMgtStoreInterfaceMock_GetLayoutList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayoutList'
-type layoutMgtStoreInterfaceMock_GetLayoutList_Call struct {
-	*mock.Call
-}
-
-// GetLayoutList is a helper method to define mock.On call
-//   - limit int
-//   - offset int
-func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayoutList(limit interface{}, offset interface{}) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
-	return &layoutMgtStoreInterfaceMock_GetLayoutList_Call{Call: _e.mock.On("GetLayoutList", limit, offset)}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) Run(run func(limit int, offset int)) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
-		if args[0] != nil {
-			arg0 = args[0].(int)
-		}
-		var arg1 int
-		if args[1] != nil {
-			arg1 = args[1].(int)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) Return(layouts []layoutmgt.Layout, err error) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
-	_c.Call.Return(layouts, err)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) RunAndReturn(run func(limit int, offset int) ([]layoutmgt.Layout, error)) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetLayoutListCount provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) GetLayoutListCount() (int, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetLayoutListCount")
-	}
-
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// layoutMgtStoreInterfaceMock_GetLayoutListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayoutListCount'
-type layoutMgtStoreInterfaceMock_GetLayoutListCount_Call struct {
-	*mock.Call
-}
-
-// GetLayoutListCount is a helper method to define mock.On call
-func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayoutListCount() *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
-	return &layoutMgtStoreInterfaceMock_GetLayoutListCount_Call{Call: _e.mock.On("GetLayoutListCount")}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) Run(run func()) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) Return(n int, err error) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) RunAndReturn(run func() (int, error)) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsLayoutDeclarative provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) IsLayoutDeclarative(id string) bool {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsLayoutDeclarative")
-	}
-
-	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	return r0
-}
-
-// layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutDeclarative'
-type layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call struct {
-	*mock.Call
-}
-
-// IsLayoutDeclarative is a helper method to define mock.On call
-//   - id string
-func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutDeclarative(id interface{}) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
-	return &layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call{Call: _e.mock.On("IsLayoutDeclarative", id)}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) Run(run func(id string)) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) Return(b bool) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
-	_c.Call.Return(b)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) RunAndReturn(run func(id string) bool) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsLayoutExist provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) IsLayoutExist(id string) (bool, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsLayoutExist")
-	}
-
-	var r0 bool
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// layoutMgtStoreInterfaceMock_IsLayoutExist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutExist'
-type layoutMgtStoreInterfaceMock_IsLayoutExist_Call struct {
-	*mock.Call
-}
-
-// IsLayoutExist is a helper method to define mock.On call
-//   - id string
-func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutExist(id interface{}) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
-	return &layoutMgtStoreInterfaceMock_IsLayoutExist_Call{Call: _e.mock.On("IsLayoutExist", id)}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) Run(run func(id string)) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) Return(b bool, err error) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
-	_c.Call.Return(b, err)
-	return _c
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) RunAndReturn(run func(id string) (bool, error)) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsLayoutHandleConflict provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) IsLayoutHandleConflict(handle string, excludeID string) (bool, error) {
-	ret := _mock.Called(handle, excludeID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsLayoutHandleConflict")
-	}
-
-	var r0 bool
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (bool, error)); ok {
-		return returnFunc(handle, excludeID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) bool); ok {
-		r0 = returnFunc(handle, excludeID)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = returnFunc(handle, excludeID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutHandleConflict'
-type layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call struct {
-	*mock.Call
-}
-
-// IsLayoutHandleConflict is a helper method to define mock.On call
-//   - handle string
-//   - excludeID string
-func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutHandleConflict(handle interface{}, excludeID interface{}) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
-	return &layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call{Call: _e.mock.On("IsLayoutHandleConflict", handle, excludeID)}
-}
-
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) Run(run func(handle string, excludeID string)) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -492,27 +148,422 @@ func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) Run(run func(
 	return _c
 }
 
+func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) Return(err error) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_DeleteLayout_Call) RunAndReturn(run func(ctx context.Context, id string) error) *layoutMgtStoreInterfaceMock_DeleteLayout_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLayout provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) GetLayout(ctx context.Context, id string) (layoutmgt.Layout, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLayout")
+	}
+
+	var r0 layoutmgt.Layout
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (layoutmgt.Layout, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) layoutmgt.Layout); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(layoutmgt.Layout)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// layoutMgtStoreInterfaceMock_GetLayout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayout'
+type layoutMgtStoreInterfaceMock_GetLayout_Call struct {
+	*mock.Call
+}
+
+// GetLayout is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayout(ctx interface{}, id interface{}) *layoutMgtStoreInterfaceMock_GetLayout_Call {
+	return &layoutMgtStoreInterfaceMock_GetLayout_Call{Call: _e.mock.On("GetLayout", ctx, id)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) Run(run func(ctx context.Context, id string)) *layoutMgtStoreInterfaceMock_GetLayout_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) Return(layout layoutmgt.Layout, err error) *layoutMgtStoreInterfaceMock_GetLayout_Call {
+	_c.Call.Return(layout, err)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayout_Call) RunAndReturn(run func(ctx context.Context, id string) (layoutmgt.Layout, error)) *layoutMgtStoreInterfaceMock_GetLayout_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLayoutList provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) GetLayoutList(ctx context.Context, limit int, offset int) ([]layoutmgt.Layout, error) {
+	ret := _mock.Called(ctx, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLayoutList")
+	}
+
+	var r0 []layoutmgt.Layout
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]layoutmgt.Layout, error)); ok {
+		return returnFunc(ctx, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []layoutmgt.Layout); ok {
+		r0 = returnFunc(ctx, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]layoutmgt.Layout)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// layoutMgtStoreInterfaceMock_GetLayoutList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayoutList'
+type layoutMgtStoreInterfaceMock_GetLayoutList_Call struct {
+	*mock.Call
+}
+
+// GetLayoutList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - limit int
+//   - offset int
+func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayoutList(ctx interface{}, limit interface{}, offset interface{}) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
+	return &layoutMgtStoreInterfaceMock_GetLayoutList_Call{Call: _e.mock.On("GetLayoutList", ctx, limit, offset)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) Run(run func(ctx context.Context, limit int, offset int)) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) Return(layouts []layoutmgt.Layout, err error) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
+	_c.Call.Return(layouts, err)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]layoutmgt.Layout, error)) *layoutMgtStoreInterfaceMock_GetLayoutList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLayoutListCount provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) GetLayoutListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLayoutListCount")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// layoutMgtStoreInterfaceMock_GetLayoutListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLayoutListCount'
+type layoutMgtStoreInterfaceMock_GetLayoutListCount_Call struct {
+	*mock.Call
+}
+
+// GetLayoutListCount is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *layoutMgtStoreInterfaceMock_Expecter) GetLayoutListCount(ctx interface{}) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
+	return &layoutMgtStoreInterfaceMock_GetLayoutListCount_Call{Call: _e.mock.On("GetLayoutListCount", ctx)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) Run(run func(ctx context.Context)) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) Return(n int, err error) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *layoutMgtStoreInterfaceMock_GetLayoutListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsLayoutDeclarative provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) IsLayoutDeclarative(ctx context.Context, id string) bool {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsLayoutDeclarative")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutDeclarative'
+type layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call struct {
+	*mock.Call
+}
+
+// IsLayoutDeclarative is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutDeclarative(ctx interface{}, id interface{}) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
+	return &layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call{Call: _e.mock.On("IsLayoutDeclarative", ctx, id)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) Run(run func(ctx context.Context, id string)) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) Return(b bool) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call) RunAndReturn(run func(ctx context.Context, id string) bool) *layoutMgtStoreInterfaceMock_IsLayoutDeclarative_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsLayoutExist provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) IsLayoutExist(ctx context.Context, id string) (bool, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsLayoutExist")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// layoutMgtStoreInterfaceMock_IsLayoutExist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutExist'
+type layoutMgtStoreInterfaceMock_IsLayoutExist_Call struct {
+	*mock.Call
+}
+
+// IsLayoutExist is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutExist(ctx interface{}, id interface{}) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
+	return &layoutMgtStoreInterfaceMock_IsLayoutExist_Call{Call: _e.mock.On("IsLayoutExist", ctx, id)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) Run(run func(ctx context.Context, id string)) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) Return(b bool, err error) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutExist_Call) RunAndReturn(run func(ctx context.Context, id string) (bool, error)) *layoutMgtStoreInterfaceMock_IsLayoutExist_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsLayoutHandleConflict provides a mock function for the type layoutMgtStoreInterfaceMock
+func (_mock *layoutMgtStoreInterfaceMock) IsLayoutHandleConflict(ctx context.Context, handle string, excludeID string) (bool, error) {
+	ret := _mock.Called(ctx, handle, excludeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsLayoutHandleConflict")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (bool, error)); ok {
+		return returnFunc(ctx, handle, excludeID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = returnFunc(ctx, handle, excludeID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, handle, excludeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLayoutHandleConflict'
+type layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call struct {
+	*mock.Call
+}
+
+// IsLayoutHandleConflict is a helper method to define mock.On call
+//   - ctx context.Context
+//   - handle string
+//   - excludeID string
+func (_e *layoutMgtStoreInterfaceMock_Expecter) IsLayoutHandleConflict(ctx interface{}, handle interface{}, excludeID interface{}) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
+	return &layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call{Call: _e.mock.On("IsLayoutHandleConflict", ctx, handle, excludeID)}
+}
+
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) Run(run func(ctx context.Context, handle string, excludeID string)) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
 func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) Return(b bool, err error) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
 	_c.Call.Return(b, err)
 	return _c
 }
 
-func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) RunAndReturn(run func(handle string, excludeID string) (bool, error)) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
+func (_c *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call) RunAndReturn(run func(ctx context.Context, handle string, excludeID string) (bool, error)) *layoutMgtStoreInterfaceMock_IsLayoutHandleConflict_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateLayout provides a mock function for the type layoutMgtStoreInterfaceMock
-func (_mock *layoutMgtStoreInterfaceMock) UpdateLayout(id string, layout layoutmgt.UpdateLayoutRequest) error {
-	ret := _mock.Called(id, layout)
+func (_mock *layoutMgtStoreInterfaceMock) UpdateLayout(ctx context.Context, id string, layout layoutmgt.UpdateLayoutRequest) error {
+	ret := _mock.Called(ctx, id, layout)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateLayout")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, layoutmgt.UpdateLayoutRequest) error); ok {
-		r0 = returnFunc(id, layout)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, layoutmgt.UpdateLayoutRequest) error); ok {
+		r0 = returnFunc(ctx, id, layout)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -525,25 +576,31 @@ type layoutMgtStoreInterfaceMock_UpdateLayout_Call struct {
 }
 
 // UpdateLayout is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - layout layoutmgt.UpdateLayoutRequest
-func (_e *layoutMgtStoreInterfaceMock_Expecter) UpdateLayout(id interface{}, layout interface{}) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
-	return &layoutMgtStoreInterfaceMock_UpdateLayout_Call{Call: _e.mock.On("UpdateLayout", id, layout)}
+func (_e *layoutMgtStoreInterfaceMock_Expecter) UpdateLayout(ctx interface{}, id interface{}, layout interface{}) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
+	return &layoutMgtStoreInterfaceMock_UpdateLayout_Call{Call: _e.mock.On("UpdateLayout", ctx, id, layout)}
 }
 
-func (_c *layoutMgtStoreInterfaceMock_UpdateLayout_Call) Run(run func(id string, layout layoutmgt.UpdateLayoutRequest)) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
+func (_c *layoutMgtStoreInterfaceMock_UpdateLayout_Call) Run(run func(ctx context.Context, id string, layout layoutmgt.UpdateLayoutRequest)) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 layoutmgt.UpdateLayoutRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(layoutmgt.UpdateLayoutRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 layoutmgt.UpdateLayoutRequest
+		if args[2] != nil {
+			arg2 = args[2].(layoutmgt.UpdateLayoutRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -554,7 +611,7 @@ func (_c *layoutMgtStoreInterfaceMock_UpdateLayout_Call) Return(err error) *layo
 	return _c
 }
 
-func (_c *layoutMgtStoreInterfaceMock_UpdateLayout_Call) RunAndReturn(run func(id string, layout layoutmgt.UpdateLayoutRequest) error) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
+func (_c *layoutMgtStoreInterfaceMock_UpdateLayout_Call) RunAndReturn(run func(ctx context.Context, id string, layout layoutmgt.UpdateLayoutRequest) error) *layoutMgtStoreInterfaceMock_UpdateLayout_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/design/thememock/themeMgtStoreInterface_mock.go
+++ b/backend/tests/mocks/design/thememock/themeMgtStoreInterface_mock.go
@@ -5,6 +5,8 @@
 package thememock
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/design/theme/mgt"
 )
@@ -37,16 +39,16 @@ func (_m *themeMgtStoreInterfaceMock) EXPECT() *themeMgtStoreInterfaceMock_Expec
 }
 
 // CreateTheme provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) CreateTheme(id string, theme thememgt.CreateThemeRequest) error {
-	ret := _mock.Called(id, theme)
+func (_mock *themeMgtStoreInterfaceMock) CreateTheme(ctx context.Context, id string, theme thememgt.CreateThemeRequest) error {
+	ret := _mock.Called(ctx, id, theme)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateTheme")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, thememgt.CreateThemeRequest) error); ok {
-		r0 = returnFunc(id, theme)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, thememgt.CreateThemeRequest) error); ok {
+		r0 = returnFunc(ctx, id, theme)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -59,25 +61,31 @@ type themeMgtStoreInterfaceMock_CreateTheme_Call struct {
 }
 
 // CreateTheme is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - theme thememgt.CreateThemeRequest
-func (_e *themeMgtStoreInterfaceMock_Expecter) CreateTheme(id interface{}, theme interface{}) *themeMgtStoreInterfaceMock_CreateTheme_Call {
-	return &themeMgtStoreInterfaceMock_CreateTheme_Call{Call: _e.mock.On("CreateTheme", id, theme)}
+func (_e *themeMgtStoreInterfaceMock_Expecter) CreateTheme(ctx interface{}, id interface{}, theme interface{}) *themeMgtStoreInterfaceMock_CreateTheme_Call {
+	return &themeMgtStoreInterfaceMock_CreateTheme_Call{Call: _e.mock.On("CreateTheme", ctx, id, theme)}
 }
 
-func (_c *themeMgtStoreInterfaceMock_CreateTheme_Call) Run(run func(id string, theme thememgt.CreateThemeRequest)) *themeMgtStoreInterfaceMock_CreateTheme_Call {
+func (_c *themeMgtStoreInterfaceMock_CreateTheme_Call) Run(run func(ctx context.Context, id string, theme thememgt.CreateThemeRequest)) *themeMgtStoreInterfaceMock_CreateTheme_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 thememgt.CreateThemeRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(thememgt.CreateThemeRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 thememgt.CreateThemeRequest
+		if args[2] != nil {
+			arg2 = args[2].(thememgt.CreateThemeRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -88,22 +96,22 @@ func (_c *themeMgtStoreInterfaceMock_CreateTheme_Call) Return(err error) *themeM
 	return _c
 }
 
-func (_c *themeMgtStoreInterfaceMock_CreateTheme_Call) RunAndReturn(run func(id string, theme thememgt.CreateThemeRequest) error) *themeMgtStoreInterfaceMock_CreateTheme_Call {
+func (_c *themeMgtStoreInterfaceMock_CreateTheme_Call) RunAndReturn(run func(ctx context.Context, id string, theme thememgt.CreateThemeRequest) error) *themeMgtStoreInterfaceMock_CreateTheme_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteTheme provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) DeleteTheme(id string) error {
-	ret := _mock.Called(id)
+func (_mock *themeMgtStoreInterfaceMock) DeleteTheme(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteTheme")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -116,369 +124,17 @@ type themeMgtStoreInterfaceMock_DeleteTheme_Call struct {
 }
 
 // DeleteTheme is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *themeMgtStoreInterfaceMock_Expecter) DeleteTheme(id interface{}) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
-	return &themeMgtStoreInterfaceMock_DeleteTheme_Call{Call: _e.mock.On("DeleteTheme", id)}
+func (_e *themeMgtStoreInterfaceMock_Expecter) DeleteTheme(ctx interface{}, id interface{}) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
+	return &themeMgtStoreInterfaceMock_DeleteTheme_Call{Call: _e.mock.On("DeleteTheme", ctx, id)}
 }
 
-func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) Run(run func(id string)) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
+func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) Run(run func(ctx context.Context, id string)) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) Return(err error) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) RunAndReturn(run func(id string) error) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetTheme provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) GetTheme(id string) (thememgt.Theme, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetTheme")
-	}
-
-	var r0 thememgt.Theme
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (thememgt.Theme, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) thememgt.Theme); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(thememgt.Theme)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// themeMgtStoreInterfaceMock_GetTheme_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTheme'
-type themeMgtStoreInterfaceMock_GetTheme_Call struct {
-	*mock.Call
-}
-
-// GetTheme is a helper method to define mock.On call
-//   - id string
-func (_e *themeMgtStoreInterfaceMock_Expecter) GetTheme(id interface{}) *themeMgtStoreInterfaceMock_GetTheme_Call {
-	return &themeMgtStoreInterfaceMock_GetTheme_Call{Call: _e.mock.On("GetTheme", id)}
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) Run(run func(id string)) *themeMgtStoreInterfaceMock_GetTheme_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) Return(theme thememgt.Theme, err error) *themeMgtStoreInterfaceMock_GetTheme_Call {
-	_c.Call.Return(theme, err)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) RunAndReturn(run func(id string) (thememgt.Theme, error)) *themeMgtStoreInterfaceMock_GetTheme_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetThemeList provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) GetThemeList(limit int, offset int) ([]thememgt.Theme, error) {
-	ret := _mock.Called(limit, offset)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetThemeList")
-	}
-
-	var r0 []thememgt.Theme
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]thememgt.Theme, error)); ok {
-		return returnFunc(limit, offset)
-	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []thememgt.Theme); ok {
-		r0 = returnFunc(limit, offset)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]thememgt.Theme)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(limit, offset)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// themeMgtStoreInterfaceMock_GetThemeList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetThemeList'
-type themeMgtStoreInterfaceMock_GetThemeList_Call struct {
-	*mock.Call
-}
-
-// GetThemeList is a helper method to define mock.On call
-//   - limit int
-//   - offset int
-func (_e *themeMgtStoreInterfaceMock_Expecter) GetThemeList(limit interface{}, offset interface{}) *themeMgtStoreInterfaceMock_GetThemeList_Call {
-	return &themeMgtStoreInterfaceMock_GetThemeList_Call{Call: _e.mock.On("GetThemeList", limit, offset)}
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) Run(run func(limit int, offset int)) *themeMgtStoreInterfaceMock_GetThemeList_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
-		if args[0] != nil {
-			arg0 = args[0].(int)
-		}
-		var arg1 int
-		if args[1] != nil {
-			arg1 = args[1].(int)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) Return(themes []thememgt.Theme, err error) *themeMgtStoreInterfaceMock_GetThemeList_Call {
-	_c.Call.Return(themes, err)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) RunAndReturn(run func(limit int, offset int) ([]thememgt.Theme, error)) *themeMgtStoreInterfaceMock_GetThemeList_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetThemeListCount provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) GetThemeListCount() (int, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetThemeListCount")
-	}
-
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// themeMgtStoreInterfaceMock_GetThemeListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetThemeListCount'
-type themeMgtStoreInterfaceMock_GetThemeListCount_Call struct {
-	*mock.Call
-}
-
-// GetThemeListCount is a helper method to define mock.On call
-func (_e *themeMgtStoreInterfaceMock_Expecter) GetThemeListCount() *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
-	return &themeMgtStoreInterfaceMock_GetThemeListCount_Call{Call: _e.mock.On("GetThemeListCount")}
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) Run(run func()) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) Return(n int, err error) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) RunAndReturn(run func() (int, error)) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsThemeDeclarative provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) IsThemeDeclarative(id string) bool {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsThemeDeclarative")
-	}
-
-	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	return r0
-}
-
-// themeMgtStoreInterfaceMock_IsThemeDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeDeclarative'
-type themeMgtStoreInterfaceMock_IsThemeDeclarative_Call struct {
-	*mock.Call
-}
-
-// IsThemeDeclarative is a helper method to define mock.On call
-//   - id string
-func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeDeclarative(id interface{}) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
-	return &themeMgtStoreInterfaceMock_IsThemeDeclarative_Call{Call: _e.mock.On("IsThemeDeclarative", id)}
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) Run(run func(id string)) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) Return(b bool) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
-	_c.Call.Return(b)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) RunAndReturn(run func(id string) bool) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsThemeExist provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) IsThemeExist(id string) (bool, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsThemeExist")
-	}
-
-	var r0 bool
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// themeMgtStoreInterfaceMock_IsThemeExist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeExist'
-type themeMgtStoreInterfaceMock_IsThemeExist_Call struct {
-	*mock.Call
-}
-
-// IsThemeExist is a helper method to define mock.On call
-//   - id string
-func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeExist(id interface{}) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
-	return &themeMgtStoreInterfaceMock_IsThemeExist_Call{Call: _e.mock.On("IsThemeExist", id)}
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) Run(run func(id string)) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) Return(b bool, err error) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
-	_c.Call.Return(b, err)
-	return _c
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) RunAndReturn(run func(id string) (bool, error)) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsThemeHandleConflict provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) IsThemeHandleConflict(handle string, excludeID string) (bool, error) {
-	ret := _mock.Called(handle, excludeID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsThemeHandleConflict")
-	}
-
-	var r0 bool
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (bool, error)); ok {
-		return returnFunc(handle, excludeID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) bool); ok {
-		r0 = returnFunc(handle, excludeID)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = returnFunc(handle, excludeID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeHandleConflict'
-type themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call struct {
-	*mock.Call
-}
-
-// IsThemeHandleConflict is a helper method to define mock.On call
-//   - handle string
-//   - excludeID string
-func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeHandleConflict(handle interface{}, excludeID interface{}) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
-	return &themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call{Call: _e.mock.On("IsThemeHandleConflict", handle, excludeID)}
-}
-
-func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) Run(run func(handle string, excludeID string)) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -492,27 +148,422 @@ func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) Run(run func(ha
 	return _c
 }
 
+func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) Return(err error) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_DeleteTheme_Call) RunAndReturn(run func(ctx context.Context, id string) error) *themeMgtStoreInterfaceMock_DeleteTheme_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTheme provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) GetTheme(ctx context.Context, id string) (thememgt.Theme, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTheme")
+	}
+
+	var r0 thememgt.Theme
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (thememgt.Theme, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) thememgt.Theme); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(thememgt.Theme)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// themeMgtStoreInterfaceMock_GetTheme_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTheme'
+type themeMgtStoreInterfaceMock_GetTheme_Call struct {
+	*mock.Call
+}
+
+// GetTheme is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *themeMgtStoreInterfaceMock_Expecter) GetTheme(ctx interface{}, id interface{}) *themeMgtStoreInterfaceMock_GetTheme_Call {
+	return &themeMgtStoreInterfaceMock_GetTheme_Call{Call: _e.mock.On("GetTheme", ctx, id)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) Run(run func(ctx context.Context, id string)) *themeMgtStoreInterfaceMock_GetTheme_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) Return(theme thememgt.Theme, err error) *themeMgtStoreInterfaceMock_GetTheme_Call {
+	_c.Call.Return(theme, err)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetTheme_Call) RunAndReturn(run func(ctx context.Context, id string) (thememgt.Theme, error)) *themeMgtStoreInterfaceMock_GetTheme_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetThemeList provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) GetThemeList(ctx context.Context, limit int, offset int) ([]thememgt.Theme, error) {
+	ret := _mock.Called(ctx, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetThemeList")
+	}
+
+	var r0 []thememgt.Theme
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]thememgt.Theme, error)); ok {
+		return returnFunc(ctx, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []thememgt.Theme); ok {
+		r0 = returnFunc(ctx, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]thememgt.Theme)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// themeMgtStoreInterfaceMock_GetThemeList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetThemeList'
+type themeMgtStoreInterfaceMock_GetThemeList_Call struct {
+	*mock.Call
+}
+
+// GetThemeList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - limit int
+//   - offset int
+func (_e *themeMgtStoreInterfaceMock_Expecter) GetThemeList(ctx interface{}, limit interface{}, offset interface{}) *themeMgtStoreInterfaceMock_GetThemeList_Call {
+	return &themeMgtStoreInterfaceMock_GetThemeList_Call{Call: _e.mock.On("GetThemeList", ctx, limit, offset)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) Run(run func(ctx context.Context, limit int, offset int)) *themeMgtStoreInterfaceMock_GetThemeList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) Return(themes []thememgt.Theme, err error) *themeMgtStoreInterfaceMock_GetThemeList_Call {
+	_c.Call.Return(themes, err)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]thememgt.Theme, error)) *themeMgtStoreInterfaceMock_GetThemeList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetThemeListCount provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) GetThemeListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetThemeListCount")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// themeMgtStoreInterfaceMock_GetThemeListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetThemeListCount'
+type themeMgtStoreInterfaceMock_GetThemeListCount_Call struct {
+	*mock.Call
+}
+
+// GetThemeListCount is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *themeMgtStoreInterfaceMock_Expecter) GetThemeListCount(ctx interface{}) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
+	return &themeMgtStoreInterfaceMock_GetThemeListCount_Call{Call: _e.mock.On("GetThemeListCount", ctx)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) Run(run func(ctx context.Context)) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) Return(n int, err error) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_GetThemeListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *themeMgtStoreInterfaceMock_GetThemeListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsThemeDeclarative provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) IsThemeDeclarative(ctx context.Context, id string) bool {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsThemeDeclarative")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// themeMgtStoreInterfaceMock_IsThemeDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeDeclarative'
+type themeMgtStoreInterfaceMock_IsThemeDeclarative_Call struct {
+	*mock.Call
+}
+
+// IsThemeDeclarative is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeDeclarative(ctx interface{}, id interface{}) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
+	return &themeMgtStoreInterfaceMock_IsThemeDeclarative_Call{Call: _e.mock.On("IsThemeDeclarative", ctx, id)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) Run(run func(ctx context.Context, id string)) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) Return(b bool) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call) RunAndReturn(run func(ctx context.Context, id string) bool) *themeMgtStoreInterfaceMock_IsThemeDeclarative_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsThemeExist provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) IsThemeExist(ctx context.Context, id string) (bool, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsThemeExist")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// themeMgtStoreInterfaceMock_IsThemeExist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeExist'
+type themeMgtStoreInterfaceMock_IsThemeExist_Call struct {
+	*mock.Call
+}
+
+// IsThemeExist is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeExist(ctx interface{}, id interface{}) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
+	return &themeMgtStoreInterfaceMock_IsThemeExist_Call{Call: _e.mock.On("IsThemeExist", ctx, id)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) Run(run func(ctx context.Context, id string)) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) Return(b bool, err error) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeExist_Call) RunAndReturn(run func(ctx context.Context, id string) (bool, error)) *themeMgtStoreInterfaceMock_IsThemeExist_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsThemeHandleConflict provides a mock function for the type themeMgtStoreInterfaceMock
+func (_mock *themeMgtStoreInterfaceMock) IsThemeHandleConflict(ctx context.Context, handle string, excludeID string) (bool, error) {
+	ret := _mock.Called(ctx, handle, excludeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsThemeHandleConflict")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (bool, error)); ok {
+		return returnFunc(ctx, handle, excludeID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = returnFunc(ctx, handle, excludeID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, handle, excludeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsThemeHandleConflict'
+type themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call struct {
+	*mock.Call
+}
+
+// IsThemeHandleConflict is a helper method to define mock.On call
+//   - ctx context.Context
+//   - handle string
+//   - excludeID string
+func (_e *themeMgtStoreInterfaceMock_Expecter) IsThemeHandleConflict(ctx interface{}, handle interface{}, excludeID interface{}) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
+	return &themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call{Call: _e.mock.On("IsThemeHandleConflict", ctx, handle, excludeID)}
+}
+
+func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) Run(run func(ctx context.Context, handle string, excludeID string)) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
 func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) Return(b bool, err error) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
 	_c.Call.Return(b, err)
 	return _c
 }
 
-func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) RunAndReturn(run func(handle string, excludeID string) (bool, error)) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
+func (_c *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call) RunAndReturn(run func(ctx context.Context, handle string, excludeID string) (bool, error)) *themeMgtStoreInterfaceMock_IsThemeHandleConflict_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateTheme provides a mock function for the type themeMgtStoreInterfaceMock
-func (_mock *themeMgtStoreInterfaceMock) UpdateTheme(id string, theme thememgt.UpdateThemeRequest) error {
-	ret := _mock.Called(id, theme)
+func (_mock *themeMgtStoreInterfaceMock) UpdateTheme(ctx context.Context, id string, theme thememgt.UpdateThemeRequest) error {
+	ret := _mock.Called(ctx, id, theme)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateTheme")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, thememgt.UpdateThemeRequest) error); ok {
-		r0 = returnFunc(id, theme)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, thememgt.UpdateThemeRequest) error); ok {
+		r0 = returnFunc(ctx, id, theme)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -525,25 +576,31 @@ type themeMgtStoreInterfaceMock_UpdateTheme_Call struct {
 }
 
 // UpdateTheme is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - theme thememgt.UpdateThemeRequest
-func (_e *themeMgtStoreInterfaceMock_Expecter) UpdateTheme(id interface{}, theme interface{}) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
-	return &themeMgtStoreInterfaceMock_UpdateTheme_Call{Call: _e.mock.On("UpdateTheme", id, theme)}
+func (_e *themeMgtStoreInterfaceMock_Expecter) UpdateTheme(ctx interface{}, id interface{}, theme interface{}) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
+	return &themeMgtStoreInterfaceMock_UpdateTheme_Call{Call: _e.mock.On("UpdateTheme", ctx, id, theme)}
 }
 
-func (_c *themeMgtStoreInterfaceMock_UpdateTheme_Call) Run(run func(id string, theme thememgt.UpdateThemeRequest)) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
+func (_c *themeMgtStoreInterfaceMock_UpdateTheme_Call) Run(run func(ctx context.Context, id string, theme thememgt.UpdateThemeRequest)) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 thememgt.UpdateThemeRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(thememgt.UpdateThemeRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 thememgt.UpdateThemeRequest
+		if args[2] != nil {
+			arg2 = args[2].(thememgt.UpdateThemeRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -554,7 +611,7 @@ func (_c *themeMgtStoreInterfaceMock_UpdateTheme_Call) Return(err error) *themeM
 	return _c
 }
 
-func (_c *themeMgtStoreInterfaceMock_UpdateTheme_Call) RunAndReturn(run func(id string, theme thememgt.UpdateThemeRequest) error) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
+func (_c *themeMgtStoreInterfaceMock_UpdateTheme_Call) RunAndReturn(run func(ctx context.Context, id string, theme thememgt.UpdateThemeRequest) error) *themeMgtStoreInterfaceMock_UpdateTheme_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/i18n/mgtmock/i18nStoreInterface_mock.go
+++ b/backend/tests/mocks/i18n/mgtmock/i18nStoreInterface_mock.go
@@ -39,16 +39,16 @@ func (_m *i18nStoreInterfaceMock) EXPECT() *i18nStoreInterfaceMock_Expecter {
 }
 
 // DeleteTranslation provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) DeleteTranslation(language string, key string, namespace string) error {
-	ret := _mock.Called(language, key, namespace)
+func (_mock *i18nStoreInterfaceMock) DeleteTranslation(ctx context.Context, language string, key string, namespace string) error {
+	ret := _mock.Called(ctx, language, key, namespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteTranslation")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) error); ok {
-		r0 = returnFunc(language, key, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = returnFunc(ctx, language, key, namespace)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -61,18 +61,19 @@ type i18nStoreInterfaceMock_DeleteTranslation_Call struct {
 }
 
 // DeleteTranslation is a helper method to define mock.On call
+//   - ctx context.Context
 //   - language string
 //   - key string
 //   - namespace string
-func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslation(language interface{}, key interface{}, namespace interface{}) *i18nStoreInterfaceMock_DeleteTranslation_Call {
-	return &i18nStoreInterfaceMock_DeleteTranslation_Call{Call: _e.mock.On("DeleteTranslation", language, key, namespace)}
+func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslation(ctx interface{}, language interface{}, key interface{}, namespace interface{}) *i18nStoreInterfaceMock_DeleteTranslation_Call {
+	return &i18nStoreInterfaceMock_DeleteTranslation_Call{Call: _e.mock.On("DeleteTranslation", ctx, language, key, namespace)}
 }
 
-func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) Run(run func(language string, key string, namespace string)) *i18nStoreInterfaceMock_DeleteTranslation_Call {
+func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) Run(run func(ctx context.Context, language string, key string, namespace string)) *i18nStoreInterfaceMock_DeleteTranslation_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -82,10 +83,15 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) Run(run func(language s
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -96,7 +102,7 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) Return(err error) *i18n
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) RunAndReturn(run func(language string, key string, namespace string) error) *i18nStoreInterfaceMock_DeleteTranslation_Call {
+func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) RunAndReturn(run func(ctx context.Context, language string, key string, namespace string) error) *i18nStoreInterfaceMock_DeleteTranslation_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -165,16 +171,16 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call) RunAndReturn(run 
 }
 
 // DeleteTranslationsByLanguage provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) DeleteTranslationsByLanguage(language string) error {
-	ret := _mock.Called(language)
+func (_mock *i18nStoreInterfaceMock) DeleteTranslationsByLanguage(ctx context.Context, language string) error {
+	ret := _mock.Called(ctx, language)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteTranslationsByLanguage")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(language)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, language)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -187,19 +193,25 @@ type i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call struct {
 }
 
 // DeleteTranslationsByLanguage is a helper method to define mock.On call
+//   - ctx context.Context
 //   - language string
-func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslationsByLanguage(language interface{}) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
-	return &i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call{Call: _e.mock.On("DeleteTranslationsByLanguage", language)}
+func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslationsByLanguage(ctx interface{}, language interface{}) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
+	return &i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call{Call: _e.mock.On("DeleteTranslationsByLanguage", ctx, language)}
 }
 
-func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) Run(run func(language string)) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) Run(run func(ctx context.Context, language string)) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -210,7 +222,7 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) Return(err e
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) RunAndReturn(run func(language string) error) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) RunAndReturn(run func(ctx context.Context, language string) error) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -273,8 +285,8 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call) RunAndRetur
 }
 
 // GetDistinctLanguages provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) GetDistinctLanguages() ([]string, error) {
-	ret := _mock.Called()
+func (_mock *i18nStoreInterfaceMock) GetDistinctLanguages(ctx context.Context) ([]string, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDistinctLanguages")
@@ -282,18 +294,18 @@ func (_mock *i18nStoreInterfaceMock) GetDistinctLanguages() ([]string, error) {
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]string, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]string, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() []string); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -306,13 +318,20 @@ type i18nStoreInterfaceMock_GetDistinctLanguages_Call struct {
 }
 
 // GetDistinctLanguages is a helper method to define mock.On call
-func (_e *i18nStoreInterfaceMock_Expecter) GetDistinctLanguages() *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
-	return &i18nStoreInterfaceMock_GetDistinctLanguages_Call{Call: _e.mock.On("GetDistinctLanguages")}
+//   - ctx context.Context
+func (_e *i18nStoreInterfaceMock_Expecter) GetDistinctLanguages(ctx interface{}) *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
+	return &i18nStoreInterfaceMock_GetDistinctLanguages_Call{Call: _e.mock.On("GetDistinctLanguages", ctx)}
 }
 
-func (_c *i18nStoreInterfaceMock_GetDistinctLanguages_Call) Run(run func()) *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
+func (_c *i18nStoreInterfaceMock_GetDistinctLanguages_Call) Run(run func(ctx context.Context)) *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -322,14 +341,14 @@ func (_c *i18nStoreInterfaceMock_GetDistinctLanguages_Call) Return(strings []str
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_GetDistinctLanguages_Call) RunAndReturn(run func() ([]string, error)) *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
+func (_c *i18nStoreInterfaceMock_GetDistinctLanguages_Call) RunAndReturn(run func(ctx context.Context) ([]string, error)) *i18nStoreInterfaceMock_GetDistinctLanguages_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetTranslations provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) GetTranslations() (map[string]map[string]mgt.Translation, error) {
-	ret := _mock.Called()
+func (_mock *i18nStoreInterfaceMock) GetTranslations(ctx context.Context) (map[string]map[string]mgt.Translation, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTranslations")
@@ -337,18 +356,18 @@ func (_mock *i18nStoreInterfaceMock) GetTranslations() (map[string]map[string]mg
 
 	var r0 map[string]map[string]mgt.Translation
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (map[string]map[string]mgt.Translation, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (map[string]map[string]mgt.Translation, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() map[string]map[string]mgt.Translation); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) map[string]map[string]mgt.Translation); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]map[string]mgt.Translation)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -361,13 +380,20 @@ type i18nStoreInterfaceMock_GetTranslations_Call struct {
 }
 
 // GetTranslations is a helper method to define mock.On call
-func (_e *i18nStoreInterfaceMock_Expecter) GetTranslations() *i18nStoreInterfaceMock_GetTranslations_Call {
-	return &i18nStoreInterfaceMock_GetTranslations_Call{Call: _e.mock.On("GetTranslations")}
+//   - ctx context.Context
+func (_e *i18nStoreInterfaceMock_Expecter) GetTranslations(ctx interface{}) *i18nStoreInterfaceMock_GetTranslations_Call {
+	return &i18nStoreInterfaceMock_GetTranslations_Call{Call: _e.mock.On("GetTranslations", ctx)}
 }
 
-func (_c *i18nStoreInterfaceMock_GetTranslations_Call) Run(run func()) *i18nStoreInterfaceMock_GetTranslations_Call {
+func (_c *i18nStoreInterfaceMock_GetTranslations_Call) Run(run func(ctx context.Context)) *i18nStoreInterfaceMock_GetTranslations_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -377,14 +403,14 @@ func (_c *i18nStoreInterfaceMock_GetTranslations_Call) Return(stringToStringToTr
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_GetTranslations_Call) RunAndReturn(run func() (map[string]map[string]mgt.Translation, error)) *i18nStoreInterfaceMock_GetTranslations_Call {
+func (_c *i18nStoreInterfaceMock_GetTranslations_Call) RunAndReturn(run func(ctx context.Context) (map[string]map[string]mgt.Translation, error)) *i18nStoreInterfaceMock_GetTranslations_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetTranslationsByKey provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) GetTranslationsByKey(key string, namespace string) (map[string]mgt.Translation, error) {
-	ret := _mock.Called(key, namespace)
+func (_mock *i18nStoreInterfaceMock) GetTranslationsByKey(ctx context.Context, key string, namespace string) (map[string]mgt.Translation, error) {
+	ret := _mock.Called(ctx, key, namespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTranslationsByKey")
@@ -392,18 +418,18 @@ func (_mock *i18nStoreInterfaceMock) GetTranslationsByKey(key string, namespace 
 
 	var r0 map[string]mgt.Translation
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (map[string]mgt.Translation, error)); ok {
-		return returnFunc(key, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]mgt.Translation, error)); ok {
+		return returnFunc(ctx, key, namespace)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) map[string]mgt.Translation); ok {
-		r0 = returnFunc(key, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]mgt.Translation); ok {
+		r0 = returnFunc(ctx, key, namespace)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]mgt.Translation)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = returnFunc(key, namespace)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, key, namespace)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -416,17 +442,91 @@ type i18nStoreInterfaceMock_GetTranslationsByKey_Call struct {
 }
 
 // GetTranslationsByKey is a helper method to define mock.On call
+//   - ctx context.Context
 //   - key string
 //   - namespace string
-func (_e *i18nStoreInterfaceMock_Expecter) GetTranslationsByKey(key interface{}, namespace interface{}) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
-	return &i18nStoreInterfaceMock_GetTranslationsByKey_Call{Call: _e.mock.On("GetTranslationsByKey", key, namespace)}
+func (_e *i18nStoreInterfaceMock_Expecter) GetTranslationsByKey(ctx interface{}, key interface{}, namespace interface{}) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
+	return &i18nStoreInterfaceMock_GetTranslationsByKey_Call{Call: _e.mock.On("GetTranslationsByKey", ctx, key, namespace)}
 }
 
-func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) Run(run func(key string, namespace string)) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
+func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) Run(run func(ctx context.Context, key string, namespace string)) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) Return(stringToTranslation map[string]mgt.Translation, err error) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
+	_c.Call.Return(stringToTranslation, err)
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) RunAndReturn(run func(ctx context.Context, key string, namespace string) (map[string]mgt.Translation, error)) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTranslationsByNamespace provides a mock function for the type i18nStoreInterfaceMock
+func (_mock *i18nStoreInterfaceMock) GetTranslationsByNamespace(ctx context.Context, namespace string) (map[string]map[string]mgt.Translation, error) {
+	ret := _mock.Called(ctx, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTranslationsByNamespace")
+	}
+
+	var r0 map[string]map[string]mgt.Translation
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]map[string]mgt.Translation, error)); ok {
+		return returnFunc(ctx, namespace)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]map[string]mgt.Translation); ok {
+		r0 = returnFunc(ctx, namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]map[string]mgt.Translation)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, namespace)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// i18nStoreInterfaceMock_GetTranslationsByNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTranslationsByNamespace'
+type i18nStoreInterfaceMock_GetTranslationsByNamespace_Call struct {
+	*mock.Call
+}
+
+// GetTranslationsByNamespace is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+func (_e *i18nStoreInterfaceMock_Expecter) GetTranslationsByNamespace(ctx interface{}, namespace interface{}) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
+	return &i18nStoreInterfaceMock_GetTranslationsByNamespace_Call{Call: _e.mock.On("GetTranslationsByNamespace", ctx, namespace)}
+}
+
+func (_c *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call) Run(run func(ctx context.Context, namespace string)) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -440,89 +540,27 @@ func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) Run(run func(key str
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) Return(stringToTranslation map[string]mgt.Translation, err error) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
-	_c.Call.Return(stringToTranslation, err)
-	return _c
-}
-
-func (_c *i18nStoreInterfaceMock_GetTranslationsByKey_Call) RunAndReturn(run func(key string, namespace string) (map[string]mgt.Translation, error)) *i18nStoreInterfaceMock_GetTranslationsByKey_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetTranslationsByNamespace provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) GetTranslationsByNamespace(namespace string) (map[string]map[string]mgt.Translation, error) {
-	ret := _mock.Called(namespace)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetTranslationsByNamespace")
-	}
-
-	var r0 map[string]map[string]mgt.Translation
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (map[string]map[string]mgt.Translation, error)); ok {
-		return returnFunc(namespace)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) map[string]map[string]mgt.Translation); ok {
-		r0 = returnFunc(namespace)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]map[string]mgt.Translation)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(namespace)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// i18nStoreInterfaceMock_GetTranslationsByNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTranslationsByNamespace'
-type i18nStoreInterfaceMock_GetTranslationsByNamespace_Call struct {
-	*mock.Call
-}
-
-// GetTranslationsByNamespace is a helper method to define mock.On call
-//   - namespace string
-func (_e *i18nStoreInterfaceMock_Expecter) GetTranslationsByNamespace(namespace interface{}) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
-	return &i18nStoreInterfaceMock_GetTranslationsByNamespace_Call{Call: _e.mock.On("GetTranslationsByNamespace", namespace)}
-}
-
-func (_c *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call) Run(run func(namespace string)) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
 func (_c *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call) Return(stringToStringToTranslation map[string]map[string]mgt.Translation, err error) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
 	_c.Call.Return(stringToStringToTranslation, err)
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call) RunAndReturn(run func(namespace string) (map[string]map[string]mgt.Translation, error)) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
+func (_c *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call) RunAndReturn(run func(ctx context.Context, namespace string) (map[string]map[string]mgt.Translation, error)) *i18nStoreInterfaceMock_GetTranslationsByNamespace_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpsertTranslation provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) UpsertTranslation(trans mgt.Translation) error {
-	ret := _mock.Called(trans)
+func (_mock *i18nStoreInterfaceMock) UpsertTranslation(ctx context.Context, trans mgt.Translation) error {
+	ret := _mock.Called(ctx, trans)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpsertTranslation")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(mgt.Translation) error); ok {
-		r0 = returnFunc(trans)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, mgt.Translation) error); ok {
+		r0 = returnFunc(ctx, trans)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -535,19 +573,25 @@ type i18nStoreInterfaceMock_UpsertTranslation_Call struct {
 }
 
 // UpsertTranslation is a helper method to define mock.On call
+//   - ctx context.Context
 //   - trans mgt.Translation
-func (_e *i18nStoreInterfaceMock_Expecter) UpsertTranslation(trans interface{}) *i18nStoreInterfaceMock_UpsertTranslation_Call {
-	return &i18nStoreInterfaceMock_UpsertTranslation_Call{Call: _e.mock.On("UpsertTranslation", trans)}
+func (_e *i18nStoreInterfaceMock_Expecter) UpsertTranslation(ctx interface{}, trans interface{}) *i18nStoreInterfaceMock_UpsertTranslation_Call {
+	return &i18nStoreInterfaceMock_UpsertTranslation_Call{Call: _e.mock.On("UpsertTranslation", ctx, trans)}
 }
 
-func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) Run(run func(trans mgt.Translation)) *i18nStoreInterfaceMock_UpsertTranslation_Call {
+func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) Run(run func(ctx context.Context, trans mgt.Translation)) *i18nStoreInterfaceMock_UpsertTranslation_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 mgt.Translation
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(mgt.Translation)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 mgt.Translation
+		if args[1] != nil {
+			arg1 = args[1].(mgt.Translation)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -558,7 +602,7 @@ func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) Return(err error) *i18n
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) RunAndReturn(run func(trans mgt.Translation) error) *i18nStoreInterfaceMock_UpsertTranslation_Call {
+func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) RunAndReturn(run func(ctx context.Context, trans mgt.Translation) error) *i18nStoreInterfaceMock_UpsertTranslation_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -621,16 +665,16 @@ func (_c *i18nStoreInterfaceMock_UpsertTranslations_Call) RunAndReturn(run func(
 }
 
 // UpsertTranslationsByLanguage provides a mock function for the type i18nStoreInterfaceMock
-func (_mock *i18nStoreInterfaceMock) UpsertTranslationsByLanguage(language string, translations []mgt.Translation) error {
-	ret := _mock.Called(language, translations)
+func (_mock *i18nStoreInterfaceMock) UpsertTranslationsByLanguage(ctx context.Context, language string, translations []mgt.Translation) error {
+	ret := _mock.Called(ctx, language, translations)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpsertTranslationsByLanguage")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []mgt.Translation) error); ok {
-		r0 = returnFunc(language, translations)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []mgt.Translation) error); ok {
+		r0 = returnFunc(ctx, language, translations)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -643,25 +687,31 @@ type i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call struct {
 }
 
 // UpsertTranslationsByLanguage is a helper method to define mock.On call
+//   - ctx context.Context
 //   - language string
 //   - translations []mgt.Translation
-func (_e *i18nStoreInterfaceMock_Expecter) UpsertTranslationsByLanguage(language interface{}, translations interface{}) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
-	return &i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call{Call: _e.mock.On("UpsertTranslationsByLanguage", language, translations)}
+func (_e *i18nStoreInterfaceMock_Expecter) UpsertTranslationsByLanguage(ctx interface{}, language interface{}, translations interface{}) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
+	return &i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call{Call: _e.mock.On("UpsertTranslationsByLanguage", ctx, language, translations)}
 }
 
-func (_c *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call) Run(run func(language string, translations []mgt.Translation)) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
+func (_c *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call) Run(run func(ctx context.Context, language string, translations []mgt.Translation)) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 []mgt.Translation
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].([]mgt.Translation)
+			arg1 = args[1].(string)
+		}
+		var arg2 []mgt.Translation
+		if args[2] != nil {
+			arg2 = args[2].([]mgt.Translation)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -672,7 +722,7 @@ func (_c *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call) Return(err e
 	return _c
 }
 
-func (_c *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call) RunAndReturn(run func(language string, translations []mgt.Translation) error) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
+func (_c *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call) RunAndReturn(run func(ctx context.Context, language string, translations []mgt.Translation) error) *i18nStoreInterfaceMock_UpsertTranslationsByLanguage_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Purpose
Of all the stores, these three are the only ones whose methods take no `context.Context`. That makes them the odd ones out, and it stops them being scoped by the request's deployment id the way the others are, because there is no context to read it from.

## Goals
Thread a context through the layout, theme and translation stores, so they can be scoped per request like the rest.

## Approach
- The three store interfaces take `ctx context.Context` as their first parameter: 26 methods in total.
- The composite and file backed implementations, the services above them, the declarative resource wiring and the tests follow.
- The mockery mocks for the changed interfaces are regenerated.

Where there is genuinely no request, the caller supplies a background context rather than inventing one deeper down:

- The declarative loader's `Validator` and `Storer.Create` come from shared `ResourceConfig` signatures that carry no context, and they run as resources are read from disk at start-up. Changing those shared signatures would touch every declarative resource in the tree, which is a different change.

No behaviour changes anywhere.

## User stories
As a maintainer I can scope these three stores by the request's deployment id, which is impossible while their methods take no context.

## Release note
N/A, internal refactor with no behaviour change.

## Documentation
N/A, no user-facing change.

## Training
N/A

## Tests
Existing tests updated for the new signatures, including the mock expectations, which each needed an extra argument matcher. `make lint_backend` reports 0 issues, `make verify_mocks` passes, the full unit suite passes, and the full integration suite passes against a fresh build: 50 suites, 0 failures.

## Related PRs
Pairs with #5268, which puts the deployment id on the request context and scopes the other 13 stores by it. That PR notes these three as deliberately left out.

## Follow-up
Once both land, scoping these three is one line each: replacing the stored `deploymentID` field with the same `scope(ctx)` helper the other stores use. It is not here because the `deployment` package does not exist on main yet, it arrives with #5268.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized context handling across layout, theme, and translation management operations.
  - Context now flows consistently through retrieval, creation, updates, deletion, validation, and conflict checks.
  - Existing business logic, error handling, and supported operations remain unchanged.

- **Tests**
  - Updated automated coverage and mocks for context-aware operations.
  - Existing scenarios, assertions, and error-case coverage remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->