### PR TITLE
Fixed the script that generates md files so they stay in versioned doc links.

### DIFF
--- a/docs/plugins/docusaurus-plugin-markdown-export/index.js
+++ b/docs/plugins/docusaurus-plugin-markdown-export/index.js
@@ -13,9 +13,10 @@ const {processMarkdownFile} = require('./mdxProcessor');
  *     → build/docs/next/getting-started/foo.md
  *     → served at /docs/next/getting-started/foo.md
  *
- *   versioned_docs/version-v1.0.x/getting-started/foo.mdx (permalink /docs/v1.0.x/getting-started/foo)
- *     → build/docs/v1.0.x/getting-started/foo.md
- *     → served at /docs/v1.0.x/getting-started/foo.md
+ *   versioned_docs/version-v1.0.x/getting-started/foo.mdx (v1.0.x is the
+ *   lastVersion, so its permalink is the bare /docs/getting-started/foo)
+ *     → build/docs/getting-started/foo.md
+ *     → served at /docs/getting-started/foo.md
  *
  *   community/overview.mdx (permalink /community/overview)
  *     → build/community/overview.md
@@ -25,6 +26,12 @@ const {processMarkdownFile} = require('./mdxProcessor');
  * slug from the source file path) keeps this in lockstep with
  * docusaurus-plugin-llms-txt, including for index/category-root docs whose
  * permalink has no trailing "/index" segment.
+ *
+ * The lastVersion's docs also get a copy written under their old
+ * /docs/<versionName>/... path (e.g. /docs/v1.0.x/getting-started/foo.md),
+ * matching the alias @docusaurus/plugin-client-redirects generates for the
+ * HTML pages, so links and tooling built against the pre-lastVersion-move
+ * .md URLs (see tools/cli/internal/product.DocsVersionURL) keep working.
  */
 module.exports = function pluginMarkdownExport(context) {
   const {siteDir, siteConfig} = context;
@@ -41,6 +48,20 @@ module.exports = function pluginMarkdownExport(context) {
   // relative to `outDir`, which Docusaurus serves mounted at baseUrl.
   function stripBaseUrl(permalink) {
     return permalink.startsWith(baseUrl) ? permalink.slice(baseUrl.length - 1) : permalink;
+  }
+
+  // For the lastVersion, also resolve the pre-move URL (e.g. "/docs/getting-started/foo"
+  // → "/docs/v1.0.x/getting-started/foo") so its .md files stay reachable at their old
+  // path. Returns null for every other version, since only the lastVersion's URL moved.
+  function legacyLastVersionAlias(relPermalink, version) {
+    if (!version.isLast || version.versionName === 'current') {
+      return null;
+    }
+    const [routeBase, ...rest] = relPermalink.split('/').filter(Boolean);
+    if (!routeBase) {
+      return null;
+    }
+    return '/' + [routeBase, version.versionName, ...rest].join('/');
   }
 
   async function exportVersion(outDir, version) {
@@ -64,6 +85,14 @@ module.exports = function pluginMarkdownExport(context) {
         fs.mkdirSync(path.dirname(outputPath), {recursive: true});
         fs.writeFileSync(outputPath, cleaned);
         written++;
+
+        const aliasPermalink = legacyLastVersionAlias(relPermalink, version);
+        if (aliasPermalink) {
+          const aliasOutputPath = path.join(outDir, aliasPermalink + '.md');
+          fs.mkdirSync(path.dirname(aliasOutputPath), {recursive: true});
+          fs.writeFileSync(aliasOutputPath, cleaned);
+          written++;
+        }
       } catch (err) {
         console.error(`[markdown-export] Error processing ${fullPath}: ${err.message}`);
       }


### PR DESCRIPTION
### Purpose
$subject

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documentation exports now preserve legacy versioned `.md` URLs, improving compatibility with existing links and bookmarks.
  - Added automated documentation coverage reports, including maturity scoring, demand signals, drift checks, trend tracking, and downloadable scan results.
- **Chores**
  - Generated documentation scan artifacts are now excluded from source control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->