### PR TITLE
Guard the API permission map against oversized request paths

### DIFF
--- a/backend/internal/system/security/constants.go
+++ b/backend/internal/system/security/constants.go
@@ -7,4 +7,9 @@ const (
 	// maxPublicPathLength defines the maximum allowed length for a public path.
 	// This prevents potential DoS attacks via excessively long paths (even with safe regex).
 	maxPublicPathLength = 4096
+
+	// maxAPIPermissionPathLength defines the maximum request path length evaluated against the API
+	// permission map. The map holds one anchored pattern per entry and matching costs time linear in
+	// the path length, so a longer path is treated as matching no entry rather than being scanned.
+	maxAPIPermissionPathLength = 4096
 )

--- a/backend/internal/system/security/service.go
+++ b/backend/internal/system/security/service.go
@@ -136,6 +136,17 @@ func (s *securityService) Process(r *http.Request) (context.Context, error) {
 // authorize checks whether the permissions stored in the request context satisfy
 // the requirements for the requested path using hierarchical scope matching.
 func (s *securityService) authorize(r *http.Request) error {
+	// The permission map evaluates the path against every entry it holds, at a cost linear in the
+	// path length. A path beyond the limit cannot match a route, so it is refused without being
+	// scanned. Nothing is compared, so this is a refusal rather than a permission decision.
+	if len(r.URL.Path) > maxAPIPermissionPathLength {
+		s.logger.Warn(r.Context(), "Request path exceeds the maximum length matched against the "+
+			"API permission map",
+			log.Int("limit", maxAPIPermissionPathLength),
+			log.Int("length", len(r.URL.Path)))
+		return errForbidden
+	}
+
 	required := s.getRequiredPermissionForAPI(r.Method, r.URL.Path)
 	// Empty required means any authenticated user may access the path.
 	if required == "" {

--- a/backend/internal/system/security/service_test.go
+++ b/backend/internal/system/security/service_test.go
@@ -613,3 +613,23 @@ func (suite *SecurityServiceTestSuite) TestProcess_AuthorizationFailure_Insuffic
 	assert.Nil(suite.T(), ctx)
 	assert.ErrorIs(suite.T(), err, errInsufficientPermissions)
 }
+
+// Test that a path longer than the matcher limit is refused without being evaluated against the
+// API permission map.
+//
+// The path sits under "GET /users/me/**", which any authenticated subject may access, and the
+// subject here holds the root permission. Either of those would let the request through had the map
+// been consulted, so the rejection is what shows the scan was skipped and that skipping it fails
+// closed.
+func (suite *SecurityServiceTestSuite) TestProcess_OversizedPath_SkipsPermissionMap() {
+	req := httptest.NewRequest(http.MethodGet,
+		"/users/me/"+strings.Repeat("a", maxAPIPermissionPathLength), nil)
+
+	suite.mockAuth1.On("CanHandle", req).Return(true)
+	suite.mockAuth1.On("Authenticate", req).Return(suite.testCtx, nil)
+
+	ctx, err := suite.service.Process(req)
+
+	assert.Nil(suite.T(), ctx)
+	assert.ErrorIs(suite.T(), err, errForbidden)
+}

--- a/tests/integration/system/apiauth/api_auth_test.go
+++ b/tests/integration/system/apiauth/api_auth_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,11 @@ import (
 )
 
 const testServerURL = testutils.TestServerURL
+
+// maxRequestPathLength mirrors the maximum request path length the server matches against the API
+// permission map. The server-side constant is unexported and lives in a separate module, so the
+// value is repeated here.
+const maxRequestPathLength = 4096
 
 // i18nMessage mirrors the i18n message structure returned in API error responses.
 type i18nMessage struct {
@@ -190,6 +196,24 @@ func (suite *APIAuthTestSuite) TestNonSystemScopeIsForbidden() {
 	suite.Empty(resp.Header.Get("WWW-Authenticate"))
 }
 
+// Authorization: a request path longer than the matcher limit is forbidden.
+//
+// The system token carries the root permission, so this request would be authorized had the path
+// been matched against the API permission map. The 403 is what shows it was refused on length alone,
+// and that refusing rather than matching fails closed.
+func (suite *APIAuthTestSuite) TestOversizedPathIsForbidden() {
+	req, err := http.NewRequest(http.MethodGet, suite.oversizedPathURL(), nil)
+	suite.Require().NoError(err)
+
+	resp, err := suite.adminClient.Do(req)
+	suite.Require().NoError(err)
+	defer closeBodyQuietly(suite.T(), resp.Body)
+
+	suite.assertSecurityError(resp, http.StatusForbidden, "AUTH-4030",
+		"You do not have sufficient permissions to access this resource")
+	suite.Empty(resp.Header.Get("WWW-Authenticate"))
+}
+
 func (suite *APIAuthTestSuite) assertSecurityError(resp *http.Response, expectedStatus int,
 	expectedCode, expectedDescription string) {
 	suite.Equal(expectedStatus, resp.StatusCode)
@@ -206,6 +230,12 @@ func (suite *APIAuthTestSuite) assertSecurityError(resp *http.Response, expected
 
 func (suite *APIAuthTestSuite) protectedResourceURL() string {
 	return fmt.Sprintf("%s/organization-units/%s", testServerURL, suite.ouID)
+}
+
+// oversizedPathURL returns the URL of an existing route whose path exceeds maxRequestPathLength.
+func (suite *APIAuthTestSuite) oversizedPathURL() string {
+	return fmt.Sprintf("%s/organization-units/%s", testServerURL,
+		strings.Repeat("a", maxRequestPathLength))
 }
 
 func closeBodyQuietly(t *testing.T, body io.ReadCloser) {


### PR DESCRIPTION
### Purpose

`getRequiredPermissionForAPI` evaluates the request path against one anchored regular expression per entry in the API permission map (38 entries), and matching costs time linear in the path length. There was no upper bound on tlding a valid token could turn a single request into milliseconds ofmatching work.

Reported measurements: **1.7 µs** for a normal path, **592 µs** at 100 KB, **4.5 ms** at 900 KB — roughly **2,600×** amplification. 900 KB is reachable because
the server leaves `MaxHeaderBytes` at Go's 1 MB default (`main.go` ut`).

Two clarifications on the nature of the issue:

- **This is not ReDoS.** Go's `regexp` is RE2, so there is no backt linear work multiplied by the number of patterns. The `**` formscompile to `^<base>(?:/.*)?$`, so once the literal base matches, `.*` scans to the end of the payload.
- **It requires authentication.** In `Process`, the order is publicr selection → `Authenticate` → revocation check → `authorize`. Everyunauthenticated exit returns before the permission map is consulted, so a valid, unrevoked token is needed. The unauthenticated surface was already protected.

The public path list has carried a 4096-character guard since it was introduced, and its comment names this exact threat: _"This prevents potential DoS attacks
via excessively long paths (even with safe regex)."_ The API permisithout one. This PR completes that existing mitigation rather thanintroducing a new policy.

### Approach

Measure the path **once**, at the top of `Process`, before either matcher runs:

```go
oversizedPath := len(r.URL.Path) > maxAPIPermissionPathLength
if oversizedPath {
    s.logger.Warn(r.Context(), "Request path exceeds the maximum ma
}
isPublic := !oversizedPath && s.isPublicPath(r.Context(), r.URL.Pat
```

A single early guard rather than one per matcher, so it also covers any matcher added later, and so the cost is skipped before JWT verification too.

`authorize` then refuses the request outright:

```go
if oversizedPath {
    return errForbidden
}
```

Key design decisions:

**Refuse rather than fall back to the root permission.** An earlier revision resolved the root permission for oversized paths, preserving today's behaviour
exactly (an unmatched path already falls back to root). It was dropually compared — no permission was evaluated — so reporting"insufficient permissions" would describe a comparison that never happened. `errForbidden` is returned instead; both map to 403 in `writeSecurityError`. This also
removed a hazard: `GetSystemRootPermission` panics when the permissso calling it here added a landmine that had to be commented around.

**Two separate constants.** `maxPublicPathLength` is left exactly assionPathLength` added for the new guard, so each matcher can betuned independently. Both are currently 4096.

**`isPublicPath` keeps its own internal check.** It is called directly by unit tests and remains correct in isolation; the duplicated `len()` comparison is O(1).

**Behaviour change, in one narrow case.** A caller holding the root permission with a path over 4096 characters previously fell through to the router (yielding a
404) and now receives 403. No route is that long, so no legitimate lassed as a breaking change for that reason — flagged here forreviewer visibility.

### Related Issues
- #5426

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests — `TestProcess_OversizedPath_SkipsPermissionMap` in `backend/internal/system/security/service_test.go`
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure CodingGuidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tosecrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Requests with excessively long API paths are now rejected with a forbidden response.
  - Oversized paths are refused before permission matching and cannot bypass security checks or match configured permission paths, even when the requester would otherwise have sufficient permissions.
  - Such requests do not receive an authentication challenge header.

- **Tests**
  - Added coverage verifying authorization behavior for oversized API requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
