### PR TITLE
Handle incompatible yq implementations

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -142,7 +142,7 @@ read_config() {
         PUBLIC_HOSTNAME=""
     else
         # Try yq first (YAML parser)
-        if command -v yq >/dev/null 2>&1; then
+        if command -v yq >/dev/null 2>&1 && yq eval '.' /dev/null >/dev/null 2>&1; then
             HOSTNAME=$(yq eval '.server.hostname // "localhost"' "$config_file" 2>/dev/null)
             PORT=$(yq eval '.server.port // 8090' "$config_file" 2>/dev/null)
             HTTP_ONLY=$(yq eval '.server.http_only // false' "$config_file" 2>/dev/null)

--- a/setup.sh
+++ b/setup.sh
@@ -254,7 +254,7 @@ read_config() {
     log_debug "Reading configuration from: $config_file"
 
     # Try yq first (YAML parser)
-    if command -v yq >/dev/null 2>&1; then
+    if command -v yq >/dev/null 2>&1 && yq eval '.' /dev/null >/dev/null 2>&1; then
         HOSTNAME=$(yq eval '.server.hostname // "localhost"' "$config_file" 2>/dev/null)
         PORT=$(yq eval '.server.port // 8090' "$config_file" 2>/dev/null)
         HTTP_ONLY=$(yq eval '.server.http_only // false' "$config_file" 2>/dev/null)


### PR DESCRIPTION
### Purpose
Prevent setup.sh and build.sh from terminating when an incompatible yq implementation is present in PATH on the 1.0.x branch.

Fixes #5216

### Approach
- Verify that the detected yq supports the required eval syntax before using it.
- Use the existing grep/awk configuration fallback when the compatibility probe fails.
- Apply the same check to setup and source-build configuration parsing.

### Related Issues
- Fixes #5216

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. Not required for this change.
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. No shell test framework exists for these scripts.
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. None.
    - [ ] Breaking changes section filled.
    - [ ] breaking change label added.

### Validation
- Reproduced on Debian 13.6 Trixie amd64 with the official APT yq 3.4.3-2 package.
- Before the fix, setup.sh exited with status 2 at the first yq eval call and generated no security files.
- After the fix, the incompatible yq probe exited with status 2, setup.sh selected the fallback parser, completed with status 0, and generated all certificate, signing, crypto, and Direct Auth secret files.
- Used a successful bootstrap stub in the isolated container because the source tree does not contain the packaged server binary. Configuration parsing and security material generation used the real 1.0.x scripts and deployment configuration.
- bash -n setup.sh build.sh
- git diff --check

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR does not commit keys, passwords, tokens, usernames, or other secrets.