### PR TITLE
Improve inline code contrast and readability

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -91,7 +91,13 @@ html[data-theme='dark'] [class*='docMainContainer'] {
   --ifm-color-primary-light: var(--oxygen-palette-primary-light);
   --ifm-color-primary-lighter: rgb(var(--oxygen-palette-primary-lightChannel));
   --ifm-color-primary-lightest: rgb(var(--oxygen-palette-primary-lightChannel));
-  
+
+  /* Inline code pills. Light mode: dark, saturated text on a light tint so the
+     token reads clearly instead of washing out. Dark mode overrides below. */
+  --inline-code-color: var(--ifm-color-primary-darker);
+  --inline-code-bg: color-mix(in srgb, var(--ifm-color-primary) 2%, transparent);
+  --inline-code-border: color-mix(in srgb, var(--ifm-color-primary) 10%, transparent);
+
   /* Navbar */
   --ifm-navbar-background-color: var(--oxygen-palette-background-paper);
 
@@ -120,6 +126,12 @@ html[data-theme='dark'] [class*='docMainContainer'] {
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+  /* Inline code pills: lighter text and a stronger tint so it stays legible on
+     the dark surface. */
+  --inline-code-color: var(--ifm-color-primary-light);
+  --inline-code-bg: color-mix(in srgb, var(--ifm-color-primary) 8%, transparent);
+  --inline-code-border: color-mix(in srgb, var(--ifm-color-primary) 18%, transparent);
 
   /* Body Background */
     --site-background: radial-gradient(circle at 15% 50%, rgb(0 136 255 / 13%) 0%, rgb(6 13 26 / 0%) 40% 70%),
@@ -275,12 +287,13 @@ h5 {
 }
 
 .markdown code:not([class*='language-']):not(pre code) {
-  background-color: color-mix(in srgb, var(--ifm-color-primary) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--ifm-color-primary) 18%, transparent);
-  border-radius: 4px;
-  padding: 0.1em 0.4em;
-  font-size: 0.875em;
-  color: var(--ifm-color-primary-light, var(--ifm-color-primary));
+  background-color: var(--inline-code-bg);
+  border: 1px solid var(--inline-code-border);
+  border-radius: 5px;
+  padding: 0.12em 0.42em;
+  font-size: 0.9em;
+  font-weight: 500;
+  color: var(--inline-code-color);
 }
 
 /* ------------------------------ Code blocks ----------------------------- */


### PR DESCRIPTION
## Purpose

Inline code tokens were hard to read in light mode. They rendered in a light primary color on a pale primary tint, so the text washed out against its own background/

## What changed

A single change in `docs/src/css/custom.css`, applied globally to inline code across docs and blog markdown:

- Drive the inline-code pill through per-theme tokens instead of a hardcoded light color:
  - **Light mode:** dark, saturated text (`--ifm-color-primary-darker`) on a light tint, so tokens read clearly.
  - **Dark mode:** lighter text (`--ifm-color-primary-light`) on a slightly stronger tint, so it stays legible on the dark surface.
- Nudge the font size (`0.875em` to `0.9em`) and weight (`500`) up for legibility. Fira Code is a variable font, so the weight renders cleanly.
- Slightly rounder pill (`4px` to `5px`).

<img width="1728" height="985" alt="image" src="https://github.com/user-attachments/assets/ecbdb3ed-ea1c-46df-be3e-0e306b5bdc46" />


## Testing

`npm run build` passes; verified the tokens compile into the site stylesheet and the inline-code rule resolves through them in both light and dark mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated inline code styling across documentation pages.
  - Added distinct light- and dark-theme colors for inline code text, backgrounds, and borders.
  - Refined inline code spacing, corner rounding, font size, and weight for improved readability and visual consistency.
  - Improved inline code presentation to remain clear and visually consistent across supported themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->