### PR TITLE
Include credential configurations and presentation definitions in Console export

### DIFF
--- a/frontend/packages/configure-import-export/src/components/ConfigureExport.tsx
+++ b/frontend/packages/configure-import-export/src/components/ConfigureExport.tsx
@@ -10,6 +10,7 @@ import {
   Copy,
   FileDown,
   Group,
+  IdCard,
   Languages,
   Layers,
   LayoutGrid,
@@ -95,6 +96,8 @@ export default function ConfigureExport({
   const [expandedGroups, setExpandedGroups] = useState(false);
   const [expandedAgents, setExpandedAgents] = useState(false);
   const [expandedServerConfigs, setExpandedServerConfigs] = useState(false);
+  const [expandedCredentialConfigurations, setExpandedCredentialConfigurations] = useState(false);
+  const [expandedPresentationDefinitions, setExpandedPresentationDefinitions] = useState(false);
 
   const nextSteps = [
     t('importExport:configureExport.nextSteps.startWithConfig', {productName}),
@@ -271,6 +274,12 @@ export default function ConfigureExport({
   const serverConfigsCount =
     resourceCounts?.['server_config'] ??
     (Array.isArray(configData?.['server_config']) ? configData['server_config'].length : 0);
+  const credentialConfigurationsCount =
+    resourceCounts?.['credential_configuration'] ??
+    (Array.isArray(configData?.['credential_configuration']) ? configData['credential_configuration'].length : 0);
+  const presentationDefinitionsCount =
+    resourceCounts?.['presentation_definition'] ??
+    (Array.isArray(configData?.['presentation_definition']) ? configData['presentation_definition'].length : 0);
 
   const items: ConfigSummaryItem[] = [];
 
@@ -1152,6 +1161,139 @@ export default function ConfigureExport({
                   size="small"
                   variant="outlined"
                   onClick={() => setExpandedServerConfigs(!expandedServerConfigs)}
+                  sx={{cursor: 'pointer'}}
+                />
+              </Box>
+            )}
+          </Stack>
+        </Box>
+      ),
+    });
+  }
+
+  // Add credential configurations (OID4VCI templates) if present
+  if (credentialConfigurationsCount > 0) {
+    const credentialConfigurations =
+      (configData?.['credential_configuration'] as {name?: string; handle?: string; vct?: string}[]) ?? [];
+    const displayedCredentialConfigurations = expandedCredentialConfigurations
+      ? credentialConfigurations
+      : credentialConfigurations.slice(0, 5);
+    const remainingCount = credentialConfigurations.length - 5;
+
+    items.push({
+      id: 'credential-configurations',
+      label: t('importExport:configureExport.labels.credentialConfigurations'),
+      icon: <IdCard size={16} />,
+      value: credentialConfigurationsCount,
+      status: 'ready',
+      dependencyCount: 0,
+      content: (
+        <Box sx={{px: 3, py: 2, bgcolor: 'background.default'}}>
+          <Stack spacing={2}>
+            <Stack spacing={2} divider={<Box sx={{borderBottom: 1, borderColor: 'divider'}} />}>
+              {displayedCredentialConfigurations.map((credentialConfiguration, idx) => (
+                <Stack
+                  key={
+                    credentialConfiguration.handle ?? credentialConfiguration.name ?? `credential-configuration-${idx}`
+                  }
+                  spacing={0.5}
+                >
+                  <Stack direction="row" spacing={1} sx={{alignItems: 'center'}}>
+                    <IdCard size={14} />
+                    <Typography variant="body2" fontWeight={600}>
+                      {credentialConfiguration.name ??
+                        credentialConfiguration.handle ??
+                        t('importExport:configureExport.fallback.unnamedCredentialConfiguration')}
+                    </Typography>
+                    {credentialConfiguration.vct && (
+                      <Chip label={credentialConfiguration.vct} size="small" sx={{height: 18, fontSize: '0.65rem'}} />
+                    )}
+                  </Stack>
+                  {credentialConfiguration.handle &&
+                    credentialConfiguration.name !== credentialConfiguration.handle && (
+                      <Typography variant="caption" color="text.secondary" sx={{pl: 2.5, fontFamily: 'monospace'}}>
+                        {credentialConfiguration.handle}
+                      </Typography>
+                    )}
+                </Stack>
+              ))}
+            </Stack>
+            {remainingCount > 0 && (
+              <Box sx={{pt: 1, textAlign: 'center'}}>
+                <Chip
+                  label={
+                    expandedCredentialConfigurations
+                      ? t('importExport:configureExport.actions.showLess')
+                      : t('importExport:configureExport.actions.more', {count: remainingCount})
+                  }
+                  size="small"
+                  variant="outlined"
+                  onClick={() => setExpandedCredentialConfigurations(!expandedCredentialConfigurations)}
+                  sx={{cursor: 'pointer'}}
+                />
+              </Box>
+            )}
+          </Stack>
+        </Box>
+      ),
+    });
+  }
+
+  // Add presentation definitions (OID4VP) if present
+  if (presentationDefinitionsCount > 0) {
+    const presentationDefinitions =
+      (configData?.['presentation_definition'] as {name?: string; handle?: string; vct?: string}[]) ?? [];
+    const displayedPresentationDefinitions = expandedPresentationDefinitions
+      ? presentationDefinitions
+      : presentationDefinitions.slice(0, 5);
+    const remainingCount = presentationDefinitions.length - 5;
+
+    items.push({
+      id: 'presentation-definitions',
+      label: t('importExport:configureExport.labels.presentationDefinitions'),
+      icon: <ShieldCheck size={16} />,
+      value: presentationDefinitionsCount,
+      status: 'ready',
+      dependencyCount: 0,
+      content: (
+        <Box sx={{px: 3, py: 2, bgcolor: 'background.default'}}>
+          <Stack spacing={2}>
+            <Stack spacing={2} divider={<Box sx={{borderBottom: 1, borderColor: 'divider'}} />}>
+              {displayedPresentationDefinitions.map((presentationDefinition, idx) => (
+                <Stack
+                  key={presentationDefinition.handle ?? presentationDefinition.name ?? `presentation-definition-${idx}`}
+                  spacing={0.5}
+                >
+                  <Stack direction="row" spacing={1} sx={{alignItems: 'center'}}>
+                    <ShieldCheck size={14} />
+                    <Typography variant="body2" fontWeight={600}>
+                      {presentationDefinition.name ??
+                        presentationDefinition.handle ??
+                        t('importExport:configureExport.fallback.unnamedPresentationDefinition')}
+                    </Typography>
+                    {presentationDefinition.vct && (
+                      <Chip label={presentationDefinition.vct} size="small" sx={{height: 18, fontSize: '0.65rem'}} />
+                    )}
+                  </Stack>
+                  {presentationDefinition.handle && presentationDefinition.name !== presentationDefinition.handle && (
+                    <Typography variant="caption" color="text.secondary" sx={{pl: 2.5, fontFamily: 'monospace'}}>
+                      {presentationDefinition.handle}
+                    </Typography>
+                  )}
+                </Stack>
+              ))}
+            </Stack>
+            {remainingCount > 0 && (
+              <Box sx={{pt: 1, textAlign: 'center'}}>
+                <Chip
+                  label={
+                    expandedPresentationDefinitions
+                      ? t('importExport:configureExport.actions.showLess')
+                      : t('importExport:configureExport.actions.more', {count: remainingCount})
+                  }
+                  size="small"
+                  variant="outlined"
+                  onClick={() => setExpandedPresentationDefinitions(!expandedPresentationDefinitions)}
                   sx={{cursor: 'pointer'}}
                 />
               </Box>

--- a/frontend/packages/configure-import-export/src/components/__tests__/ConfigureExport.test.tsx
+++ b/frontend/packages/configure-import-export/src/components/__tests__/ConfigureExport.test.tsx
@@ -372,6 +372,18 @@ type: google
       label: 'Server Configurations',
       body: (idx) => `resource_type: server_config\nname: Server Config ${idx}`,
     },
+    {
+      resourceType: 'credential_configuration',
+      label: 'Credential Configurations',
+      body: (idx) =>
+        `resource_type: credential_configuration\nname: Credential Config ${idx}\nhandle: credential-config-${idx}\nvct: VerifiableId`,
+    },
+    {
+      resourceType: 'presentation_definition',
+      label: 'Presentation Definitions',
+      body: (idx) =>
+        `resource_type: presentation_definition\nname: Presentation Definition ${idx}\nhandle: presentation-definition-${idx}\nvct: VerifiableId`,
+    },
   ];
 
   describe.each(resourceTypeCases)('$resourceType resource section', ({label, body}) => {

--- a/frontend/packages/configure-import-export/src/models/export-configuration.ts
+++ b/frontend/packages/configure-import-export/src/models/export-configuration.ts
@@ -68,6 +68,14 @@ export interface ExportRequest {
    */
   serverConfigs?: string[];
   /**
+   * List of credential configuration (OID4VCI template) IDs to export. Use `["*"]` to export all.
+   */
+  credentialConfigurations?: string[];
+  /**
+   * List of presentation definition (OID4VP) IDs to export. Use `["*"]` to export all.
+   */
+  presentationDefinitions?: string[];
+  /**
    * Optional configuration for export behavior
    */
   options?: ExportOptions;

--- a/frontend/packages/configure-import-export/src/pages/ExportPage.tsx
+++ b/frontend/packages/configure-import-export/src/pages/ExportPage.tsx
@@ -37,6 +37,8 @@ export default function ExportPage(): JSX.Element {
       groups: ['*'],
       agents: ['*'],
       serverConfigs: ['*'],
+      credentialConfigurations: ['*'],
+      presentationDefinitions: ['*'],
     });
   }, [mutate]);
 

--- a/frontend/packages/configure-import-export/src/pages/__tests__/ExportPage.test.tsx
+++ b/frontend/packages/configure-import-export/src/pages/__tests__/ExportPage.test.tsx
@@ -66,6 +66,8 @@ describe('ExportPage', () => {
           groups: ['*'],
           agents: ['*'],
           serverConfigs: ['*'],
+          credentialConfigurations: ['*'],
+          presentationDefinitions: ['*'],
         }),
       );
     });

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3232,6 +3232,8 @@ const translations = {
     'configureExport.labels.resourceServers': 'Resource Servers',
     'configureExport.labels.roles': 'Roles',
     'configureExport.labels.groups': 'Groups',
+    'configureExport.labels.credentialConfigurations': 'Credential Configurations',
+    'configureExport.labels.presentationDefinitions': 'Presentation Definitions',
     'configureExport.fallback.unnamedApplication': 'Unnamed Application',
     'configureExport.fallback.unnamedProvider': 'Unnamed Provider',
     'configureExport.fallback.unnamedFlow': 'Unnamed Flow',


### PR DESCRIPTION
### Purpose
The Console's Import/Export feature already supports bulk-exporting applications, flows, connections, and most other resource types. Verifiable Credential templates (OID4VCI credential configurations) and Presentation Definitions (OID4VP) were left out of the export request and export summary view, so they could not be exported from the Console UI even though the backend `/export` API and the Console's import summary page already handle both resource types.

### Screenshots

**Export page** — Credential Configurations and Presentation Definitions now appear as exportable resource rows:

![Export summary showing Credential Configurations and Presentation Definitions](https://raw.githubusercontent.com/thiva-k/thunder/pr-5336-screenshots/export-summary.png)

**Import summary page** — the same bundle, re-imported, shows both resource types correctly:

![Import summary showing Credential Configurations and Presentation Definitions](https://raw.githubusercontent.com/thiva-k/thunder/pr-5336-screenshots/import-summary.png)

### Approach
- Added `credentialConfigurations` and `presentationDefinitions` to the `ExportRequest` model.
- Requested both resource types (`['*']`) in `ExportPage`'s `fetchExport` call, mirroring the existing resource types.
- Added summary rows for both resource types in `ConfigureExport`, following the same pattern used for applications, roles, etc., and reusing the field names from the existing backend declarative-resource models (`name`, `handle`, `vct`).
- Added the two new i18n labels used by the new rows.

No backend changes were needed: the `/export` API, `CredentialConfigurationDTO`/presentation definition exporters, and the import-side summary page already supported both resource types.

### Related Issues
- Fixes #5256

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. (Vitest coverage added; see Tests below.)
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added export support for credential configurations and presentation definitions.
  - Export summaries now show resource names, handles, optional type metadata, and expandable lists for these resource types.
  - Full export includes all credential configurations and presentation definitions.
  - Added English labels for the new export categories.

- **Tests**
  - Added coverage for displaying and expanding the new resource sections.
  - Updated export request validation for the additional resource categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
