### PR TITLE
Move every pinned action to Node 24

### DIFF
--- a/.github/actions/deploy-docs/action.yml
+++ b/.github/actions/deploy-docs/action.yml
@@ -40,13 +40,13 @@ runs:
   steps:
     - name: ⚙️ Set up Node.js
       if: inputs.build-docs == 'true'
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: 📦 Install pnpm
       if: inputs.build-docs == 'true'
-      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
       with:
         run_install: false
         version: ${{ inputs.pnpm-version }}
@@ -63,7 +63,7 @@ runs:
 
     - name: 📥 Download Docs Artifact
       if: inputs.docs-artifact-name != ''
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.docs-artifact-name }}
         path: docs/build
@@ -80,10 +80,10 @@ runs:
         ls -la docs/build
 
     - name: � Upload artifact
-      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
         path: ./docs/build
 
     - name: 🔥 Deploy to GitHub Pages
       id: deploy-gh-pages
-      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+      uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/.github/actions/generate-certificates/action.yml
+++ b/.github/actions/generate-certificates/action.yml
@@ -39,7 +39,7 @@ runs:
         fi
 
     - name: 📦 Upload Shared Certificates
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: |

--- a/.github/actions/patch-coverage-gate/action.yml
+++ b/.github/actions/patch-coverage-gate/action.yml
@@ -91,7 +91,7 @@ runs:
 
     - name: 📥 Download coverage artifacts
       if: steps.coverable.outputs.coverable == 'true' && steps.codecov-check.outputs.resolved != 'true' && (steps.codecov-api.outcome == 'skipped' || steps.codecov-api.outputs.resolved != 'true')
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: "*coverage*"
         path: coverage-artifacts

--- a/.github/actions/release-npm/action.yml
+++ b/.github/actions/release-npm/action.yml
@@ -41,13 +41,13 @@ runs:
   using: composite
   steps:
     - name: 📦 Set up pnpm
-      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
       with:
         run_install: false
         version: ${{ inputs.pnpm-version }}
 
     - name: ⚙️ Set up Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: 'https://registry.npmjs.org'

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: 📥 Download Built Distribution
       if: steps.staged_distribution.outputs.present != 'true'
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: product-distribution
         path: target/dist/

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -3,6 +3,9 @@ description: Sets up Go environment
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: backend/go.mod
+        # There is no go.sum at the repository root, so the default lookup finds nothing and
+        # the built-in cache silently does nothing. Key it off every module in the repository.
+        cache-dependency-path: "**/go.sum"

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -63,7 +63,7 @@ runs:
           echo "dependency-path=${DEPENDENCY_PATH}" >> $GITHUB_OUTPUT
         fi
 
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ steps.detect-package-manager.outputs.package-manager }}

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -23,12 +23,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+    - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
       with:
         run_install: false
         version: ${{ inputs.pnpm-version }}
 
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
 
@@ -49,7 +49,7 @@ runs:
     # attempts that follow.
     - name: 🗂️ Cache the pnpm store
       if: inputs.cache-store == 'true'
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.PNPM_STORE_PATH }}
         key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}--${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/actions/setup-samples-environment/action.yml
+++ b/.github/actions/setup-samples-environment/action.yml
@@ -27,7 +27,7 @@ runs:
       uses: ./.github/actions/setup-go
 
     - name: 📦 Install pnpm
-      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
       with:
         run_install: false
         version: ${{ inputs.pnpm-version }}
@@ -45,7 +45,7 @@ runs:
 
     - name: 📥 Download Shared Certificates
       if: inputs.download-certificates == 'true'
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.certificate-artifact-name }}
         path: target/out/.cert/

--- a/.github/actions/setup-turbo-cache/action.yml
+++ b/.github/actions/setup-turbo-cache/action.yml
@@ -15,7 +15,7 @@ runs:
     # because a failed attempt still saves at post time, so without it a partial
     # cache from attempt 1 would be frozen in for the attempts that follow.
     - name: 🗂️ Cache Turbo
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo
         key: turbo-${{ runner.os }}-${{ github.job }}-${{ hashFiles('pnpm-lock.yaml') }}--${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,7 +34,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔧 Resolve Site URLs
         id: resolve-urls

--- a/.github/workflows/docs-lint-full.yml
+++ b/.github/workflows/docs-lint-full.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔧 Install Vale
         run: |

--- a/.github/workflows/docs-style-check.yml
+++ b/.github/workflows/docs-style-check.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/forward-port-pr.yml
+++ b/.github/workflows/forward-port-pr.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Target Branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: 👥 Collect Assignees
         id: collect_assignees
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           AUTOMATION_BOT_LOGIN: ${{ env.RELEASE_GIT_USER_NAME }}
@@ -150,7 +150,7 @@ jobs:
 
       - name: 🔔 Create Forward-port PR
         id: create_pr
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           FORWARD_BRANCH: ${{ steps.cherry_pick.outputs.forward_branch }}
           SOURCE_BRANCH: ${{ steps.cherry_pick.outputs.source_branch }}
@@ -204,7 +204,7 @@ jobs:
             core.setOutput('pr_url', created.data.html_url);
 
       - name: 🏷️ Assign Users and Comment
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           NEW_PR_NUMBER: ${{ steps.create_pr.outputs.pr_number }}
           ORIGINAL_PR_NUMBER: ${{ steps.cherry_pick.outputs.pr_number }}

--- a/.github/workflows/nightly-build-validation.yml
+++ b/.github/workflows/nightly-build-validation.yml
@@ -22,20 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Go Environment
         uses: ./.github/actions/setup-go
-
-      - name: 🗄️ Cache Go Modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-modules-
 
       - name: 🔨 Build product for All Platforms
         uses: ./.github/actions/build-multiplatform
@@ -79,7 +69,7 @@ jobs:
       fail-fast: false
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Setup Samples Environment
         uses: ./.github/actions/setup-samples-environment
@@ -97,7 +87,7 @@ jobs:
       fail-fast: false
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Setup Samples Environment
         uses: ./.github/actions/setup-samples-environment
@@ -112,7 +102,7 @@ jobs:
     if: always()
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 📊 Check Overall Status
         id: check_status
@@ -159,7 +149,7 @@ jobs:
 
       - name: 🔔 Notify on Failure
         if: steps.check_status.outputs.status == 'failure'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BUILD_RESULT: ${{ needs.validate-complete-build.result }}
           LINUX_RESULT: ${{ needs.validate-sample-packaging-linux.result }}

--- a/.github/workflows/post-release-sync.yml
+++ b/.github/workflows/post-release-sync.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Target Branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: 🔔 Create Sync PR for Conflict Resolution
         if: steps.merge_sync.outputs.conflict_detected == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -39,23 +39,12 @@ jobs:
       distribution-path: ${{ steps.build.outputs.distribution-path }}
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: ⚙️ Set up Go Environment
         uses: ./.github/actions/setup-go
-
-      - name: 🗄️ Cache Go Modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        id: cache-go-modules
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-modules-
 
       - name: 📦 Install Dependencies
         run: |
@@ -86,7 +75,7 @@ jobs:
           echo "Built distribution: $DIST_PATH"
 
       - name: 📦 Upload Built Distribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: product-distribution
           path: target/dist/*.zip
@@ -138,24 +127,13 @@ jobs:
           --health-retries 5
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Go Environment
         uses: ./.github/actions/setup-go
 
-      - name: 🗄️ Cache Go Modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        id: cache-go-modules
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-modules-
-
       - name: 📥 Download Built Distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: product-distribution
           path: target/dist/
@@ -181,7 +159,7 @@ jobs:
           coverage-enabled: true
 
       - name: 📊 Upload Coverage Report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: postgres-coverage-report

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -50,7 +50,7 @@ jobs:
       powershell-changed: ${{ steps.filter.outputs.powershell }}
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -58,7 +58,7 @@ jobs:
       # merge_group payload, which a manual dispatch does not carry.
       - name: 🔍 Detect Docs and PowerShell Changes
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
@@ -90,7 +90,7 @@ jobs:
 
       - name: 🔎 Dependency Review
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           deny-licenses: GPL-3.0-only,GPL-3.0-or-later,AGPL-3.0-only,AGPL-3.0-or-later
@@ -129,7 +129,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Go Environment
         uses: ./.github/actions/setup-go
@@ -166,7 +166,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # We need the full history so that Turbo's --affected can diff against the PR or merge-group base commit.
           fetch-depth: 0
@@ -216,7 +216,7 @@ jobs:
       contents: read
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Go Environment
         uses: ./.github/actions/setup-go
@@ -225,17 +225,6 @@ jobs:
         uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: 🗄️ Cache Go Modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        id: cache-go-modules
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-modules-
 
       - name: 📦 Install Backend Dependencies
         run: |
@@ -275,7 +264,7 @@ jobs:
           echo "Built distribution: $DIST_PATH"
 
       - name: 📦 Upload Built Distribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: product-distribution
           path: target/dist/*.zip
@@ -292,22 +281,12 @@ jobs:
       contents: read
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: ⚙️ Set up Go Environment
         uses: ./.github/actions/setup-go
-
-      - name: 🗄️ Cache Go Modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-modules-
 
       - name: 📦 Install Backend Dependencies
         run: |
@@ -335,7 +314,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: 📦 Archive Unit Coverage Report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unit-coverage-report
           path: backend/coverage_unit.out
@@ -372,7 +351,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -404,7 +383,7 @@ jobs:
       # Each package writes its own coverage/lcov.info with repo-relative paths, so the
       # whole set is uploaded under one flag rather than one flag per package.
       - name: 📤 Upload packages coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: packages-coverage
           path: frontend/packages/*/coverage/lcov.info
@@ -418,7 +397,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Node.js and pnpm
         uses: ./.github/actions/setup-pnpm
@@ -453,7 +432,7 @@ jobs:
           fi
 
       - name: 📦 Upload gate coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gate-coverage
           path: frontend/apps/gate/coverage/lcov.info
@@ -481,7 +460,7 @@ jobs:
       SHARD_COUNT: 3
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Node.js and pnpm
         uses: ./.github/actions/setup-pnpm
@@ -518,7 +497,7 @@ jobs:
       # Named without "coverage" so the patch coverage gate, which downloads
       # every "*coverage*" artifact, only ever sees the merged report.
       - name: 📦 Upload console shard LCOV report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: console-lcov-shard-${{ matrix.shard }}
           path: frontend/apps/console/coverage/lcov.info
@@ -546,12 +525,12 @@ jobs:
           echo "✅ All console test shards passed"
 
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: 📥 Download console shard LCOV reports
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: console-lcov-shard-*
           path: console-shards
@@ -563,7 +542,7 @@ jobs:
           output-file: frontend/apps/console/coverage/lcov.info
 
       - name: 📦 Upload console coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: console-coverage
           path: frontend/apps/console/coverage/lcov.info
@@ -580,22 +559,22 @@ jobs:
       contents: read
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 📥 Download console coverage artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: console-coverage
           path: coverage/console
 
       - name: 📥 Download gate coverage artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gate-coverage
           path: coverage/gate
 
       - name: 📥 Download packages coverage artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: packages-coverage
           path: coverage/packages
@@ -659,7 +638,7 @@ jobs:
       checks: read
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -721,7 +700,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Go Environment
         uses: ./.github/actions/setup-go
@@ -736,7 +715,7 @@ jobs:
           make package_samples OS=$(go env GOOS) ARCH=$(go env GOARCH)
 
       - name: 📦 Upload Built Sample App
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sample-app-react-sdk
           path: target/dist/sample-app-react-sdk-*.zip
@@ -779,21 +758,10 @@ jobs:
           --health-retries 5
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Go Environment
         uses: ./.github/actions/setup-go
-
-      - name: 🗄️ Cache Go Modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        id: cache-go-modules
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-modules-
 
       - name: 📦 Install Dependencies
         run: |
@@ -816,7 +784,7 @@ jobs:
           coverage-enabled: true
 
       - name: 📦 Archive Integration Coverage Report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-coverage-${{ matrix.database }}
           path: target/coverage_integration.out
@@ -839,7 +807,7 @@ jobs:
       #   run: ./build.sh merge_coverage
 
       # - name: 📊 Upload Combined Coverage Report to Codecov
-      #   uses: codecov/codecov-action@v4
+      #   uses: codecov/codecov-action@v5
       #   with:
       #     token: ${{ secrets.CODECOV_TOKEN }}
       #     files: target/coverage_combined.out
@@ -893,7 +861,7 @@ jobs:
           apt-get install -y --no-install-recommends jq lsof unzip
 
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -906,13 +874,13 @@ jobs:
           pnpm --version
 
       - name: 📥 Download Built Distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: product-distribution
           path: target/dist/
 
       - name: 📥 Download Built Sample App
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sample-app-react-sdk
           path: target/dist/
@@ -1195,7 +1163,7 @@ jobs:
           SAMPLE_APP_USERNAME: ${{ secrets.SAMPLE_APP_USERNAME || vars.SAMPLE_APP_USERNAME || env.DEFAULT_SAMPLE_APP_USERNAME }}
           SAMPLE_APP_PASSWORD: ${{ secrets.SAMPLE_APP_PASSWORD || env.DEFAULT_SAMPLE_APP_PASSWORD }}
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
@@ -1322,7 +1290,7 @@ jobs:
           DEBUG_AUTH: ${{ vars.PLAYWRIGHT_DEBUG_AUTH || env.DEFAULT_DEBUG_AUTH }}
           SERVER_URL: ${{ env.DEFAULT_SERVER_URL }}
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-wayfinder
@@ -1338,7 +1306,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Node.js and pnpm
         uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Check for required PR labels
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const requiredLabels = [

--- a/.github/workflows/pre-release-sync.yml
+++ b/.github/workflows/pre-release-sync.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Source Branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: 🔔 Create Sync PR for Conflict Resolution
         if: steps.merge_sync.outputs.conflict_detected == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -72,7 +72,7 @@ jobs:
       commit_version: ${{ steps.get_version.outputs.commit_version }}
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
@@ -228,17 +228,6 @@ jobs:
       - name: ⚙️ Set up Go Environment  
         uses: ./.github/actions/setup-go  
 
-      - name: 🗄️ Cache Go Modules  
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4  
-        id: cache-go-modules  
-        with:  
-          path: |  
-            ~/.cache/go-build  
-            ~/go/pkg/mod  
-          key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}  
-          restore-keys: |  
-            ${{ runner.os }}-go-modules-  
-
       - name: 📦 Install Dependencies  
         run: |  
           cd backend  
@@ -259,7 +248,7 @@ jobs:
           echo "Built distribution: $DIST_PATH"
 
       - name: 📦 Upload Built Distribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: product-distribution
           path: target/dist/*.zip
@@ -289,23 +278,12 @@ jobs:
           --health-retries 5
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.RELEASE_BRANCH }}
 
       - name: ⚙️ Set up Go Environment
         uses: ./.github/actions/setup-go
-
-      - name: 🗄️ Cache Go Modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        id: cache-go-modules
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-modules-
 
       - name: 📦 Install Dependencies
         run: |
@@ -338,24 +316,13 @@ jobs:
     needs: [build, test-integration, validate-windows]
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ env.RELEASE_BRANCH }}
 
       - name: ⚙️ Set up Go Environment
         uses: ./.github/actions/setup-go
-
-      - name: 🗄️ Cache Go Modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        id: cache-go-modules
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-modules-
 
       - name: 📦 Install Dependencies
         run: |
@@ -365,13 +332,13 @@ jobs:
           go mod download
 
       - name: 📦 Install pnpm for Frontend Build
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           run_install: false
           version: ${{ env.PNPM_VERSION }}
 
       - name: ⚙️ Set up Node.js for Frontend Build
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -414,7 +381,7 @@ jobs:
         run: echo "version=$(cat version.txt)" >> $GITHUB_OUTPUT
 
       - name: 📦 Upload Backend Distribution Artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: product-distribution
           path: target/dist/*.zip
@@ -435,10 +402,10 @@ jobs:
           git push origin "$TAG_VERSION"
 
       - name: 🐳 Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: 🔐 Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -525,7 +492,7 @@ jobs:
           grep "tag:" install/helm/values.yaml | head -1
 
       - name: ⚙️ Set up Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: 'v3.12.3'
 
@@ -603,13 +570,13 @@ jobs:
           echo "✅ Updated version.txt to $NEXT_VERSION"
 
       - name: 📦 Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           run_install: false
           version: ${{ env.PNPM_VERSION }}
 
       - name: ⚙️ Set up Node.js for Version Update
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -633,7 +600,7 @@ jobs:
     needs: [build, build-and-package]
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ env.RELEASE_BRANCH }}
@@ -652,7 +619,7 @@ jobs:
         run: ./scripts/package-samples.sh
 
       - name: 📦 Upload Sample Artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.PRODUCT_NAME_LOWER }}-samples
           path: target/dist/*.zip
@@ -666,19 +633,19 @@ jobs:
       release_tag: ${{ steps.release_info.outputs.release_tag }}
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ env.RELEASE_BRANCH }}
 
       - name: 📥 Download Backend Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: product-distribution
           path: ./backend-artifacts
 
       - name: 📥 Download Sample Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.PRODUCT_NAME_LOWER }}-samples
           path: ./sample-artifacts
@@ -697,7 +664,7 @@ jobs:
           ls -la target/dist/
 
       - name: 📦 Upload Final Combined Artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: final-distribution
           path: target/dist/*.zip
@@ -711,7 +678,7 @@ jobs:
 
       - name: 📝 Generate Automatic Release Notes
         id: generate_notes
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const currentTag = '${{ needs.build.outputs.version }}';
@@ -909,7 +876,7 @@ jobs:
 
       - name: 📦 Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: ${{ env.PRODUCT_NAME }} ${{ steps.version.outputs.version }}
@@ -943,12 +910,12 @@ jobs:
     if: ${{ needs.build.outputs.run_performance_test == 'true' }}
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.RELEASE_BRANCH }}
 
       - name: ⚡ Trigger Performance Test Workflows
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.THUNDER_GITHUB_BOT_TOKEN }}
           script: |
@@ -985,7 +952,7 @@ jobs:
     needs: [build, release]
     steps:
       - name: 📚 Trigger Deploy Documentation Workflow
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
           script: |

--- a/.github/workflows/release-frontend.yml
+++ b/.github/workflows/release-frontend.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
 
@@ -105,7 +105,7 @@ jobs:
        (github.event_name == 'push' && github.event.head_commit.author.name != 'thunderid-automation-bot'))
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
 

--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
 

--- a/.github/workflows/windows-build-validation.yml
+++ b/.github/workflows/windows-build-validation.yml
@@ -24,21 +24,23 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Go Environment
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: backend/go.mod
+          # No go.sum at the repository root, so the default lookup finds nothing.
+          cache-dependency-path: "**/go.sum"
           cache: true
 
       - name: ⚙️ Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: 📦 Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           run_install: false
           version: ${{ env.PNPM_VERSION }}
@@ -49,7 +51,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $env:GITHUB_ENV
 
       - name: 🗄️ Setup pnpm cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -125,7 +127,7 @@ jobs:
       #   run: pnpm test:coverage
 
       - name: 📦 Upload Windows Distribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.PRODUCT_NAME_LOWER }}-windows-distribution-${{ github.run_id }}
           path: target/dist/${{ env.PRODUCT_NAME_LOWER }}-*-win-*.zip
@@ -136,15 +138,17 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Go Environment
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: backend/go.mod
+          # No go.sum at the repository root, so the default lookup finds nothing.
+          cache-dependency-path: "**/go.sum"
 
       - name: ⚙️ Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 'lts/*'
 
@@ -154,7 +158,7 @@ jobs:
           ./build.ps1 package_samples
 
       - name: 📦 Upload Built Sample App
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sample-app-react-sdk-windows-${{ github.run_id }}
           path: target/dist/sample-app-react-sdk-*.zip
@@ -166,12 +170,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Go Environment
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: backend/go.mod
+          # No go.sum at the repository root, so the default lookup finds nothing.
+          cache-dependency-path: "**/go.sum"
           cache: true
 
       - name: 📦 Install SQLite3
@@ -194,7 +200,7 @@ jobs:
           sqlite3 --version
 
       - name: 📥 Download Built Distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.PRODUCT_NAME_LOWER }}-windows-distribution-${{ github.run_id }}
           path: target/dist/
@@ -223,21 +229,21 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 'lts/*'
 
       - name: 📥 Download Built Distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.PRODUCT_NAME_LOWER }}-windows-distribution-${{ github.run_id }}
           path: target/dist/
 
       - name: 📥 Download Built Sample App
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sample-app-react-sdk-windows-${{ github.run_id }}
           path: target/dist/
@@ -464,7 +470,7 @@ jobs:
           SAMPLE_APP_PASSWORD: ${{ secrets.SAMPLE_APP_PASSWORD || 'e2e-test-password' }}
 
       - name: 📊 Upload Playwright Report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-windows-${{ github.run_id }}
@@ -521,7 +527,7 @@ jobs:
 
       - name: 🔔 Notify on Failure
         if: steps.check_status.outputs.status == 'failure'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BUILD_RESULT: ${{ needs.build-windows.result }}
           SAMPLES_RESULT: ${{ needs.build-samples-windows.result }}

--- a/.github/workflows/windows-powershell-validation.yml
+++ b/.github/workflows/windows-powershell-validation.yml
@@ -21,23 +21,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: ⚙️ Set up Go Environment
         uses: ./.github/actions/setup-go
-
-      - name: 🗄️ Cache Go Modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        id: cache-go-modules
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-modules-
 
       - name: 🔐 Generate Shared Certificates
         run: |
@@ -68,7 +57,7 @@ jobs:
           ls -lah target/dist/
 
       - name: 📦 Upload Windows Distribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.PRODUCT_NAME_LOWER }}-windows-distribution-${{ github.run_id }}
           path: target/dist/${{ env.PRODUCT_NAME_LOWER }}-*-win-*.zip
@@ -81,7 +70,7 @@ jobs:
 
     steps:
       - name: 📥 Download Windows Build Artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.PRODUCT_NAME_LOWER }}-windows-distribution-${{ github.run_id }}
           path: .


### PR DESCRIPTION
### Purpose
Node 20 is removed from the GitHub Actions runners on 23 September 2026. Every action pinned in this repository still targeted it, so every job logged a deprecation warning.
`actions/setup-go` has never cached anything in this repository: it looks for `go.sum` at the repository root, which does not exist here, so every Go job logged `Restore cache failed: Dependencies file is not found` and re-downloaded its modules from scratch.

This is the `1.0.x` counterpart of the same change on `main`. It is needed separately because local composite actions are read from the checked-out branch, so a release cut from `1.0.x` would otherwise load the old pins, and would get no Go cache at all now that `main`'s release builder no longer carries the hand-rolled cache steps.

### Approach
Re-pinned 121 `uses:` lines to releases whose own `action.yml` declares `node24`, verified by fetching `action.yml` at each pinned SHA. The two duplicate `actions/cache` pins were collapsed onto one.

Set `cache-dependency-path: "**/go.sum"` on `.github/actions/setup-go` so the built-in cache keys off all three Go modules instead of a root file that does not exist. Since setup-go now caches `GOMODCACHE` and `GOCACHE` itself, the ten hand-rolled `Cache Go Modules` steps became duplicates and were removed, across `pr-builder.yml` (3), `release-builder.yml` (3), `postgres-tests.yml` (2), `nightly-build-validation.yml` (1) and `windows-powershell-validation.yml` (1). The same setting was applied to the three `setup-go` calls in `windows-build-validation.yml` that bypass the composite.

**Local composite actions are read from the checked-out tree, not the dispatch ref, so this only takes effect on branches containing it.**


| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v7.0.1 |
| actions/upload-artifact | v4 | v7.0.1 |
| actions/download-artifact | v4 | v8.0.1 |
| actions/cache | v4 (two SHAs) | v6.1.0 |
| actions/github-script | v7 | v9.0.0 |
| actions/setup-node | v4 / v4.4.0 | v7.0.0 |
| actions/setup-go | v5 | v7.0.0 |
| pnpm/action-setup | v4.3.0 | v6.1.0 |
| docker/login-action | v3 | v4.6.0 |
| docker/setup-buildx-action | v3 | v4.3.0 |
| azure/setup-helm | v3 (node16) | v5.0.1 |
| softprops/action-gh-release | v2 | v3.0.3 |
| dorny/paths-filter | v3 | v4.0.3 |
| actions/dependency-review-action | v4 | v5.0.0 |
| actions/deploy-pages | v4 | v5.0.1 |
| actions/upload-pages-artifact | v3 | v5.0.0 |
| codecov/codecov-action | v4 | v5 |

### Related Issues
- #4981

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
