### PR TITLE
Keep the user organization unit when updating a user

### DIFF
--- a/frontend/packages/configure-users/src/pages/UserEditPage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserEditPage.tsx
@@ -107,8 +107,6 @@ export default function UserEditPage() {
   const matchedSchema = userTypeList?.types?.find((s) => s.name === user?.type);
 
   const schemaId = matchedSchema?.id;
-  const trimmedOuId = matchedSchema?.ouId?.trim();
-  const schemaOuId = trimmedOuId === '' ? undefined : trimmedOuId;
 
   const {
     data: userTypeDetails,
@@ -173,8 +171,7 @@ export default function UserEditPage() {
   );
 
   const handleSave = useCallback(async () => {
-    const organizationUnitId = schemaOuId ?? user?.ouId;
-    if (!userId || !organizationUnitId || !user?.type) return;
+    if (!userId || !user?.ouId || !user.type) return;
 
     // Drop stale optional attribute values so an untouched mismatch doesn't block the update.
     const attributes = dropNonConformingOptionalAttributes(
@@ -186,7 +183,7 @@ export default function UserEditPage() {
       await updateUserMutation.mutateAsync({
         userId,
         data: {
-          ouId: organizationUnitId,
+          ouId: user.ouId,
           type: user.type,
           attributes,
         },
@@ -197,7 +194,7 @@ export default function UserEditPage() {
     } catch (err) {
       logger.error('Failed to update user', {error: err});
     }
-  }, [schemaOuId, user, userId, editedUser, userTypeDetails, updateUserMutation, refetch, logger]);
+  }, [user, userId, editedUser, userTypeDetails, updateUserMutation, refetch, logger]);
 
   const hasChanges = useMemo(
     () => Object.entries(editedUser).some(([key, value]) => !isEqualIgnoringEmpty(value, user?.[key as keyof User])),

--- a/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
@@ -554,12 +554,6 @@ describe('UserEditPage', () => {
         error: null,
         refetch: mockRefetch,
       });
-      mockUseGetUserTypes.mockReturnValue({
-        data: {...mockSchemasData, types: [{...mockSchemasData.types[0], ouId: ''}]},
-        isLoading: false,
-        error: null,
-        refetch: mockRefetchUserTypes,
-      });
 
       render(<UserEditPage />);
 
@@ -658,16 +652,16 @@ describe('UserEditPage', () => {
       });
     });
 
-    it('uses schema organization unit when updating user', async () => {
+    it('keeps the user organization unit when the user type declares a different one', async () => {
       const user = userEvent.setup();
       mockUseGetUser.mockReturnValue({
-        data: {...mockUserData, ouId: 'stale-ou'},
+        data: {...mockUserData, ouId: 'sub-ou'},
         isLoading: false,
         error: null,
         refetch: mockRefetch,
       });
       mockUseGetUserTypes.mockReturnValue({
-        data: {...mockSchemasData, types: [{...mockSchemasData.types[0], ouId: 'schema-ou'}]},
+        data: {...mockSchemasData, types: [{...mockSchemasData.types[0], ouId: 'default-ou'}]},
         isLoading: false,
         error: null,
         refetch: mockRefetchUserTypes,
@@ -680,13 +674,18 @@ describe('UserEditPage', () => {
       await user.click(screen.getByRole('button', {name: 'Save'}));
 
       await waitFor(() => {
-        expect(mockUpdateMutateAsync).toHaveBeenCalled();
-        const callArgs = mockUpdateMutateAsync.mock.calls[0][0] as {data: {ouId: string}};
-        expect(callArgs.data.ouId).toBe('schema-ou');
+        expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+          userId: 'user123',
+          data: {
+            ouId: 'sub-ou',
+            type: 'Employee',
+            attributes: {department: 'sales'},
+          },
+        });
       });
     });
 
-    it('falls back to user organization unit when schema does not provide one', async () => {
+    it('sends the user organization unit when the user type declares none', async () => {
       const user = userEvent.setup();
       mockUseGetUserTypes.mockReturnValue({
         data: {...mockSchemasData, types: [{...mockSchemasData.types[0], ouId: ''}]},
@@ -702,9 +701,14 @@ describe('UserEditPage', () => {
       await user.click(screen.getByRole('button', {name: 'Save'}));
 
       await waitFor(() => {
-        expect(mockUpdateMutateAsync).toHaveBeenCalled();
-        const callArgs = mockUpdateMutateAsync.mock.calls[0][0] as {data: {ouId: string}};
-        expect(callArgs.data.ouId).toBe('test-ou');
+        expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+          userId: 'user123',
+          data: {
+            ouId: 'test-ou',
+            type: 'Employee',
+            attributes: {department: 'sales'},
+          },
+        });
       });
     });
 


### PR DESCRIPTION
### Purpose
Fixes #5299. Updating a user from the Console reset their organization unit to the default one. Editing any attribute on a user created in a sub OU moved that user out of it on save, while the import result reported success and the OU panel gave no indication anything had changed.

`UserEditPage` built its update payload from the OU declared on the **user type** rather than the OU the **user** belongs to:

```tsx
const organizationUnitId = schemaOuId ?? user?.ouId;
```

`schemaOuId` comes from `matchedSchema?.ouId`, where `matchedSchema` is the user type. Since `PUT /users/{id}` replaces the resource, the backend accepted that value as a deliberate move.

A user type permits its own OU **or any OU beneath it** (`validateOrganizationUnitForUserType` in `backend/internal/user/service.go`), so a user created in a sub OU under the user type's OU is perfectly valid. Every save collapsed such a user up into the user type's OU, which is why the OU appeared to reset to default in the reported scenario. The page also renders the OU read only, so nothing signalled the change to the user.

### Approach
The user type's OU belongs to the **create** path, where a new user has no OU of its own yet. It arrived here in `655224e5f` "Fix create user ui to include correct ou", which correctly applied it to user creation and applied it to the edit page at the same time.

On the edit path the user already has an OU, and it was validated against the user type when the user was created, so it is the correct value to send back:

- `handleSave` now guards on and sends `user.ouId`.
- The derived `trimmedOuId` / `schemaOuId` consts are removed; nothing else read them.
- `matchedSchema` and `schemaId` stay, since they still resolve `useGetUserType(schemaId)` for the Credentials tab and attribute conformance.

No backend change. Relocating a user between OUs is legitimate behaviour that the API supports; the console was simply doing it by accident on every save.

### Related Issues
- Fixes #5299

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

Unit tests in `frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx`:

- `keeps the user organization unit when the user type declares a different one` is the regression test for this issue: a user in `sub-ou` with a user type on `default-ou` must send `sub-ou`. This replaces a test that asserted the old behaviour and named the user's own OU `stale-ou`, which is the assumption that caused the bug.
- `sends the user organization unit when the user type declares none` covers the other half of the invariant, that the user type's OU has no bearing on the payload.
- `does not submit if user ouId is missing` loses setup that existed only to defeat the old fallback, which makes it stricter: it now also proves the user type's OU cannot resurrect a missing user OU.

Manually verified against a local build following the steps in the issue: created sub OUs under default, created a user in one, edited an attribute, saved, and confirmed the user stays in its sub OU.

No documentation changes: this restores the behaviour the OU panel already presents.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User updates now preserve and submit the organization-unit ID assigned to the user.
  * Editing users no longer replaces their organization-unit ID with one defined by the user type.
  * User updates correctly retain the user’s organization-unit ID even when the user type does not specify one.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->