### PR TITLE
Fix roles claim missing declarative roles assigned via the database

### DIFF
--- a/backend/internal/role/all_permissions_test.go
+++ b/backend/internal/role/all_permissions_test.go
@@ -497,6 +497,109 @@ func TestCrossStoreAllPermissions_RemovedRoleIsStillSkipped(t *testing.T) {
 	assert.Empty(t, result)
 }
 
+// A role defined declaratively in the file store but assigned to the user via the DB must still
+// appear in the user's role names, not just in GetRoleAssignments/GetAllPermissionsForAssignees.
+func TestGetUserRoles_BridgesDBAssignmentOntoFileDefinedRole(t *testing.T) {
+	ctx := context.Background()
+	dbStore := newRoleStoreInterfaceMock(t)
+	fileStore := newRoleStoreInterfaceMock(t)
+	store := newCompositeRoleStore(fileStore, dbStore)
+
+	dbStore.EXPECT().GetUserRoles(ctx, "user1", []string{}).Return([]string{"dbRole"}, nil).Once()
+	fileStore.EXPECT().GetUserRoles(ctx, "user1", []string{}).Return([]string{}, nil).Once()
+	dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).Return([]string{"declarativeRole"}, nil).Once()
+	fileStore.EXPECT().IsRoleExist(ctx, "declarativeRole").Return(true, nil).Once()
+	fileStore.EXPECT().GetRole(ctx, "declarativeRole").
+		Return(RoleWithPermissions{Name: "Declarative Admin"}, nil).Once()
+
+	result, err := store.GetUserRoles(ctx, "user1", []string{})
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"dbRole", "Declarative Admin"}, result)
+}
+
+// A role ID from a DB assignment that is not declarative is already covered by dbStore.GetUserRoles,
+// so it must not be resolved (or double-counted) via the file store.
+func TestCrossStoreUserRoles_DBOnlyRoleIsSkipped(t *testing.T) {
+	ctx := context.Background()
+	dbStore := newRoleStoreInterfaceMock(t)
+	fileStore := newRoleStoreInterfaceMock(t)
+	store := newCompositeRoleStore(fileStore, dbStore)
+
+	dbStore.EXPECT().GetUserRoles(ctx, "user1", []string{}).Return([]string{"dbRole"}, nil).Once()
+	fileStore.EXPECT().GetUserRoles(ctx, "user1", []string{}).Return([]string{}, nil).Once()
+	dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).Return([]string{"dbOnlyRole"}, nil).Once()
+	fileStore.EXPECT().IsRoleExist(ctx, "dbOnlyRole").Return(false, nil).Once()
+
+	result, err := store.GetUserRoles(ctx, "user1", []string{})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dbRole"}, result)
+}
+
+// A role whose declarative definition was removed after the assignment was made genuinely confers
+// no name, so skipping it remains correct.
+func TestCrossStoreUserRoles_RemovedRoleIsSkipped(t *testing.T) {
+	ctx := context.Background()
+	dbStore := newRoleStoreInterfaceMock(t)
+	fileStore := newRoleStoreInterfaceMock(t)
+	store := newCompositeRoleStore(fileStore, dbStore)
+
+	dbStore.EXPECT().GetUserRoles(ctx, "user1", []string{}).Return([]string{}, nil).Once()
+	fileStore.EXPECT().GetUserRoles(ctx, "user1", []string{}).Return([]string{}, nil).Once()
+	dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).Return([]string{"gone"}, nil).Once()
+	fileStore.EXPECT().IsRoleExist(ctx, "gone").Return(true, nil).Once()
+	fileStore.EXPECT().GetRole(ctx, "gone").Return(RoleWithPermissions{}, ErrRoleNotFound).Once()
+
+	result, err := store.GetUserRoles(ctx, "user1", []string{})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+// Corruption is skipped here (unlike crossStoreAllPermissions' fail-closed enumeration): role names
+// feed an informational token claim, not an authorization decision, so this mirrors
+// crossStoreAuthorizedPermissions in skipping both ErrRoleNotFound and ErrRoleDataCorrupted.
+func TestCrossStoreUserRoles_CorruptRoleIsSkipped(t *testing.T) {
+	ctx := context.Background()
+	dbStore := newRoleStoreInterfaceMock(t)
+	fileStore := newRoleStoreInterfaceMock(t)
+	store := newCompositeRoleStore(fileStore, dbStore)
+
+	dbStore.EXPECT().GetUserRoles(ctx, "user1", []string{}).Return([]string{}, nil).Once()
+	fileStore.EXPECT().GetUserRoles(ctx, "user1", []string{}).Return([]string{}, nil).Once()
+	dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).Return([]string{"corrupt"}, nil).Once()
+	fileStore.EXPECT().IsRoleExist(ctx, "corrupt").Return(true, nil).Once()
+	fileStore.EXPECT().GetRole(ctx, "corrupt").
+		Return(RoleWithPermissions{}, ErrRoleDataCorrupted).Once()
+
+	result, err := store.GetUserRoles(ctx, "user1", []string{})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+// A load failure other than ErrRoleNotFound/ErrRoleDataCorrupted is an actionable storage/IO error
+// and must propagate rather than silently producing an incomplete roles claim.
+func TestCrossStoreUserRoles_OtherErrorPropagates(t *testing.T) {
+	ctx := context.Background()
+	dbStore := newRoleStoreInterfaceMock(t)
+	fileStore := newRoleStoreInterfaceMock(t)
+	store := newCompositeRoleStore(fileStore, dbStore)
+
+	dbStore.EXPECT().GetUserRoles(ctx, "user1", []string{}).Return([]string{}, nil).Once()
+	fileStore.EXPECT().GetUserRoles(ctx, "user1", []string{}).Return([]string{}, nil).Once()
+	dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).Return([]string{"broken"}, nil).Once()
+	fileStore.EXPECT().IsRoleExist(ctx, "broken").Return(true, nil).Once()
+	fileStore.EXPECT().GetRole(ctx, "broken").
+		Return(RoleWithPermissions{}, errors.New("disk read failure")).Once()
+
+	result, err := store.GetUserRoles(ctx, "user1", []string{})
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
 // A role widened between the pre-transaction check and the write must not be assignable on the
 // strength of the earlier result. The second CanGrantMembership call, made inside the transaction,
 // is what closes that window.

--- a/backend/internal/role/composite_store.go
+++ b/backend/internal/role/composite_store.go
@@ -605,7 +605,9 @@ func (c *compositeRoleStore) GetEntityRoleIDs(
 	return c.dbStore.GetEntityRoleIDs(ctx, entityID, groupIDs)
 }
 
-// GetUserRoles retrieves role names assigned to an entity from both stores.
+// GetUserRoles retrieves role names assigned to an entity, unioned across the three places a
+// role-to-assignee binding can live: see GetAllPermissionsForAssignees for why no single store
+// can answer this on its own.
 func (c *compositeRoleStore) GetUserRoles(
 	ctx context.Context, entityID string, groupIDs []string,
 ) ([]string, error) {
@@ -619,7 +621,55 @@ func (c *compositeRoleStore) GetUserRoles(
 		return nil, err
 	}
 
-	return mergePermissions(dbRoleNames, fileRoleNames), nil
+	crossStoreRoleNames, err := c.crossStoreUserRoles(ctx, entityID, groupIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergePermissions(mergePermissions(dbRoleNames, fileRoleNames), crossStoreRoleNames), nil
+}
+
+// crossStoreUserRoles resolves role names for the (declarative role definition in file store) +
+// (runtime assignment row in DB) case, mirroring crossStoreAuthorizedPermissions.
+func (c *compositeRoleStore) crossStoreUserRoles(
+	ctx context.Context, entityID string, groupIDs []string,
+) ([]string, error) {
+	if entityID == "" && len(groupIDs) == 0 {
+		return []string{}, nil
+	}
+
+	roleIDs, err := c.dbStore.GetEntityRoleIDs(ctx, entityID, groupIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(roleIDs) == 0 {
+		return []string{}, nil
+	}
+
+	names := make([]string, 0, len(roleIDs))
+	for _, id := range roleIDs {
+		exists, err := c.fileStore.IsRoleExist(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			// Role is DB-only; already covered by dbStore.GetUserRoles.
+			continue
+		}
+		role, err := c.fileStore.GetRole(ctx, id)
+		if err != nil {
+			// See crossStoreAuthorizedPermissions: benign cases are skipped, anything else propagates.
+			if errors.Is(err, ErrRoleNotFound) || errors.Is(err, ErrRoleDataCorrupted) {
+				continue
+			}
+			log.GetLogger().Error(ctx,
+				"Failed to load declarative role for cross-store role name resolution",
+				log.String("roleID", id), log.Error(err))
+			return nil, fmt.Errorf("composite role store: load declarative role %q: %w", id, err)
+		}
+		names = append(names, role.Name)
+	}
+	return names, nil
 }
 
 // IsRoleDeclarative checks if a role is immutable (exists in file store).

--- a/backend/internal/role/composite_store_edge_cases_test.go
+++ b/backend/internal/role/composite_store_edge_cases_test.go
@@ -442,6 +442,7 @@ func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetUserRoles_MergedOrderIs
 
 	suite.mockDBStore.On("GetUserRoles", suite.ctx, "user1", []string{"group1"}).Return(dbRoles, nil)
 	suite.mockFileStore.On("GetUserRoles", suite.ctx, "user1", []string{"group1"}).Return(fileRoles, nil)
+	suite.mockDBStore.On("GetEntityRoleIDs", suite.ctx, "user1", []string{"group1"}).Return([]string{}, nil)
 
 	first, err := suite.store.GetUserRoles(suite.ctx, "user1", []string{"group1"})
 	assert.NoError(suite.T(), err)
@@ -454,6 +455,93 @@ func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetUserRoles_MergedOrderIs
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), first, repeat, "Repeated calls must return the roles in the same order")
 	}
+}
+
+// A role defined declaratively in the file store but assigned to the user via the DB must still
+// appear in GetUserRoles, not just in GetRoleAssignments/GetAuthorizedPermissions. This is the
+// same cross-store bridge as TestGetAuthorizedPermissions_DeclarativeRoleWithDynamicAssignment,
+// applied to role names instead of permissions.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetUserRoles_BridgesDBAssignmentOntoFileDefinedRole() {
+	declarativeRoleID := "a1c00000-0000-0000-0000-000000000004"
+
+	suite.mockDBStore.On("GetUserRoles", suite.ctx, "user1", []string{}).Return([]string{"DBRole"}, nil)
+	suite.mockFileStore.On("GetUserRoles", suite.ctx, "user1", []string{}).Return([]string{}, nil)
+	suite.mockDBStore.On("GetEntityRoleIDs", suite.ctx, "user1", []string{}).
+		Return([]string{declarativeRoleID}, nil)
+	suite.mockFileStore.On("IsRoleExist", suite.ctx, declarativeRoleID).Return(true, nil)
+	suite.mockFileStore.On("GetRole", suite.ctx, declarativeRoleID).
+		Return(RoleWithPermissions{ID: declarativeRoleID, Name: "TenantInstanceAdmin"}, nil)
+
+	result, err := suite.store.GetUserRoles(suite.ctx, "user1", []string{})
+
+	assert.NoError(suite.T(), err)
+	assert.ElementsMatch(suite.T(), []string{"DBRole", "TenantInstanceAdmin"}, result)
+}
+
+// A role ID from a DB assignment that is not declarative is already covered by
+// dbStore.GetUserRoles, so it must not be resolved (or double-counted) via the file store.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetUserRoles_DBOnlyRoleIsNotDoubleResolved() {
+	suite.mockDBStore.On("GetUserRoles", suite.ctx, "user1", []string{}).Return([]string{"DBRole"}, nil)
+	suite.mockFileStore.On("GetUserRoles", suite.ctx, "user1", []string{}).Return([]string{}, nil)
+	suite.mockDBStore.On("GetEntityRoleIDs", suite.ctx, "user1", []string{}).
+		Return([]string{"dbOnlyRoleID"}, nil)
+	suite.mockFileStore.On("IsRoleExist", suite.ctx, "dbOnlyRoleID").Return(false, nil)
+
+	result, err := suite.store.GetUserRoles(suite.ctx, "user1", []string{})
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []string{"DBRole"}, result)
+}
+
+// Corruption is skipped here (unlike the enumeration helpers, which fail closed): role names feed
+// an informational token claim, not an authorization decision, so this mirrors
+// crossStoreAuthorizedPermissions in skipping both ErrRoleNotFound and ErrRoleDataCorrupted.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetUserRoles_CrossStoreSkipsBenignGetRoleErrors() {
+	for _, benignErr := range []error{ErrRoleNotFound, ErrRoleDataCorrupted} {
+		suite.Run(benignErr.Error(), func() {
+			suite.SetupTest()
+			suite.mockDBStore.On("GetUserRoles", suite.ctx, "user1", []string{}).Return([]string{}, nil)
+			suite.mockFileStore.On("GetUserRoles", suite.ctx, "user1", []string{}).Return([]string{}, nil)
+			suite.mockDBStore.On("GetEntityRoleIDs", suite.ctx, "user1", []string{}).
+				Return([]string{"role1"}, nil)
+			suite.mockFileStore.On("IsRoleExist", suite.ctx, "role1").Return(true, nil)
+			suite.mockFileStore.On("GetRole", suite.ctx, "role1").Return(RoleWithPermissions{}, benignErr)
+
+			result, err := suite.store.GetUserRoles(suite.ctx, "user1", []string{})
+
+			assert.NoError(suite.T(), err)
+			assert.Empty(suite.T(), result)
+		})
+	}
+}
+
+// A load failure other than ErrRoleNotFound/ErrRoleDataCorrupted is an actionable storage/IO
+// error and must propagate rather than silently producing an incomplete roles claim.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetUserRoles_CrossStorePropagatesGetRoleError() {
+	suite.mockDBStore.On("GetUserRoles", suite.ctx, "user1", []string{}).Return([]string{}, nil)
+	suite.mockFileStore.On("GetUserRoles", suite.ctx, "user1", []string{}).Return([]string{}, nil)
+	suite.mockDBStore.On("GetEntityRoleIDs", suite.ctx, "user1", []string{}).
+		Return([]string{"role1"}, nil)
+	suite.mockFileStore.On("IsRoleExist", suite.ctx, "role1").Return(true, nil)
+	suite.mockFileStore.On("GetRole", suite.ctx, "role1").
+		Return(RoleWithPermissions{}, errors.New("disk read failure"))
+
+	result, err := suite.store.GetUserRoles(suite.ctx, "user1", []string{})
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+}
+
+// Cross-store path must not call GetEntityRoleIDs when there's no assignee to look up.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetUserRoles_CrossStoreNoEntityNoGroups() {
+	suite.mockDBStore.On("GetUserRoles", suite.ctx, "", []string{}).Return([]string{}, nil)
+	suite.mockFileStore.On("GetUserRoles", suite.ctx, "", []string{}).Return([]string{}, nil)
+
+	result, err := suite.store.GetUserRoles(suite.ctx, "", []string{})
+
+	assert.NoError(suite.T(), err)
+	assert.Empty(suite.T(), result)
+	suite.mockDBStore.AssertNotCalled(suite.T(), "GetEntityRoleIDs", mock.Anything, mock.Anything, mock.Anything)
 }
 
 // Test GetAuthorizedPermissions with empty result


### PR DESCRIPTION
### Purpose
`GetUserRoles` on the composite role store queried the file-based (declarative) store and the database store independently and merged the results. A role defined declaratively but assigned to a user via the database (API) fell into the gap between the two independent lookups, so it never appeared in the user's roles / `roles` token claim, even though `GET /roles/{id}/assignments` correctly showed the assignment.

Cherry-picked from the `1.0.x` fix in #5346.

### Approach
Added a `crossStoreUserRoles` bridge on `compositeRoleStore`, mirroring the same pattern already used by three sibling methods (`crossStoreAuthorizedPermissions`, `crossStoreAllPermissions`, `getCompositeAssignments`): fetch assigned role IDs from the DB store, resolve any that exist in the file store to their declarative name, skip `ErrRoleNotFound`/`ErrRoleDataCorrupted`, and propagate other errors. `GetUserRoles` now merges DB roles, file-store roles, and this cross-store bridge.

`main` already had a `TestGetUserRoles_MergedOrderIsStable` test that didn't mock the new `GetEntityRoleIDs` call, so it's updated alongside new coverage for the bridge (declarative-role-via-DB-assignment, DB-only roles not double-resolved, benign vs. propagated `GetRole` errors, and the no-entity/no-groups short circuit).

Verified end-to-end against a locally built distribution (`make build`): configured `role.store: composite`, defined a declarative role with no YAML assignments, assigned it to a test user via the API (DB-only assignment), and confirmed the role now appears in the user's token `roles` claim. Reverting the fix and rebuilding reproduces the reported bug exactly (claim silently missing); reapplying the fix restores it.

### Related Issues
- Fixes #5345

### Related PRs
- #5346 (same fix on `1.0.x`)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User role listings now include declarative roles assigned at runtime.
  * Database and file-defined role names are merged without duplicate entries.
  * Missing or corrupted role records are skipped safely.
  * Unexpected role lookup errors are now surfaced instead of producing incomplete role information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->