### PR TITLE
Preserve all hash parameters when storing and verifying credentials

### DIFF
--- a/backend/internal/entity/hash_roundtrip_test.go
+++ b/backend/internal/entity/hash_roundtrip_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package entity
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/thunder-id/thunderid/internal/system/cryptolib"
+	"github.com/thunder-id/thunderid/internal/system/log"
+)
+
+// TestCredentialHashRoundTrip guards against parameter propagation regressions like #5303.
+func TestCredentialHashRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  cryptolib.HashConfig
+	}{
+		{name: "SHA256", cfg: cryptolib.HashConfig{Algorithm: cryptolib.SHA256, SaltSize: 16}},
+		{name: "PBKDF2", cfg: cryptolib.HashConfig{
+			Algorithm: cryptolib.PBKDF2, SaltSize: 16, Iterations: 10000, KeySize: 32,
+		}},
+		{name: "ARGON2ID", cfg: cryptolib.HashConfig{
+			Algorithm: cryptolib.ARGON2ID, SaltSize: 16, Memory: 65536, Iterations: 3,
+			Parallelism: 2, KeySize: 32,
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hashService, err := cryptolib.Initialize(tt.cfg)
+			require.NoError(t, err)
+
+			svc := &entityService{
+				hashService: hashService,
+				logger:      log.GetLogger(),
+			}
+
+			plaintextJSON, err := json.Marshal(map[string]interface{}{"password": "correct horse battery staple"})
+			require.NoError(t, err)
+
+			storedJSON, err := svc.hashPlaintextCredentials(plaintextJSON)
+			require.NoError(t, err)
+
+			err = svc.verifyCredentials(t.Context(),
+				map[string]interface{}{"password": "correct horse battery staple"}, storedJSON, nil)
+			require.NoError(t, err, "correct password must verify against the persisted credential")
+
+			err = svc.verifyCredentials(t.Context(),
+				map[string]interface{}{"password": "wrong password"}, storedJSON, nil)
+			require.ErrorIs(t, err, ErrAuthenticationFailed)
+		})
+	}
+}

--- a/backend/internal/entity/service.go
+++ b/backend/internal/entity/service.go
@@ -498,7 +498,7 @@ func (s *entityService) AuthenticateEntityByID(
 		return nil, ErrEntityNotFound
 	}
 
-	if err := s.verifyCredentials(credentials, result.SchemaCredentials, result.SystemCredentials); err != nil {
+	if err := s.verifyCredentials(ctx, credentials, result.SchemaCredentials, result.SystemCredentials); err != nil {
 		return nil, err
 	}
 
@@ -511,7 +511,7 @@ func (s *entityService) AuthenticateEntityByID(
 }
 
 // verifyCredentials verifies provided credentials from both schema and system credentials.
-func (s *entityService) verifyCredentials(credentials map[string]interface{},
+func (s *entityService) verifyCredentials(ctx context.Context, credentials map[string]interface{},
 	schemaCredsJSON, systemCredsJSON json.RawMessage) error {
 	// Merge both credential columns for verification.
 	storedCreds := make(map[string][]StoredCredential)
@@ -561,16 +561,17 @@ func (s *entityService) verifyCredentials(credentials map[string]interface{},
 		verified := false
 		for _, stored := range credList {
 			ref := cryptolib.Credential{
-				Algorithm: stored.StorageAlgo,
-				Hash:      stored.Value,
-				Parameters: cryptolib.CredParameters{
-					Salt:       stored.StorageAlgoParams.Salt,
-					Iterations: stored.StorageAlgoParams.Iterations,
-					KeySize:    stored.StorageAlgoParams.KeySize,
-				},
+				Algorithm:  stored.StorageAlgo,
+				Hash:       stored.Value,
+				Parameters: stored.StorageAlgoParams,
 			}
 			ok, verifyErr := s.hashService.Verify([]byte(credValue), ref)
-			if verifyErr == nil && ok {
+			if verifyErr != nil {
+				s.logger.Debug(ctx, "Credential verification error", log.String("credentialType", credType),
+					log.Any("error", verifyErr))
+				continue
+			}
+			if ok {
 				verified = true
 				break
 			}
@@ -1097,13 +1098,9 @@ func (s *entityService) hashPlaintextCredentials(creds json.RawMessage) (json.Ra
 			}
 			result[credType] = []StoredCredential{
 				{
-					StorageAlgo: credHash.Algorithm,
-					StorageAlgoParams: cryptolib.CredParameters{
-						Salt:       credHash.Parameters.Salt,
-						Iterations: credHash.Parameters.Iterations,
-						KeySize:    credHash.Parameters.KeySize,
-					},
-					Value: credHash.Hash,
+					StorageAlgo:       credHash.Algorithm,
+					StorageAlgoParams: credHash.Parameters,
+					Value:             credHash.Hash,
 				},
 			}
 		default:

--- a/backend/internal/entity/service_test.go
+++ b/backend/internal/entity/service_test.go
@@ -633,6 +633,17 @@ func (s *ServiceTestSuite) TestAuthenticateEntityByID_WrongCredentials() {
 	s.ErrorIs(err, ErrAuthenticationFailed)
 }
 
+func (s *ServiceTestSuite) TestAuthenticateEntityByID_VerifyError() {
+	storedCreds := testCredentialsJSON()
+	e := testEntity("auth-verify-err-1")
+	s.store.On("GetEntityWithCredentials", mock.Anything, e.ID).
+		Return(&entityWithCredentials{Entity: e, SchemaCredentials: storedCreds}, nil)
+	s.hashService.On("Verify", []byte("password123"), mock.Anything).Return(false, s.testErr)
+
+	_, err := s.svc.AuthenticateEntityByID(s.ctx, e.ID, map[string]interface{}{"password": "password123"})
+	s.ErrorIs(err, ErrAuthenticationFailed)
+}
+
 func (s *ServiceTestSuite) TestAuthenticateEntity_DelegatesToByID() {
 	id := "delegate-1"
 	filters := map[string]interface{}{"username": "user1"}

--- a/backend/internal/user/declarative_resource.go
+++ b/backend/internal/user/declarative_resource.go
@@ -438,6 +438,8 @@ func parseCredentialObject(
 	}
 
 	iterations, _ := paramsMap["iterations"].(int)
+	parallelism, _ := paramsMap["parallelism"].(int)
+	memory, _ := paramsMap["memory"].(int)
 	keySize, _ := paramsMap["keySize"].(int)
 	salt, _ := paramsMap["salt"].(string)
 
@@ -445,9 +447,11 @@ func parseCredentialObject(
 		StorageType: storageType,
 		StorageAlgo: cryptolib.CredAlgorithm(storageAlgo),
 		StorageAlgoParams: cryptolib.CredParameters{
-			Iterations: iterations,
-			KeySize:    keySize,
-			Salt:       salt,
+			Iterations:  iterations,
+			Parallelism: parallelism,
+			Memory:      memory,
+			KeySize:     keySize,
+			Salt:        salt,
 		},
 		Value: value,
 	}, nil


### PR DESCRIPTION
### Purpose
`crypto.password_hashing.algorithm: ARGON2ID` broke authentication completely: users could be created and bootstrapped, but every login afterward failed with a generic "Invalid credentials", even with the exact correct password. Root cause was in `internal/entity/service.go`: `hashPlaintextCredentials` (write) and `verifyCredentials` (read) both reconstructed `cryptolib.CredParameters` by naming only `Salt`, `Iterations`, and `KeySize`, silently dropping `Memory` and `Parallelism`. Since Argon2id's provider requires both to be positive, the reconstructed reference credential was always rejected internally, and the resulting error was swallowed, so it looked identical to a wrong password. `PBKDF2` (the shipped default) was unaffected, which is likely why this went unnoticed.

Filed as #5303 with a full repro (code-level test and an end-to-end run against a built distribution).

### Approach
- `verifyCredentials` and `hashPlaintextCredentials` now assign `CredParameters` wholesale instead of naming individual fields, since `StoredCredential.StorageAlgoParams` is already typed as `cryptolib.CredParameters`. This is a copy-boundary fix, not a schema change.
- `verifyCredentials` now takes `ctx` and logs the internal `Verify` error at debug level, so a parameter/config mismatch is distinguishable from a wrong password going forward.
- `parseCredentialObject`'s pre-hashed-credential-import branch (declarative user resources) had the same gap for `memory`/`parallelism`; fixed to match.
- Added `hash_roundtrip_test.go`, a regression test that hashes and verifies a credential end-to-end for `SHA256`, `PBKDF2`, and `ARGON2ID`, covering both correct- and wrong-password cases. This would have caught #5303 before it shipped.

### Related Issues
- Fixes #5303

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved credential authentication reliability when checking multiple stored credentials.
  - Preserved complete hashing parameters, including memory and parallelism settings, for pre-hashed credentials.
  - Ensured authentication continues correctly when an individual stored credential cannot be verified.
- **Tests**
  - Added coverage for SHA-256, PBKDF2, and Argon2id credentials across persistence and authentication flows.
  - Added validation that incorrect passwords are consistently rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->