### PR TITLE
Add B2C use-case docs for sessions, SSO, sign-out, and back-channel logout

### DIFF
--- a/docs/content/use-cases/b2c/index.mdx
+++ b/docs/content/use-cases/b2c/index.mdx
@@ -27,6 +27,11 @@ identity layer in <ProductName /> instead of from scratch. This section walks fr
     href="./try-it-out"
   />
   <NextStepsCard
+    title="Sign In Once, Sign Out Everywhere"
+    description="Sessions, single sign-on, and a sign-out that reaches every application, told in plain language."
+    href="./sessions-index"
+  />
+  <NextStepsCard
     title="Design Decisions"
     description="The reasoning behind the defaults, and what to pick when your constraints differ."
     href="./architecture-decisions"

--- a/docs/content/use-cases/b2c/sessions-decisions.mdx
+++ b/docs/content/use-cases/b2c/sessions-decisions.mdx
@@ -1,0 +1,89 @@
+---
+title: Session and Sign-Out Decisions
+docType: use-case
+sidebar_position: 5
+description: The choices behind sign in once, sign out everywhere, and what to pick instead when your applications, your users, or your appetite for risk differ from Wayfinder's.
+---
+
+# Session and Sign-Out Decisions
+
+You have seen the pattern in the [Overview](../sessions-overview) and followed John through
+[Sign In Once for Every Application](../sessions-sign-in-once), [Sign Out](../sessions-sign-out), and
+[Sign Out Everywhere](../sessions-sign-out-everywhere). This page is the reasoning behind that shape: the choices Wayfinder
+made, and what to choose instead when your situation differs. It sits beside the wider
+[Design Decisions & Alternatives](../architecture-decisions) for consumer access, which covers the token and API
+choices these pages take for granted.
+
+The decisions fall into four groups:
+
+- Which applications share one sign-in.
+- How long a sign-in lasts.
+- How each application signs out.
+- What happens when a sign-out message cannot be delivered.
+
+## Choose Which Applications Share a Sign-In
+
+Applications share a session when they sign people in through the same flow, which makes the flow your grouping tool.
+
+- Put applications that carry the same level of risk on one flow, so one sign-in covers them. Wayfinder Web, Wayfinder
+  Rewards, and the Help Center are one group.
+- Give a more sensitive application its own flow, with stronger steps, so a session from the everyday group never opens
+  it. The payments page is the example.
+- Within a flow, place the steps that a remembered sign-in may skip inside the checkpoint, and keep any step that must
+  always run outside it.
+
+See [Single Sign-On for Flows](../../../guides/flows/single-sign-on) for how the flow is built.
+
+## Choose How Long a Sign-In Lasts
+
+Two clocks bound every session, an idle limit and a total limit, and both are set once for the whole deployment.
+
+- Shorten the idle limit when people use shared or public computers, such as the lounge, so a forgotten session ends on
+  its own sooner. Lengthen it when people work inside one application all day and a prompt would only interrupt them.
+- The total limit is the longest a sign-in can ever be trusted, however active the person is. Keep it in step with how
+  often you want people to prove who they are.
+- The idle limit cannot be longer than the total limit.
+- A session that runs out of time sends no sign-out message to applications. Keep each application's own sign-in short
+  enough that this does not matter.
+
+See [Configure Session Lifetime](../../../guides/flows/single-sign-on#configure-session-lifetime).
+
+## Choose How Each Application Signs Out
+
+Every application already has a sign-out flow, so the choices here are about the experience and the reach.
+
+- Use the sign-out address for an application that sends the browser to <ProductName /> to sign in. Register the page
+  it should return people to, so <ProductName /> can send them back.
+- Run the sign-out flow through the API for an application that draws its own screens.
+- Decide whether to ask "Are you sure?" The default flow ends the session without asking. Choose the
+  **Confirm & Sign Out** template to ask every time, or **Conditional Confirmation** to ask only when the request does
+  not say who is signing out.
+- Give each application a back-channel logout address so it is told when a session it shared ends. An application
+  without one is never told, and keeps its own sign-in until that expires.
+- Turn on **Require session identifier** for an application that may hold more than one session for the same person,
+  such as one on a laptop and one on a phone, so a sign-out ends exactly the right one.
+
+See [RP-Initiated Logout](../../../guides/protocols/oauth-oidc/rp-initiated-logout) and
+[Build a Sign-Out Flow](../../../guides/flows/build-a-flow#go-further).
+
+## Choose What Happens When a Message Cannot Be Delivered
+
+Back-channel delivery is built so that one slow or broken application never spoils sign-out for the person or for the
+other applications. What is left to decide is how much you rely on it.
+
+- Treat the sign-out message as the fast path, not the only path. Keep each application's own sign-in short, so that a
+  message that never arrives costs minutes rather than days.
+- Use the delivery records to find applications that keep failing. Every attempt is recorded with the application, the
+  session, the outcome, and the time, and never with the message itself.
+- Keep the production default, which only delivers to `https` addresses. For development, an operator can allow plain
+  `http` addresses for the whole deployment.
+
+## Expected Outcome
+
+With these choices made, signed in and signed out mean the same thing to every Wayfinder application: one session in
+<ProductName /> that applications borrow, grouped by how much trust each one needs, ended by a click, an
+administrator, or a clock, and announced to every application that shared it.
+
+If a choice on this page does not fit, change that choice and recheck the pages that depend on it. Grouping
+applications differently changes which sessions are shared. Changing the clocks changes when a session ends on its own.
+The sign-out choices are made per application and do not affect the others.

--- a/docs/content/use-cases/b2c/sessions-index.mdx
+++ b/docs/content/use-cases/b2c/sessions-index.mdx
@@ -1,0 +1,41 @@
+---
+title: Sign In Once, Sign Out Everywhere
+docType: use-case
+sidebar_position: 0
+description: One sign-in for every Wayfinder application and one sign-out that ends them all, with {{ProductName}} keeping the record of who is signed in where.
+---
+
+# Sign In Once, Sign Out Everywhere
+
+Wayfinder is no longer one application. Beside the booking site there is a rewards site and a help center, and a
+customer expects to sign in once, reach all of them, and be fully signed out when they leave. <ProductName /> keeps the
+record of who is signed in, shares it across the applications, and tells every one of them when it ends. This part of
+the consumer access story follows John Doe through an afternoon in an airport lounge, in plain language.
+
+<NextSteps>
+  <NextStepsCard
+    title="Overview"
+    description="The problem more than one application creates, and the shape of the solution."
+    href="../sessions-overview"
+  />
+  <NextStepsCard
+    title="Sign In Once for Every Application"
+    description="One sign-in, reused by every application that shares it, until it runs out of time."
+    href="../sessions-sign-in-once"
+  />
+  <NextStepsCard
+    title="Sign Out"
+    description="What a sign-out click has to do at the application and at the identity layer."
+    href="../sessions-sign-out"
+  />
+  <NextStepsCard
+    title="Sign Out Everywhere"
+    description="How every other application is told, even when the browser is closed or nobody clicked."
+    href="../sessions-sign-out-everywhere"
+  />
+  <NextStepsCard
+    title="Session and Sign-Out Decisions"
+    description="The reasoning behind the defaults, and what to pick when your constraints differ."
+    href="../sessions-decisions"
+  />
+</NextSteps>

--- a/docs/content/use-cases/b2c/sessions-overview.mdx
+++ b/docs/content/use-cases/b2c/sessions-overview.mdx
@@ -1,0 +1,119 @@
+---
+title: Overview
+docType: use-case
+sidebar_position: 1
+description: Why one sign-in should open every Wayfinder application, why one sign-out should close them all, and how {{ProductName}} keeps track of both.
+---
+
+# Overview
+
+John Doe, the returning traveller from the [consumer access story](../overview), is waiting for a flight in the
+Skyline Lounge. Wayfinder has grown into three applications he uses in one sitting: the booking site, Wayfinder Web,
+where he checks his flight; Wayfinder Rewards, where he looks up his Gold tier points; and the Wayfinder Help Center,
+where he changes his seat. He does all of it on a shared computer in the lounge. When his flight is called, he clicks
+**Sign out** in the Help Center and walks to the gate.
+
+To John, that was one sign-in and one sign-out. Behind the scenes, every one of those applications had to answer the
+same questions:
+
+- Has this person already signed in somewhere we trust, or do we ask again?
+- How long should that sign-in stay good for?
+- When he signs out of one application, which others need to know?
+- What if he never clicks sign out at all?
+
+Handling those questions is what it takes to make "sign in once, sign out everywhere" true. The sign-in screen is the
+part John sees. The rest is bookkeeping about who is signed in where, and that is the part that goes wrong.
+
+:::note About the Applications in This Story
+The Wayfinder sample ships the booking site, Wayfinder Web. The rewards site, the help center, and the payments page
+appear in this story to show what happens when more than one application shares a sign-in. They stand in for whatever
+second and third applications your own product grows.
+:::
+
+## The Problem
+
+Every application starts out keeping its own record of who signed in. That works for one application and breaks as
+soon as there are two:
+
+- **Signing in again and again.** Each application only knows about its own sign-in, so John types his password three
+  times in one visit. Every new application Wayfinder adds makes it one worse.
+- **A sign-out that only half works.** Clicking **Sign out** in the Help Center clears the Help Center. Wayfinder Web
+  and Wayfinder Rewards still believe he is there. On a shared computer, the next person to sit down inherits his
+  bookings and his points.
+- **Applications that are never told.** Even with one central place that ends the sign-in, each application only finds
+  out if something carries the message to it. Leaving that to the browser is fragile: it fails when the browser is
+  closed, when the browser blocks the hidden pages or cookies the message rides on, or when no browser was involved at
+  all.
+- **Sign-outs that nobody clicked.** A laptop is lost, an account is closed, or a session should end after a quiet
+  afternoon. These endings happen without John doing anything, and they still have to reach every application.
+- **Different levels of trust.** A sign-in that was good enough to check points should not, on its own, open the
+  payments page where his cards are saved. Some applications must ask again, and that has to be a deliberate choice
+  rather than an accident.
+
+## How It Works
+
+Solving this means moving the record of who is signed in out of the applications and into one shared place.
+<ProductName /> is that place: the **identity layer**, the one system that handles signing in and signing out for every
+application. When John signs in, <ProductName /> creates a **session**, a record that this person signed in, in this
+browser, at this time. The applications do not keep their own copy of that record. Each one asks <ProductName />
+instead.
+
+The diagram shows John's afternoon with the identity layer in the middle.
+
+```mermaid
+flowchart LR
+  J(["John, at a shared<br/>lounge computer"])
+  subgraph apps["Wayfinder applications"]
+    A["Wayfinder Web"]
+    B["Wayfinder Rewards"]
+    C["Wayfinder Help Center"]
+  end
+  IL["Identity layer<br/>Runs the sign-in and sign-out screens.<br/>Keeps one session for this browser.<br/>Tells every application when it ends."]
+  J -->|"1. Signs in once."| A
+  J -->|"2. Opens it. Already signed in."| B
+  J -->|"3. Clicks sign out."| C
+  A -->|"Hands the sign-in to the identity layer."| IL
+  B -->|"Asks whether John is signed in."| IL
+  C -->|"Asks the identity layer to end the session."| IL
+  IL -.->|"4. Tells each application directly that the session ended."| A
+  IL -.-> B
+  IL -.-> C
+```
+
+Three things happen in that picture, and together they are the whole pattern:
+
+- **Sign in once.** Wayfinder Web hands John to <ProductName /> to sign in. <ProductName /> checks his password, starts
+  a session, and sends him back with a **signed token**, a small signed message that tells the site who he is.
+- **Already signed in.** Wayfinder Rewards also hands him to <ProductName />, which finds the session and sends him
+  straight back. He never sees a sign-in screen. This is **single sign-on** (SSO): one sign-in, reused by every
+  application that shares it.
+- **Sign out everywhere.** The Help Center asks <ProductName /> to end the session. <ProductName /> ends it, then tells
+  Wayfinder Web and Wayfinder Rewards directly, over its own connection to each of them, that the session is over. That
+  message never travels through John's browser, so it still arrives if the browser is already closed. This is
+  **back-channel logout**.
+
+The one idea to hold on to: the session lives in <ProductName />, not in the applications. Applications borrow it while
+it lasts, and they are told when it ends.
+
+:::tip Not Your Pattern?
+- If each of your customers is a separate organization with its own users and settings, see
+  [Multi-Tenant SaaS Identity](../../b2b/multi-tenant-saas).
+:::
+
+None of this needs custom code in each application. Signing out and back-channel logout follow the
+[OpenID Connect](../../../guides/protocols/oauth-oidc/openid-connect) standards, so an application built with any
+standard OpenID Connect library can join a session, sign out, and receive the sign-out message the same way it would
+with any other identity layer.
+
+## Next Steps
+
+The rest of this part follows John through each step:
+
+1. [Sign In Once for Every Application](../sessions-sign-in-once) follows his first sign-in, the second application that lets
+   him straight in, and how long the session lasts.
+2. [Sign Out](../sessions-sign-out) follows the **Sign out** click, and why the application and <ProductName /> both have to take
+   part.
+3. [Sign Out Everywhere](../sessions-sign-out-everywhere) follows the message to the other applications, including the cases
+   where the browser is closed or nobody clicked at all.
+4. [Session and Sign-Out Decisions](../sessions-decisions) covers the choices behind this shape: which applications share a
+   sign-in, how long it lasts, and what to do when a message cannot be delivered.

--- a/docs/content/use-cases/b2c/sessions-sign-in-once.mdx
+++ b/docs/content/use-cases/b2c/sessions-sign-in-once.mdx
@@ -1,0 +1,85 @@
+---
+title: Sign In Once for Every Application
+docType: use-case
+sidebar_position: 2
+description: How a {{ProductName}} session lets John Doe sign in to Wayfinder Web and open the other Wayfinder applications without signing in again, and how long that lasts.
+---
+
+# Sign In Once for Every Application
+
+John sits down at the lounge computer and opens Wayfinder Web. The site has no sign-in screen of its own. It sends his
+browser to <ProductName />, which shows the Wayfinder sign-in page. He signs in as `john.doe`, <ProductName /> checks
+the password, and sends him back to the site signed in. This page follows what <ProductName /> remembered at that
+moment, what it lets the next application skip, and when it forgets.
+
+## The Session
+
+When John's password checks out, <ProductName /> creates a **session**: its record that this person signed in, from
+this browser, at this time. The session is stored in <ProductName />. The browser gets only a small reference to it, a
+random handle that means nothing on its own, kept in a browser cookie. The cookie carries no name, no password, and
+nothing else about John. The next time the browser comes back to <ProductName />, it presents the handle, and
+<ProductName /> looks up the session.
+
+The session belongs to the browser John used. Signing in on the lounge computer does not sign in his phone. If he
+opens Wayfinder Rewards on his phone, he signs in there separately, and that creates a second session. Keeping
+sessions apart by browser is what later lets <ProductName /> sign out the lounge computer without touching his phone.
+
+## Already Signed In
+
+John now opens Wayfinder Rewards. Like the booking site, it sends him to <ProductName /> to sign in. This time
+<ProductName /> finds a session for his browser, sees that it already covers the password step, and sends him straight
+back to Wayfinder Rewards as a signed-in user. He never sees the sign-in page. This is **single sign-on** (SSO): one
+sign-in, reused by every application that shares it.
+
+Which applications share it is a choice, not an accident. In <ProductName />, every application signs people in through
+a **flow**: the ordered steps a person goes through, such as entering a password or typing a code from a text message.
+Applications that use the same flow share one session. Applications on a different flow do not, even for the same
+person in the same browser. The flow is the grouping key.
+
+Wayfinder uses that to sort its applications by how sensitive they are:
+
+- Wayfinder Web, Wayfinder Rewards, and the Wayfinder Help Center all use the **customer sign-in** flow, which asks for
+  a password. One sign-in covers all three.
+- The payments page, where members keep their saved cards, uses its own **payments sign-in** flow, which asks for a
+  password and a code sent to the member's phone. John's customer session does not open it. When he goes to update a
+  card, he signs in again, with the extra step.
+
+Even within one flow, the person who designs it chooses which steps a remembered sign-in may skip and which always run.
+The part that may be skipped is called a **checkpoint**. On John's first sign-in, the flow runs the password step and
+saves the checkpoint under his session. On his next sign-in through the same flow, the checkpoint is reused and the
+password step is skipped. A step placed outside the checkpoint runs every time.
+
+## How Long It Lasts
+
+A session does not last forever. Two clocks run on it at once:
+
+| Clock | What it measures | Default |
+|---|---|---|
+| Idle time | How long since the session was last used. Every use resets it, so an active session stays alive. | 30 minutes |
+| Total time | How long since the session was created. Nothing resets it. | 8 hours |
+
+The session ends when either clock runs out. If John's flight is delayed and he wanders off for 2 hours, the idle clock
+has run out by the time he comes back, and the next application he opens asks him to sign in again. If he works through
+the whole day, the total clock ends the session after 8 hours no matter how busy he was. An administrator sets both
+limits once for the whole deployment.
+
+A session can also end early, when someone signs out. That is the next page.
+
+## Behind the Scenes
+
+For the technical reader, the pieces above map to these parts of <ProductName />:
+
+- The session model, the per-flow cookie, and the two timeouts are described in
+  [Sessions and Single Sign-On](../../../key-concepts/authentication/sessions).
+- The checkpoint is built from two nodes in the flow, **Check SSO Session** and **Save / Load Session**, described in
+  [Single Sign-On for Flows](../../../guides/flows/single-sign-on).
+- The session lifetime is set in the `session` server configuration, described in
+  [Configure Session Lifetime](../../../guides/flows/single-sign-on#configure-session-lifetime).
+- The sign-in flow John goes through is the one built in [Build the Sign-In Flows](../build-flows).
+
+## Next Steps
+
+- [Sign Out](../sessions-sign-out) follows John's **Sign out** click, and what has to happen at the application and at
+  <ProductName />.
+- [Session and Sign-Out Decisions](../sessions-decisions) covers how to group applications into flows and how to set the two
+  clocks.

--- a/docs/content/use-cases/b2c/sessions-sign-out-everywhere.mdx
+++ b/docs/content/use-cases/b2c/sessions-sign-out-everywhere.mdx
@@ -1,0 +1,170 @@
+---
+title: Sign Out Everywhere
+docType: use-case
+sidebar_position: 4
+description: How {{ProductName}} tells every Wayfinder application that shared a session when it ends, directly and without the browser, so that signed out means signed out everywhere.
+---
+
+# Sign Out Everywhere
+
+When John signed out of the Help Center, the session in <ProductName /> ended. Wayfinder Web and Wayfinder Rewards were
+not part of that click. Each still holds its own note that John is signed in, and each keeps trusting that note until
+it expires. **Back-channel logout** is how <ProductName /> closes that gap: when a session ends, <ProductName /> sends a
+signed message to every application that shared it, directly from its own servers to theirs, with no help from John's
+browser.
+
+The diagram follows the session ending and the messages that go out afterwards.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor J as John
+  participant HC as Help Center
+  participant IL as Identity layer
+  participant WW as Wayfinder Web
+  participant WR as Wayfinder Rewards
+  J->>HC: Clicks Sign out
+  HC->>IL: Asks the identity layer to end the session
+  IL->>IL: Ends the session and notes which applications shared it
+  IL-->>HC: Sends the browser back to the Help Center
+  HC-->>J: Shows that he has been signed out
+  par Messages go out after John is already done
+    IL->>WW: Signed sign-out message for this session
+    WW->>WW: Checks the signature, ends its own note for that session
+    WW-->>IL: Received
+  and
+    IL->>WR: Signed sign-out message for this session
+    WR->>WR: Checks the signature, ends its own note for that session
+    WR-->>IL: Received
+  and
+    IL->>HC: Signed sign-out message for this session
+    HC->>HC: Already signed out, so nothing to do
+    HC-->>IL: Received
+  end
+```
+
+The rest of this page walks through the situations Wayfinder cares about, one at a time.
+
+## Signing Out of One Signs Out of All
+
+John signs out of the Help Center. <ProductName /> ends the session, then sends a sign-out message to every application
+that took part in it and gave <ProductName /> an address for such messages: Wayfinder Web, Wayfinder Rewards, and the
+Help Center itself. Each application ends its own note for that session. The Help Center had already cleared its note
+when John clicked, so it ignores the message, which is expected.
+
+Only applications that shared the session are told. John's phone session, from a different browser, is a different
+session, and nothing happens to it.
+
+## The Browser Is Already Closed
+
+John clicks **Sign out**, closes the browser before the signed-out page finishes loading, and heads for the gate. The
+messages to Wayfinder Web and Wayfinder Rewards still arrive, because they never used his browser. <ProductName />
+sends them from its own servers after the session has ended, and John's part in the sign-out was over the moment the
+session ended.
+
+This is the difference from older sign-out designs that had the browser load a hidden page for each application. Those
+stop working when the browser is closed, when the browser blocks hidden pages or third-party cookies, or when there
+was never a browser at all. The back channel depends on none of that.
+
+## Nobody Clicked Sign Out
+
+Not every session ends with a click. Alex Carter, the operations admin, can end every session a person has, for
+example when the person's account is deleted. That happens on Alex's side, with no browser of John's involved.
+<ProductName /> treats it the same way as a click: the session ends, and the sign-out messages go out to every
+application that shared it.
+
+One ending is different. When a session runs out of time, no message is sent. Each application's own note has its own
+time limit and expires on its own. If that matters for an application, keep its own limit short.
+[Session and Sign-Out Decisions](../sessions-decisions) covers that choice.
+
+## Only the Right Session Ends
+
+John is signed in to Wayfinder Web on the lounge computer and, separately, on his phone. When he signs out at the lounge
+computer, only that session should end. The phone should stay signed in.
+
+Every sign-out message names the session it is about. Each application received that same session name when John
+signed in, tucked inside the signed token, so it can match the message to the right note and leave the others alone.
+Wayfinder Web ends John's lounge-computer session and keeps his phone signed in. An application can tell
+<ProductName /> that it needs the session name in every message it receives.
+
+## An Application Cannot Be Reached
+
+Wayfinder Rewards is down for maintenance when John signs out. <ProductName /> ends his session anyway, tells Wayfinder
+Web anyway, and never delays or fails John's sign-out because of the rewards site. His browser was sent back to the
+Help Center before any message went out.
+
+For Wayfinder Rewards, <ProductName /> tries again a few times, waiting a little longer each time. If it still cannot
+get through, it records that the message was not delivered and moves on. Every attempt is recorded, whether it
+succeeded or failed, so Alex can later see which applications were told and which were not. The record never contains
+the message itself or anything about John beyond the identifiers needed to find the session.
+
+## How an Application Knows the Message Is Genuine
+
+A message that says "sign this person out" must not be something anyone can forge. Three things protect it:
+
+- **It is signed by <ProductName />.** The message is signed with the same keys <ProductName /> uses for sign-in tokens,
+  and every application already knows how to check those keys. A message that does not check out is thrown away.
+- **It is addressed to one application.** Each application gets its own message, naming that application. A message
+  meant for Wayfinder Web is not accepted by Wayfinder Rewards.
+- **It cannot be replayed.** Every message carries a unique number and expires within minutes. An application remembers
+  the numbers it has seen and rejects a copy.
+
+Because the message follows the OpenID Connect Back-Channel Logout standard, an application built with a standard
+library checks all of this without custom code.
+
+<details>
+<summary>What the message looks like</summary>
+
+For the technical reader, the message is a signed **logout token**, delivered as a `POST` to the address the
+application registered, with the token in the request body. Decoded, the copy sent to Wayfinder Web looks like this:
+
+```json
+{
+  "iss": "https://auth.wayfinder.example",
+  "aud": "wayfinder-web",
+  "iat": 1893456000,
+  "exp": 1893456120,
+  "jti": "0a1b2c3d-4e5f-4a6b-8c7d-9e0f1a2b3c4d",
+  "sub": "3f29a1d2-8b4e-4c7a-9f21-6e5d0a1b2c3d",
+  "sid": "01930c7e-2f4a-7b3c-9d1e-5a6b7c8d9e0f",
+  "events": {
+    "http://schemas.openid.net/event/backchannel-logout": {}
+  }
+}
+```
+
+`iss` is the <ProductName /> instance that signed it, `aud` is the application it is for, `sub` is John, and `sid` is
+the session that ended. `jti` is the unique number that stops replays, and `exp` is when the message expires. The
+`events` entry marks it as a sign-out message rather than a sign-in token, so one can never be mistaken for the other.
+`sub` is the same value that identifies John in the [access token](../build-run#the-token) Wayfinder Web already
+holds.
+
+</details>
+
+## Setting It Up
+
+Each application tells <ProductName /> where to send its sign-out messages. Alex does this in the Console, on the
+application's settings page, in the same section as the page the application returns people to after sign-out:
+
+- **Back-Channel Logout URI** is the address <ProductName /> sends the message to. It must be a full `https` address.
+  Leave it empty for an application that should not receive messages, and <ProductName /> skips that application
+  without treating it as an error.
+- **Require session identifier** asks <ProductName /> to always name the session in the message, so the application can
+  end exactly one session. It can only be turned on once an address is set.
+
+The same two settings are available through the management API and in declarative configuration, and an application
+that registers itself through
+[Dynamic Client Registration](../../../guides/protocols/oauth-oidc/dynamic-client-registration) can send them with
+its registration. Whichever path is used, an invalid address is rejected the same way.
+
+<ProductName /> also announces that it supports back-channel logout in its published
+[server metadata](../../../guides/protocols/oauth-oidc/server-metadata), so an application built with a standard
+OpenID Connect library turns the feature on by itself once it has an address. An operator can turn back-channel
+delivery off for the whole deployment. The registered addresses stay in place, unused, until it is turned on again.
+
+## Next Steps
+
+- [Session and Sign-Out Decisions](../sessions-decisions) covers which applications should register an address, how short to
+  keep each application's own sign-in, and what the delivery records are for.
+- [RP-Initiated Logout](../../../guides/protocols/oauth-oidc/rp-initiated-logout) is the sign-out request that,
+  together with back-channel logout, makes sign out everywhere work for browser-based applications.

--- a/docs/content/use-cases/b2c/sessions-sign-out.mdx
+++ b/docs/content/use-cases/b2c/sessions-sign-out.mdx
@@ -1,0 +1,104 @@
+---
+title: Sign Out
+docType: use-case
+sidebar_position: 3
+description: What happens when John Doe clicks sign out in one Wayfinder application, and why both the application and {{ProductName}} have to take part before he is really signed out.
+---
+
+# Sign Out
+
+John's flight is called. He clicks **Sign out** in the Wayfinder Help Center. That click has to do two separate things,
+and if either one is missed he is not really signed out.
+
+## Two Places to Sign Out Of
+
+The Help Center keeps a small note of its own that says John is signed in here, so it does not have to ask
+<ProductName /> on every page he opens. The session that started it all lives in <ProductName />. Signing out means
+clearing both:
+
+- **The application's own note.** The Help Center clears it when John clicks **Sign out**. If it stopped there, the
+  session in <ProductName /> would still be alive. The next time John, or whoever sits down next, opened the Help
+  Center, it would send the browser to <ProductName />, find the session, and let them straight in without a password.
+  John would appear to be signed out and would not be.
+- **The session in <ProductName />.** The Help Center asks <ProductName /> to end it. Once it is gone, the next visit to
+  any application that shared it asks for a password again.
+
+This is why an application cannot sign a person out by itself. It has to ask <ProductName /> too.
+
+## What Happens When He Clicks
+
+The diagram follows the click from the Help Center to the identity layer and back.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor J as John
+  participant HC as Help Center
+  participant IL as Identity layer
+  J->>HC: Clicks Sign out
+  HC->>HC: Clears its own note that John is signed in
+  HC->>IL: Sends the browser to the sign-out address, with a hint of who is signing out
+  IL->>IL: Checks the hint, and checks the page the Help Center wants him sent back to
+  IL->>IL: Runs the sign-out flow, ends the session, clears the session cookie
+  IL-->>HC: Sends the browser back to the Help Center's signed-out page
+  HC-->>J: Shows that he has been signed out
+```
+
+In words:
+
+1. The Help Center clears its own note.
+2. It sends John's browser to the <ProductName /> sign-out address, along with a hint of who is signing out (the signed
+   token it received when he signed in) and the page it wants him returned to.
+3. <ProductName /> checks the hint, and checks that the return page is one the Help Center registered in advance. A
+   return page that was not registered is refused, so nobody can use the sign-out address to send a person to a
+   look-alike site.
+4. <ProductName /> runs the application's **sign-out flow**. Every application has one, and by default it ends the
+   session at once without asking anything. If Wayfinder prefers an "Are you sure you want to sign out?" screen, it can
+   choose a flow that asks every time, or one that asks only when the hint is missing.
+5. <ProductName /> ends the session and clears the session cookie from the browser.
+6. The browser lands on the Help Center's signed-out page.
+
+From this moment, opening Wayfinder Web or Wayfinder Rewards in that browser and going through sign-in asks for a
+password again. The session that let them skip it is gone.
+
+## What Has Not Happened Yet
+
+John ended the session, but Wayfinder Web and Wayfinder Rewards still hold their own notes that he is signed in. Nothing
+on this page told them anything. If John left Wayfinder Web open in another tab, it may still show his bookings until
+its own note expires, because it has not been back to <ProductName /> to ask. Closing that gap, without depending on
+John's browser, is what [Sign Out Everywhere](../sessions-sign-out-everywhere) is about.
+
+## Applications That Draw Their Own Screens
+
+Some applications never send the browser to <ProductName />. They draw their own sign-in screens and talk to
+<ProductName /> directly, the [app-native pattern](../integration-patterns#app-native). Those applications run the
+same sign-out flow through the <ProductName /> API instead of the sign-out address, and the result is the same: the
+session ends. See [Build a Sign-Out Flow](../../../guides/flows/build-a-flow#go-further).
+
+## What the Sign-Out Request Looks Like
+
+For the technical reader, the "sends the browser to the sign-out address" step in the diagram is one web address. The
+Help Center sends John's browser here:
+
+```http
+GET /oauth2/logout
+  ?id_token_hint=$ID_TOKEN
+  &post_logout_redirect_uri=https://help.wayfinder.example/signed-out
+  &state=xyz
+```
+
+- `id_token_hint` is the hint: the signed token the Help Center received at sign-in, which tells <ProductName /> which
+  application and which person this is.
+- `post_logout_redirect_uri` is the return page, which must match one registered on the application.
+- `state` is a value the Help Center can use to recognize the return.
+
+<ProductName /> ends the session and sends the browser to `https://help.wayfinder.example/signed-out?state=xyz`. Every
+parameter, the validation rules, and the confirmation options are in
+[RP-Initiated Logout](../../../guides/protocols/oauth-oidc/rp-initiated-logout).
+
+## Next Steps
+
+- [Sign Out Everywhere](../sessions-sign-out-everywhere) follows the message from <ProductName /> to the applications that were
+  not part of the click.
+- [Session and Sign-Out Decisions](../sessions-decisions) covers whether to ask for confirmation, and which sign-out path fits
+  each kind of application.

--- a/docs/content/use-cases/b2c/tokens-and-apis.mdx
+++ b/docs/content/use-cases/b2c/tokens-and-apis.mdx
@@ -31,6 +31,10 @@ Three patterns cover most consumer scenarios:
 
 Many consumer apps combine the second and third into a long, sliding, revocable session. Whichever you pick, refresh-token rotation limits the damage if a token leaks.
 
+These patterns describe the credential the application holds. The <ProductName /> session behind it, how single
+sign-on reuses that session across applications, and how a sign-out reaches every application are covered in
+[Sign In Once, Sign Out Everywhere](../sessions-index).
+
 ## Where the Application Holds the Token
 
 For a browser-based web app, storing an access token somewhere JavaScript can read it, `localStorage` or a

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -204,6 +204,38 @@ const sidebars: SidebarsConfig = {
             },
             {
               type: 'category',
+              label: 'Sign In Once, Sign Out Everywhere',
+              key: 'b2c-sessions',
+              link: {type: 'doc', id: 'use-cases/b2c/sessions-index'},
+              collapsible: true,
+              collapsed: true,
+              items: [
+                {
+                  type: 'doc',
+                  id: 'use-cases/b2c/sessions-overview',
+                  label: 'Overview',
+                  key: 'b2c-sessions-overview',
+                },
+                {
+                  type: 'doc',
+                  id: 'use-cases/b2c/sessions-sign-in-once',
+                  label: 'Sign In Once for Every Application',
+                },
+                {type: 'doc', id: 'use-cases/b2c/sessions-sign-out', label: 'Sign Out'},
+                {
+                  type: 'doc',
+                  id: 'use-cases/b2c/sessions-sign-out-everywhere',
+                  label: 'Sign Out Everywhere',
+                },
+                {
+                  type: 'doc',
+                  id: 'use-cases/b2c/sessions-decisions',
+                  label: 'Session and Sign-Out Decisions',
+                },
+              ],
+            },
+            {
+              type: 'category',
               label: 'Design Decisions & Alternatives',
               link: {type: 'doc', id: 'use-cases/b2c/architecture-decisions'},
               collapsible: true,


### PR DESCRIPTION
### Purpose

Adds a use-case part for sessions, Single Sign-On, sign-out, and OIDC Back-Channel Logout inside the B2C section, as flat `sessions-*.mdx` pages in `docs/content/use-cases/b2c/`, following the `build-*.mdx` naming the Build It tutorial uses. The pages are written in plain English for a reader who is not an identity engineer. They follow the existing Wayfinder cast: John Doe, the returning traveller, uses Wayfinder Web, a rewards site, and a help center from a shared computer in the Skyline Lounge, and Alex Carter, the operations admin, configures and audits the sign-out messages. Protocol detail is kept to short "for the technical reader" asides and collapsible blocks.

The back-channel logout pages describe the behavior specified in #5233 and its design under review. They should merge together with, or after, the implementation, and the wording of the Console labels (**Back-Channel Logout URI**, **Require session identifier**) should be re-checked against the final UI before release.

### Approach

**A sub-section of B2C.** It is registered in `sidebars.ts` as a category between `See It in a Sample App` and `Design Decisions & Alternatives`, with a card on the B2C landing page and a pointer from the `Tokens and APIs` session strategy section. Inside: a light landing map (`sessions-index.mdx`) with cards, then `Overview` (the situation, the problem, and the solution shape with one diagram), three scenario pages, and `Session and Sign-Out Decisions` at the end, which links to the wider B2C decisions page for the token and API choices it takes for granted.

| Page | What it covers |
|---|---|
| Overview | The four questions every application has to answer, the five problems that appear once there is more than one application, and the identity-layer-in-the-middle shape. |
| Sign In Once for Every Application | The session, the browser cookie that only carries a reference to it, SSO as flow-scoped session reuse, checkpoints, the idle and absolute timeouts, and browser scope. |
| Sign Out | Why the application and ThunderID both have to take part, the RP-Initiated Logout round trip as a sequence diagram, the confirmation options, the app-native path, and the `end_session_endpoint` request as the concrete artifact. |
| Sign Out Everywhere | Back-channel logout as one scenario per row of the use-case table in #5233: sign-out from one application reaches all (UC-1, UC-2), browser already closed (UC-3), administrative termination (UC-4), `sid` so only the matching session ends (UC-5, UC-6), an unreachable RP (UC-7), signature, audience, and replay protection (UC-8, UC-9), and configuration through the Console, the management API, declarative configuration, and DCR (UC-10, UC-11). A decoded logout token sits in a collapsible block. |
| Session and Sign-Out Decisions | Which applications share a flow, how to set the two timeouts, redirect vs. app-native sign-out and confirmation, whether to register a back-channel address and require `sid`, and what to rely on when delivery fails. |

**Jargon is glossed at first use.** Session, identity layer, signed token, single sign-on, flow, checkpoint, back-channel logout, and logout token are each introduced in one plain sentence before the term is used. Relying party, OpenID Provider, and claim names appear only inside the technical asides, next to a link to the reference page.

**Every claim about current behavior is verified against the existing docs and code.** Flow-scoped sessions, the opaque per-flow cookie, the 30 minute and 8 hour defaults, the sign-out flow resolution order, the three sign-out templates, post-logout redirect validation, and `TerminateBySubject` from the user-deletion administration flow all come from `key-concepts/authentication/sessions`, `guides/flows/single-sign-on`, `guides/protocols/oauth-oidc/rp-initiated-logout`, `guides/flows/build-a-flow`, and `backend/internal/flow/session`. Claims about back-channel logout come from the requirements and design for #5233.

**What is deliberately left out.** Session expiry is stated as not sending a notification, matching the design. Front-channel logout is not mentioned, because no page exists for it yet. There are no walkthroughs in the running sample, because Wayfinder ships one application and has no multi-application sign-out journey; the overview says so in a note, and the rewards site, help center, and payments page are introduced as stand-ins for the second and third applications a product grows.

**Checks run.** `vale docs/content/use-cases/b2c/` passes with no errors or warnings. The site builds with `onBrokenLinks: 'throw'`, so every relative link resolves.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/5233

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7pTfEMjYgdhf1xZRKmPZU
