### PR TITLE
Preserve all hash parameters when storing and verifying credentials

### DIFF
--- a/backend/internal/entity/hash_roundtrip_test.go
+++ b/backend/internal/entity/hash_roundtrip_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package entity
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/thunder-id/thunderid/internal/system/cryptolib"
+	"github.com/thunder-id/thunderid/internal/system/log"
+)
+
+// TestCredentialHashRoundTrip guards against parameter propagation regressions like #5303.
+func TestCredentialHashRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  cryptolib.HashConfig
+	}{
+		{name: "SHA256", cfg: cryptolib.HashConfig{Algorithm: cryptolib.SHA256, SaltSize: 16}},
+		{name: "PBKDF2", cfg: cryptolib.HashConfig{
+			Algorithm: cryptolib.PBKDF2, SaltSize: 16, Iterations: 10000, KeySize: 32,
+		}},
+		{name: "ARGON2ID", cfg: cryptolib.HashConfig{
+			Algorithm: cryptolib.ARGON2ID, SaltSize: 16, Memory: 65536, Iterations: 3,
+			Parallelism: 2, KeySize: 32,
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hashService, err := cryptolib.Initialize(tt.cfg)
+			require.NoError(t, err)
+
+			svc := &entityService{
+				hashService: hashService,
+				logger:      log.GetLogger(),
+			}
+
+			plaintextJSON, err := json.Marshal(map[string]interface{}{"password": "correct horse battery staple"})
+			require.NoError(t, err)
+
+			storedJSON, err := svc.hashPlaintextCredentials(plaintextJSON)
+			require.NoError(t, err)
+
+			err = svc.verifyCredentials(t.Context(),
+				map[string]interface{}{"password": "correct horse battery staple"}, storedJSON, nil)
+			require.NoError(t, err, "correct password must verify against the persisted credential")
+
+			err = svc.verifyCredentials(t.Context(),
+				map[string]interface{}{"password": "wrong password"}, storedJSON, nil)
+			require.ErrorIs(t, err, ErrAuthenticationFailed)
+		})
+	}
+}

--- a/backend/internal/entity/service.go
+++ b/backend/internal/entity/service.go
@@ -498,7 +498,7 @@ func (s *entityService) AuthenticateEntityByID(
 		return nil, ErrEntityNotFound
 	}
 
-	if err := s.verifyCredentials(credentials, result.SchemaCredentials, result.SystemCredentials); err != nil {
+	if err := s.verifyCredentials(ctx, credentials, result.SchemaCredentials, result.SystemCredentials); err != nil {
 		return nil, err
 	}
 
@@ -511,7 +511,7 @@ func (s *entityService) AuthenticateEntityByID(
 }
 
 // verifyCredentials verifies provided credentials from both schema and system credentials.
-func (s *entityService) verifyCredentials(credentials map[string]interface{},
+func (s *entityService) verifyCredentials(ctx context.Context, credentials map[string]interface{},
 	schemaCredsJSON, systemCredsJSON json.RawMessage) error {
 	// Merge both credential columns for verification.
 	storedCreds := make(map[string][]StoredCredential)
@@ -561,16 +561,17 @@ func (s *entityService) verifyCredentials(credentials map[string]interface{},
 		verified := false
 		for _, stored := range credList {
 			ref := cryptolib.Credential{
-				Algorithm: stored.StorageAlgo,
-				Hash:      stored.Value,
-				Parameters: cryptolib.CredParameters{
-					Salt:       stored.StorageAlgoParams.Salt,
-					Iterations: stored.StorageAlgoParams.Iterations,
-					KeySize:    stored.StorageAlgoParams.KeySize,
-				},
+				Algorithm:  stored.StorageAlgo,
+				Hash:       stored.Value,
+				Parameters: stored.StorageAlgoParams,
 			}
 			ok, verifyErr := s.hashService.Verify([]byte(credValue), ref)
-			if verifyErr == nil && ok {
+			if verifyErr != nil {
+				s.logger.Debug(ctx, "Credential verification error", log.String("credentialType", credType),
+					log.Any("error", verifyErr))
+				continue
+			}
+			if ok {
 				verified = true
 				break
 			}
@@ -1097,13 +1098,9 @@ func (s *entityService) hashPlaintextCredentials(creds json.RawMessage) (json.Ra
 			}
 			result[credType] = []StoredCredential{
 				{
-					StorageAlgo: credHash.Algorithm,
-					StorageAlgoParams: cryptolib.CredParameters{
-						Salt:       credHash.Parameters.Salt,
-						Iterations: credHash.Parameters.Iterations,
-						KeySize:    credHash.Parameters.KeySize,
-					},
-					Value: credHash.Hash,
+					StorageAlgo:       credHash.Algorithm,
+					StorageAlgoParams: credHash.Parameters,
+					Value:             credHash.Hash,
 				},
 			}
 		default:

--- a/backend/internal/entity/service_test.go
+++ b/backend/internal/entity/service_test.go
@@ -633,6 +633,17 @@ func (s *ServiceTestSuite) TestAuthenticateEntityByID_WrongCredentials() {
 	s.ErrorIs(err, ErrAuthenticationFailed)
 }
 
+func (s *ServiceTestSuite) TestAuthenticateEntityByID_VerifyError() {
+	storedCreds := testCredentialsJSON()
+	e := testEntity("auth-verify-err-1")
+	s.store.On("GetEntityWithCredentials", mock.Anything, e.ID).
+		Return(&entityWithCredentials{Entity: e, SchemaCredentials: storedCreds}, nil)
+	s.hashService.On("Verify", []byte("password123"), mock.Anything).Return(false, s.testErr)
+
+	_, err := s.svc.AuthenticateEntityByID(s.ctx, e.ID, map[string]interface{}{"password": "password123"})
+	s.ErrorIs(err, ErrAuthenticationFailed)
+}
+
 func (s *ServiceTestSuite) TestAuthenticateEntity_DelegatesToByID() {
 	id := "delegate-1"
 	filters := map[string]interface{}{"username": "user1"}

--- a/backend/internal/user/declarative_resource.go
+++ b/backend/internal/user/declarative_resource.go
@@ -438,6 +438,8 @@ func parseCredentialObject(
 	}
 
 	iterations, _ := paramsMap["iterations"].(int)
+	parallelism, _ := paramsMap["parallelism"].(int)
+	memory, _ := paramsMap["memory"].(int)
 	keySize, _ := paramsMap["keySize"].(int)
 	salt, _ := paramsMap["salt"].(string)
 
@@ -445,9 +447,11 @@ func parseCredentialObject(
 		StorageType: storageType,
 		StorageAlgo: cryptolib.CredAlgorithm(storageAlgo),
 		StorageAlgoParams: cryptolib.CredParameters{
-			Iterations: iterations,
-			KeySize:    keySize,
-			Salt:       salt,
+			Iterations:  iterations,
+			Parallelism: parallelism,
+			Memory:      memory,
+			KeySize:     keySize,
+			Salt:        salt,
 		},
 		Value: value,
 	}, nil


### PR DESCRIPTION
## Summary
- Pass all stored hash parameters (including memory/parallelism for Argon2id) through to `cryptolib.Credential` when hashing and verifying credentials, instead of dropping fields to a fixed subset (salt/iterations/keySize).
- Propagate `parallelism` and `memory` when parsing declarative user credential objects.
- Log and skip (rather than silently ignore) verification errors per stored credential, continuing to the next candidate.

## Test plan
- [ ] `make test_unit` (backend/internal/entity)
- [ ] New `TestCredentialHashRoundTrip` covers SHA256, PBKDF2, and Argon2id round trips
- [ ] New `TestAuthenticateEntityByID_VerifyError` covers a verification error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)