### PR TITLE
Stop design resolve distinguishing unknown and designless applications

### DIFF
--- a/api/design.yaml
+++ b/api/design.yaml
@@ -762,19 +762,23 @@ paths:
         "400":
           $ref: '#/components/responses/BadRequest'
         "404":
-          description: Entity not found or has no design configuration
+          description: >
+            No design could be resolved for the given entity. This endpoint is unauthenticated, so
+            it answers identically whether the entity has no theme or layout configured or does not
+            exist at all: a response that distinguished the two would let an anonymous caller
+            confirm which entity IDs are real.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
               example:
-                code: "DSR-1004"
+                code: "DSR-1005"
                 message:
-                  key: "design.resolve.error.app_not_found"
-                  defaultValue: "Application not found"
+                  key: "design.resolve.error.app_no_design"
+                  defaultValue: "Application has no design configuration"
                 description:
-                  key: "design.resolve.error.app_not_found_description"
-                  defaultValue: "The application with the specified id does not exist"
+                  key: "design.resolve.error.app_no_design_description"
+                  defaultValue: "The specified application does not have an associated theme or layout configuration"
         "500":
           $ref: '#/components/responses/InternalServerError'
 

--- a/backend/internal/design/common/error_constants.go
+++ b/backend/internal/design/common/error_constants.go
@@ -49,20 +49,13 @@ var (
 			DefaultValue: "The specified resolve type is not yet supported. Currently only 'APP' type is supported",
 		},
 	}
-	// ErrorApplicationNotFound is the error returned when an application is not found.
-	ErrorApplicationNotFound = tidcommon.ServiceError{
-		Type: tidcommon.ClientErrorType,
-		Code: "DSR-1004",
-		Error: tidcommon.I18nMessage{
-			Key:          "design.resolve.error.app_not_found",
-			DefaultValue: "Application not found",
-		},
-		ErrorDescription: tidcommon.I18nMessage{
-			Key:          "design.resolve.error.app_not_found_description",
-			DefaultValue: "The application with the specified id does not exist",
-		},
-	}
-	// ErrorApplicationHasNoDesign is the error returned when an application has no associated design.
+	// DSR-1004 ("Application not found") is retired and must not be reused. It shipped in v1.0.x, so
+	// reassigning the code would change the meaning of a response clients may already match on.
+	//
+	// ErrorApplicationHasNoDesign is the error returned when no design can be resolved for the given
+	// application, whether because it has none configured or because it does not exist. The resolve
+	// endpoint is unauthenticated, so it deliberately does not distinguish the two: a caller able to
+	// tell them apart could confirm which application IDs exist.
 	ErrorApplicationHasNoDesign = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
 		Code: "DSR-1005",

--- a/backend/internal/design/resolve/handler.go
+++ b/backend/internal/design/resolve/handler.go
@@ -65,8 +65,7 @@ func (
 			common.ErrorMissingResolveID.Code,
 			common.ErrorUnsupportedResolveType.Code:
 			statusCode = http.StatusBadRequest
-		case common.ErrorApplicationHasNoDesign.Code,
-			common.ErrorApplicationNotFound.Code:
+		case common.ErrorApplicationHasNoDesign.Code:
 			statusCode = http.StatusNotFound
 		default:
 			statusCode = http.StatusBadRequest

--- a/backend/internal/design/resolve/handler_test.go
+++ b/backend/internal/design/resolve/handler_test.go
@@ -160,27 +160,6 @@ func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_UnsupportedType()
 	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
 }
 
-// Test HandleResolveRequest - Application not found
-func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_ApplicationNotFound() {
-	mockService := &mockDesignResolveService{
-		resolveDesignFn: func(
-			ctx context.Context,
-			resolveType providers.DesignResolveType,
-			id string,
-		) (*providers.DesignResponse, *tidcommon.ServiceError) {
-			return nil, &common.ErrorApplicationNotFound
-		},
-	}
-
-	handler := newDesignResolveHandler(mockService)
-	req := httptest.NewRequest(http.MethodGet, "/design/resolve?type=APP&id=non-existent", nil)
-	w := httptest.NewRecorder()
-
-	handler.HandleResolveRequest(w, req)
-
-	assert.Equal(suite.T(), http.StatusNotFound, w.Code)
-}
-
 // Test HandleResolveRequest - Application has no design
 func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_ApplicationHasNoDesign() {
 	mockService := &mockDesignResolveService{
@@ -250,11 +229,6 @@ func (suite *ResolveHandlerTestSuite) TestHandleError_StatusCodeMapping() {
 		{
 			name:           "ApplicationHasNoDesign",
 			svcErr:         &common.ErrorApplicationHasNoDesign,
-			expectedStatus: http.StatusNotFound,
-		},
-		{
-			name:           "ApplicationNotFound",
-			svcErr:         &common.ErrorApplicationNotFound,
 			expectedStatus: http.StatusNotFound,
 		},
 		{

--- a/backend/internal/design/resolve/service.go
+++ b/backend/internal/design/resolve/service.go
@@ -79,8 +79,13 @@ func (drs *designResolveService) ResolveDesign(
 		if svcErr.Code == application.ErrorInvalidApplicationID.Code {
 			return nil, &common.ErrorMissingResolveID
 		}
+		// This endpoint is unauthenticated, so an unknown application reports the same result as a
+		// known one with nothing configured. Distinguishing them lets an anonymous caller confirm
+		// which application IDs exist.
 		if svcErr.Code == application.ErrorApplicationNotFound.Code {
-			return nil, &common.ErrorApplicationNotFound
+			drs.logger.Debug(ctx, "No design resolved; application does not exist",
+				log.String("applicationId", id))
+			return nil, &common.ErrorApplicationHasNoDesign
 		}
 		return nil, svcErr
 	}

--- a/backend/internal/design/resolve/service_test.go
+++ b/backend/internal/design/resolve/service_test.go
@@ -84,8 +84,10 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_NilApplicationService() 
 	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, err.Code)
 }
 
-// Test ResolveDesign - Application not found
-func (suite *ResolveServiceTestSuite) TestResolveDesign_ApplicationNotFound() {
+// Test ResolveDesign - an unknown application reports the same error as a known one with no design
+// configured. The resolve endpoint is unauthenticated, so a distinct error here would let an
+// anonymous caller confirm which application IDs exist.
+func (suite *ResolveServiceTestSuite) TestResolveDesign_UnknownApplicationIsIndistinguishable() {
 	suite.mockAppService.On("GetApplication", mock.Anything, "00000000-0000-0000-0000-000000000099").
 		Return(nil, &application.ErrorApplicationNotFound)
 
@@ -94,7 +96,9 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_ApplicationNotFound() {
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), common.ErrorApplicationNotFound.Code, err.Code)
+	assert.Equal(suite.T(), common.ErrorApplicationHasNoDesign.Code, err.Code)
+	assert.Equal(suite.T(), common.ErrorApplicationHasNoDesign.Error, err.Error)
+	assert.Equal(suite.T(), common.ErrorApplicationHasNoDesign.ErrorDescription, err.ErrorDescription)
 }
 
 // Test ResolveDesign - Invalid application ID (passed through to app service)

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -12,8 +12,6 @@ package core
 var defaultMessages = map[string]string{
 	"design.resolve.error.app_no_design": "Application has no design configuration",
 	"design.resolve.error.app_no_design_description": "The specified application does not have an associated theme or layout configuration",
-	"design.resolve.error.app_not_found": "Application not found",
-	"design.resolve.error.app_not_found_description": "The application with the specified id does not exist",
 	"design.resolve.error.invalid_type": "Invalid request format",
 	"design.resolve.error.invalid_type_description": "The 'type' query parameter is required and must be either 'APP' or 'OU'",
 	"design.resolve.error.missing_id": "Invalid request format",

--- a/tests/integration/design/resolve_api_test.go
+++ b/tests/integration/design/resolve_api_test.go
@@ -145,12 +145,15 @@ func (suite *ResolveAPITestSuite) TestResolveDesign_UnsupportedType() {
 }
 
 // Test Resolve Design - Application Not Found
+// An unknown application reports the same "no design" error as a known one with nothing
+// configured, so the response cannot be used to tell whether an application ID exists.
 func (suite *ResolveAPITestSuite) TestResolveDesign_ApplicationNotFound() {
 	_, statusCode, err := suite.resolveDesign("APP", "00000000-0000-0000-0000-000000000000")
 
 	suite.Error(err)
 	suite.Equal(http.StatusNotFound, statusCode)
-	suite.Contains(err.Error(), "DSR-1004")
+	suite.Contains(err.Error(), "DSR-1005")
+	suite.NotContains(err.Error(), "DSR-1004")
 }
 
 // Test Resolve Design - Success Case
@@ -186,6 +189,47 @@ func (suite *ResolveAPITestSuite) TestResolveDesign_ApplicationWithoutDesign() {
 	suite.Error(err)
 	suite.Equal(http.StatusNotFound, statusCode)
 	suite.Contains(err.Error(), "DSR-1005")
+}
+
+// Test Resolve Design - Unknown And Designless Applications Are Indistinguishable
+// This endpoint is unauthenticated, so an anonymous caller must not be able to tell a real
+// application from an unknown ID. Both cases have to answer with the same status and the same
+// body, byte for byte.
+func (suite *ResolveAPITestSuite) TestResolveDesign_UnknownAndDesignlessAreIndistinguishable() {
+	knownAppID := suite.createResolveApplication("Resolve Enumeration Probe", "", "")
+	defer suite.deleteResolveApplication(knownAppID)
+
+	knownStatus, knownBody := suite.rawResolveDesign("APP", knownAppID)
+	unknownStatus, unknownBody := suite.rawResolveDesign("APP", "00000000-0000-0000-0000-0000000000ff")
+
+	suite.Equal(http.StatusNotFound, knownStatus, "body: %s", knownBody)
+	suite.Equal(knownStatus, unknownStatus,
+		"an unknown application must not be distinguishable by status")
+	suite.Equal(knownBody, unknownBody,
+		"an unknown application must not be distinguishable by response body")
+}
+
+// rawResolveDesign issues a resolve request and returns the status and the response body verbatim,
+// so a test can compare two responses without the wrapping that resolveDesign applies.
+//
+// It deliberately uses a client that injects no credentials. The leak this guards against is one an
+// anonymous caller could exploit, and suite.client would attach a bearer token: /design/resolve is
+// not in the test transport's public-prefix list, so the comparison would otherwise run as an
+// authenticated administrator rather than the caller the endpoint is exposed to.
+func (suite *ResolveAPITestSuite) rawResolveDesign(resolveType, id string) (int, string) {
+	url := fmt.Sprintf("%s%s?type=%s&id=%s", testServerURL, resolveBasePath, resolveType, id)
+
+	req, err := http.NewRequest("GET", url, nil)
+	suite.Require().NoError(err)
+
+	resp, err := testutils.GetRawHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+
+	return resp.StatusCode, string(bodyBytes)
 }
 
 // Test Resolve Design - Only Theme Configured


### PR DESCRIPTION
### Purpose

 Remove an application confirmation oracle from the unauthenticated GET /design/resolve endpoint. Previously, unknown applications and existing applications without design configuration returned HTTP 404 with different error bodies, allowing callers to distinguish the two using an application ID they already held.

  ### ⚠️ Breaking Changes

  #### 🔧 Summary of Breaking Changes
  Unknown application IDs now return DSR-1005 instead of DSR-1004. The HTTP status remains 404.

  #### 💥 Impact
  Clients matching DSR-1004 must update their error handling. The existing frontend consumer checks only the HTTP status and is unaffected.

  #### 🔄 Migration Guide
  Treat HTTP 404 or DSR-1005 as “no design resolved.” Do not infer application existence from this response.

  ### Approach
  - Return the same error code, message, and description for unknown applications and applications without design configuration.
  - Preserve the underlying reason in server-side debug logs.
  - Remove the unused DSR-1004 error, handler mapping, and i18n defaults; document that the code is retired.
  - Add regression coverage comparing both HTTP statuses and response bodies byte for byte.
  - Update the OpenAPI specification while preserving released documentation snapshots.

  Applications with configured designs continue to return their existing successful responses.

  ### Related Issues

  - #5425

  ### Related PRs

  - N/A

  ### Checklist
  - [ ] Followed the contribution guidelines.
  - [x] Manual test round performed and verified.
  - [x] Documentation provided: OpenAPI specification (api/design.yaml).
      - [ ] Ran Vale and fixed all errors and warnings
  - [x] Tests provided.
      - [x] Unit Tests: resolve service tests (backend/internal/design/resolve/service_test.go)
      - [x] Integration Tests: resolve API tests (tests/integration/design/resolve_api_test.go)
  - [x] Breaking changes.
      - [x] Breaking changes section filled.
      - [ ] breaking change label added.

  ### Security checks
  - [ ] Followed secure coding standards in WSO2 Secure Coding Guidelines
  - [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Design resolution now returns the same “no design configuration” response for unknown entities and entities without configured designs.
  * Error responses no longer reveal whether an entity exists when accessed without authentication.
  * Updated the error code and message to clearly indicate that no design configuration is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
