### PR TITLE
Point the CLI's docs fetch at the bare /docs root instead of /docs/v1.0.x

### DIFF
--- a/tools/cli/internal/product/product.go
+++ b/tools/cli/internal/product/product.go
@@ -17,9 +17,11 @@ const (
 	GitHubArchiveURL = "https://codeload.github.com/thunder-id/thunderid/zip/refs/heads/main"
 )
 
-// DocsVersionURL is the root of the current versioned docs tree, indexed at
-// https://thunderid.dev/llms.txt. Bump this when the docs site cuts a new version.
-const DocsVersionURL = "https://thunderid.dev/docs/v1.0.x"
+// DocsVersionURL is the root of the current docs tree, indexed at
+// https://thunderid.dev/llms.txt. The latest release is served at the bare
+// /docs root (not a versioned path); only /docs/next carries a path segment,
+// for the unreleased preview.
+const DocsVersionURL = "https://thunderid.dev/docs"
 
 // DocsBaseURL is the canonical per-platform "connect your application" guide directory.
 // Appending "/<slug>.md" fetches the raw markdown guide; appending "/<slug>" (no

--- a/tools/cli/internal/services/docs/docs_test.go
+++ b/tools/cli/internal/services/docs/docs_test.go
@@ -45,7 +45,7 @@ func TestFetchGuide_ErrorsOnNon200(t *testing.T) {
 
 func TestSiteURL_NoMarkdownExtension(t *testing.T) {
 	assert.Equal(t,
-		"https://thunderid.dev/docs/v1.0.x/getting-started/connect-your-application/react",
+		"https://thunderid.dev/docs/getting-started/connect-your-application/react",
 		SiteURL("react"),
 	)
 }


### PR DESCRIPTION
### Purpose

The CLI fetches per-platform "connect your application" guides (used by the REPL's `/integrate-*` commands and `thunderid integrate`) from `product.DocsVersionURL`, hardcoded to `https://thunderid.dev/docs/v1.0.x`.

#5247 moved the v1.0.x release docs from `/docs/v1.0.x/*` to the bare `/docs` root (it's the `lastVersion`; only `/docs/next` keeps a path segment now). The `@docusaurus/plugin-client-redirects` added in that PR only generates static HTML redirect stubs for browser navigation, it doesn't cover the raw `.md` export path the CLI fetches. So the CLI's hardcoded URL now 404s:

```
$ curl -I https://thunderid.dev/docs/v1.0.x/getting-started/connect-your-application/react.md
HTTP/2 404
```

while the content lives at the new root:

```
$ curl -I https://thunderid.dev/docs/getting-started/connect-your-application/react.md
HTTP/2 200
```

This is what's failing `tests/e2e-cli/tests/repl/integrate.spec.ts` ("REPL /integrate › loads the React guide") on CLI E2E (ubuntu-latest and macos-latest) for every PR since the docs move landed, independent of what each PR actually changes.

### Approach

Update `product.DocsVersionURL` to point at the bare `/docs` root instead of the retired `/docs/v1.0.x` segment, matching the current docs layout. Updated the accompanying unit test's expected URL to match.

### Related Issues
- N/A

### Related PRs
- #5247 (moved the v1.0.x release docs to the `/docs` root; this PR is the fix-up for the CLI's now-stale URL)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Documentation links now use the latest release at the unversioned `/docs` path.
  - Links to the application connection guide now point to the updated documentation URL.
  - Documentation URL validation has been updated to reflect the new path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->