### PR TITLE
Wrap declarative OU handle lookups in a runtime context

### DIFF
--- a/backend/internal/group/declarative_resource_test.go
+++ b/backend/internal/group/declarative_resource_test.go
@@ -20,6 +20,9 @@ import (
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/declarative_resource/entity"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+	"github.com/thunder-id/thunderid/tests/mocks/oumock"
 )
 
 // GroupExporterTestSuite contains tests for the groupExporter.
@@ -516,6 +519,29 @@ func (suite *GroupExporterTestSuite) TestValidateGroupWrapper_MissingOUID() {
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "ouId or ouHandle is required")
+}
+
+// TestValidateGroupWrapper_OUHandleUsesRuntimeContext verifies the ouHandle lookup carries a
+// runtime context. Declarative resources load at server boot with no authenticated caller, and
+// GetOrganizationUnitByPath's authorization check denies unauthenticated, non-runtime callers;
+// a plain context here would make every ouHandle-based group fail to load with a misleading
+// "organization unit ... not found" error even though the OU exists. Regression test for that.
+func (suite *GroupExporterTestSuite) TestValidateGroupWrapper_OUHandleUsesRuntimeContext() {
+	ouSvc := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvc.EXPECT().
+		GetOrganizationUnitByPath(mock.MatchedBy(security.IsRuntimeContext), "root/eng").
+		Return(providers.OrganizationUnit{ID: "ou-123"}, nil).Once()
+
+	grp := &groupDeclarativeResource{
+		ID:       "group1",
+		Name:     "Admins",
+		OUHandle: "root/eng",
+	}
+
+	err := validateGroupWrapper(grp, nil, nil, ouSvc)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "ou-123", grp.OUID)
 }
 
 // Test validateGroupWrapper - duplicate ID in DB store

--- a/backend/internal/group/service.go
+++ b/backend/internal/group/service.go
@@ -1286,7 +1286,7 @@ func resolveGroupOUHandle(
 		return nil
 	}
 
-	ou, svcErr := ouService.GetOrganizationUnitByPath(ctx, grp.OUHandle)
+	ou, svcErr := ouService.GetOrganizationUnitByPath(security.WithRuntimeContext(ctx), grp.OUHandle)
 	if svcErr != nil {
 		return fmt.Errorf("organization unit with handle %q not found: %v", grp.OUHandle, svcErr)
 	}

--- a/backend/internal/vc/credential/declarative_resource.go
+++ b/backend/internal/vc/credential/declarative_resource.go
@@ -13,6 +13,7 @@ import (
 
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
 	"gopkg.in/yaml.v3"
@@ -188,7 +189,7 @@ func resolveConfigurationOU(
 	ctx context.Context, cfg *CredentialConfigurationDTO, ouService ou.OrganizationUnitServiceInterface,
 ) error {
 	if ouService != nil && cfg.OUID == "" && strings.TrimSpace(cfg.OUHandle) != "" {
-		resolved, svcErr := ouService.GetOrganizationUnitByPath(ctx, cfg.OUHandle)
+		resolved, svcErr := ouService.GetOrganizationUnitByPath(security.WithRuntimeContext(ctx), cfg.OUHandle)
 		if svcErr != nil {
 			return fmt.Errorf("organization unit with handle %q not found for credential configuration '%s'",
 				cfg.OUHandle, cfg.Handle)

--- a/backend/internal/vc/credential/declarative_resource_test.go
+++ b/backend/internal/vc/credential/declarative_resource_test.go
@@ -17,6 +17,9 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/config"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+	"github.com/thunder-id/thunderid/tests/mocks/oumock"
 )
 
 type ConfigurationExporterTestSuite struct {
@@ -297,6 +300,23 @@ func (s *ConfigurationExporterTestSuite) TestValidateRejectsUnknownOUHandle() {
 	err := validateConfigurationWrapper(dto, nil, nil, ouSvc)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "no/such/ou")
+}
+
+// TestValidateResolvesOUHandleUsesRuntimeContext verifies the ouHandle lookup carries a runtime
+// context. Declarative resources load at server boot with no authenticated caller, and
+// GetOrganizationUnitByPath's authorization check denies unauthenticated, non-runtime callers;
+// a plain context here would make every ouHandle-based resource fail to load with a misleading
+// "organization unit ... not found" error even though the OU exists. Regression test for that.
+func (s *ConfigurationExporterTestSuite) TestValidateResolvesOUHandleUsesRuntimeContext() {
+	ouSvc := oumock.NewOrganizationUnitServiceInterfaceMock(s.T())
+	ouSvc.EXPECT().
+		GetOrganizationUnitByPath(mock.MatchedBy(security.IsRuntimeContext), "root/eng").
+		Return(providers.OrganizationUnit{ID: "ou-123"}, nil).Once()
+	ouSvc.EXPECT().IsOrganizationUnitExists(mock.Anything, "ou-123").Return(true, nil).Once()
+
+	cfg := &CredentialConfigurationDTO{ID: "cfg-1", Handle: "h", VCT: "v", OUHandle: "root/eng"}
+	s.Require().NoError(validateConfigurationWrapper(cfg, nil, nil, ouSvc))
+	s.Equal("ou-123", cfg.OUID)
 }
 
 // TestValidateRejectsMissingOU verifies a declarative configuration without an organization

--- a/backend/internal/vc/presentation/declarative_resource.go
+++ b/backend/internal/vc/presentation/declarative_resource.go
@@ -13,6 +13,7 @@ import (
 
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
 	"gopkg.in/yaml.v3"
@@ -216,7 +217,7 @@ func resolveDefinitionOU(
 	ctx context.Context, def *PresentationDefinitionDTO, ouService ou.OrganizationUnitServiceInterface,
 ) error {
 	if ouService != nil && def.OUID == "" && strings.TrimSpace(def.OUHandle) != "" {
-		resolved, svcErr := ouService.GetOrganizationUnitByPath(ctx, def.OUHandle)
+		resolved, svcErr := ouService.GetOrganizationUnitByPath(security.WithRuntimeContext(ctx), def.OUHandle)
 		if svcErr != nil {
 			return fmt.Errorf("organization unit with handle %q not found for presentation definition '%s'",
 				def.OUHandle, def.Handle)

--- a/backend/internal/vc/presentation/declarative_resource_test.go
+++ b/backend/internal/vc/presentation/declarative_resource_test.go
@@ -17,7 +17,10 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/config"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+	"github.com/thunder-id/thunderid/tests/mocks/oumock"
 )
 
 type DefinitionExporterTestSuite struct {
@@ -331,6 +334,23 @@ func (s *DefinitionExporterTestSuite) TestValidateRejectsUnknownOUHandle() {
 	err := validateDefinitionWrapper(dto, nil, nil, ouSvc)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "no/such/ou")
+}
+
+// TestValidateResolvesOUHandleUsesRuntimeContext verifies the ouHandle lookup carries a runtime
+// context. Declarative resources load at server boot with no authenticated caller, and
+// GetOrganizationUnitByPath's authorization check denies unauthenticated, non-runtime callers;
+// a plain context here would make every ouHandle-based resource fail to load with a misleading
+// "organization unit ... not found" error even though the OU exists. Regression test for that.
+func (s *DefinitionExporterTestSuite) TestValidateResolvesOUHandleUsesRuntimeContext() {
+	ouSvc := oumock.NewOrganizationUnitServiceInterfaceMock(s.T())
+	ouSvc.EXPECT().
+		GetOrganizationUnitByPath(mock.MatchedBy(security.IsRuntimeContext), "root/eng").
+		Return(providers.OrganizationUnit{ID: "ou-123"}, nil).Once()
+	ouSvc.EXPECT().IsOrganizationUnitExists(mock.Anything, "ou-123").Return(true, nil).Once()
+
+	dto := &PresentationDefinitionDTO{ID: "def-1", Handle: "h", VCT: "v", OUHandle: "root/eng"}
+	s.Require().NoError(validateDefinitionWrapper(dto, nil, nil, ouSvc))
+	s.Equal("ou-123", dto.OUID)
 }
 
 // TestValidateRejectsMissingOU verifies a declarative definition without an organization


### PR DESCRIPTION
### Purpose
The presentation, credential, and group declarative resource loaders resolve `ouHandle` to `ouId` via `OrganizationUnitService.GetOrganizationUnitByPath`, but pass a plain, unauthenticated context. `GetOrganizationUnitByPath` runs an authorization check after the lookup, which denies unauthenticated/non-runtime callers. That denial gets mislabeled as "organization unit with handle ... not found", even when the OU exists, and crashes server initialization for any declarative resource that sets `ouHandle` (rather than `ouId` directly).

This broke every restart that loads such a resource, most visibly the `try wayfinder` CLI e2e test, which writes a presentation definition with `ouHandle: default` and restarts ThunderID — the server now fails `Failed to initialize presentation definition service` and exits, so the CLI never sees it come back up. The `credential` and `presentation` bugs were introduced by #5117; the same bug already existed in `group`.

### Approach
Wrap the context passed to `GetOrganizationUnitByPath` with `security.WithRuntimeContext(ctx)` in all three declarative loaders, matching the existing pattern already used by `role`, `user`, `entitytype`, `agent`, `application`, and `resource`.

Also added a regression test per package that asserts the actual context handed to `GetOrganizationUnitByPath` is a runtime context (`mock.MatchedBy(security.IsRuntimeContext)`). The existing tests mock the whole `OrganizationUnitServiceInterface` with `mock.Anything` for the context argument, so none of them exercised the real authorization check — that's why this shipped unnoticed. I verified each new test fails without the fix and passes with it.

### Related Issues
- N/A

### Related PRs
- Refs #5117

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. Not applicable, no user-facing behavior change.
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. None.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved organization-unit handle resolution for group, credential, and presentation configurations.
  - Resolved organization-unit paths with the appropriate runtime security context, ensuring valid organization-unit IDs are retained during configuration validation.

- **Tests**
  - Added regression coverage to verify runtime security context handling and organization-unit existence validation across supported configuration types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->