### PR TITLE
Force LF line endings repo-wide via .gitattributes to fix Docker build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Force LF line endings for all text files regardless of local core.autocrlf.
+# Prevents CRLF corruption breaking Linux-container builds (Docker/Podman) on Windows checkouts.
+* text=auto eol=lf
+


### PR DESCRIPTION
### Purpose
On Windows, `git clone`/`checkout` with the common `core.autocrlf=true` setting silently converts tracked text files to CRLF line endings. Two concrete build failures result when running `docker build` / `podman build` from such a checkout:

1. `build.sh` gets a `#!/bin/bash\r` shebang, so the Linux container reports `./build.sh: not found` (exit 127) even though the file exists.
2. `version.txt` picks up a trailing `\r`, which leaks into `$VERSION` when read via `cat`, corrupting the generated distribution zip's internal file paths during packaging (`zip warning: name not matched: ...`).

This adds a `.gitattributes` file that forces LF line endings for all text files on checkout, regardless of the contributor's local `core.autocrlf` setting, so a fresh Windows clone builds successfully with no manual git configuration.

### Approach
Uses a single blanket rule, `* text=auto eol=lf`, rather than listing individual filenames or extensions. `text=auto` preserves git's normal binary-detection heuristic (null-byte scan), so actual binary assets are left untouched; only files git already treats as text get their line endings normalized. This covers every script and data file the build reads (`build.sh`, `version.txt`, `start.sh`, `setup.sh`, `backend/scripts/init_script.sh`, `backend/scripts/cleanup_runtime_transient_db.sh`, `Makefile`, `Dockerfile`, etc.) without needing to enumerate them individually or maintain the list as new scripts are added.

Verified against a clean Windows checkout with `core.autocrlf=true` (the default): before this change, `podman build` fails at both points described above; after, `.gitattributes` forces LF regardless of the local autocrlf setting and the image builds and tags successfully from a fully cold cache (no cached layers, no pulled base images).

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized text files to use LF line endings, improving consistency across environments and preventing line-ending-related build issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->