### PR TITLE
Rename MessageProviderType to NotificationProviderType to improve extensibility

### DIFF
--- a/backend/internal/connection/declarative_resource.go
+++ b/backend/internal/connection/declarative_resource.go
@@ -262,15 +262,15 @@ func connectionModelFromSenderDTO(dto ncommon.NotificationSenderDTO) (connection
 		Description: dto.Description,
 	}
 	switch dto.Provider {
-	case ncommon.MessageProviderTypeTwilio:
+	case ncommon.NotificationProviderTypeTwilio:
 		model.AccountSID = values[ncommon.TwilioPropKeyAccountSID]
 		model.AuthToken = values[ncommon.TwilioPropKeyAuthToken]
 		model.SenderID = values[ncommon.TwilioPropKeySenderID]
-	case ncommon.MessageProviderTypeVonage:
+	case ncommon.NotificationProviderTypeVonage:
 		model.APIKey = values[ncommon.VonagePropKeyAPIKey]
 		model.APISecret = values[ncommon.VonagePropKeyAPISecret]
 		model.SenderID = values[ncommon.VonagePropKeySenderID]
-	case ncommon.MessageProviderTypeCustom:
+	case ncommon.NotificationProviderTypeCustom:
 		model.URL = values[ncommon.CustomPropKeyURL]
 		model.HTTPMethod = values[ncommon.CustomPropKeyHTTPMethod]
 		model.HTTPHeaders = values[ncommon.CustomPropKeyHTTPHeaders]

--- a/backend/internal/connection/declarative_resource_test.go
+++ b/backend/internal/connection/declarative_resource_test.go
@@ -75,7 +75,7 @@ func (s *DeclarativeResourceTestSuite) TestConnectionModelFromIDPDTORejectsUnreg
 func (s *DeclarativeResourceTestSuite) TestConnectionModelFromSenderDTOUnmasksSecret() {
 	dto := ncommon.NotificationSenderDTO{
 		ID: "tw-1", Name: "My Twilio", Type: ncommon.NotificationSenderTypeMessage,
-		Provider: ncommon.MessageProviderTypeTwilio,
+		Provider: ncommon.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{
 			mustProperty(s.T(), ncommon.TwilioPropKeyAccountSID, "AC00000000000000000000000000000000", false),
 			mustProperty(s.T(), ncommon.TwilioPropKeyAuthToken, "tok", true),
@@ -91,7 +91,7 @@ func (s *DeclarativeResourceTestSuite) TestConnectionModelFromSenderDTOUnmasksSe
 func (s *DeclarativeResourceTestSuite) TestConnectionModelFromSenderDTOSMSGateway() {
 	dto := ncommon.NotificationSenderDTO{
 		ID: "sg-1", Name: "Gateway", Type: ncommon.NotificationSenderTypeMessage,
-		Provider: ncommon.MessageProviderTypeCustom,
+		Provider: ncommon.NotificationProviderTypeCustom,
 		Properties: []cmodels.Property{
 			mustProperty(s.T(), ncommon.CustomPropKeyURL, "https://sms.example.com/send", false),
 		},
@@ -154,7 +154,7 @@ func (s *DeclarativeResourceTestSuite) TestConnectionModelToDTORoundTripsSMSVend
 	cases := []struct {
 		name         string
 		model        connectionExportModel
-		wantProvider ncommon.MessageProviderType
+		wantProvider ncommon.NotificationProviderType
 	}{
 		{
 			"twilio",
@@ -162,19 +162,19 @@ func (s *DeclarativeResourceTestSuite) TestConnectionModelToDTORoundTripsSMSVend
 				ID: "s1", Type: "twilio", Name: "n", AccountSID: "AC00000000000000000000000000000000",
 				AuthToken: "t", SenderID: "+1",
 			},
-			ncommon.MessageProviderTypeTwilio,
+			ncommon.NotificationProviderTypeTwilio,
 		},
 		{
 			"vonage",
 			connectionExportModel{
 				ID: "s2", Type: "vonage", Name: "n", APIKey: "k", APISecret: "s", SenderID: "ThunderID",
 			},
-			ncommon.MessageProviderTypeVonage,
+			ncommon.NotificationProviderTypeVonage,
 		},
 		{
 			"sms-gateway",
 			connectionExportModel{ID: "s3", Type: smsGatewayVendorName, Name: "n", URL: "https://x/send"},
-			ncommon.MessageProviderTypeCustom,
+			ncommon.NotificationProviderTypeCustom,
 		},
 	}
 	for _, tc := range cases {
@@ -252,7 +252,7 @@ httpMethod: POST
 	s.Nil(idpDTO)
 	s.Require().NotNil(senderDTO)
 	s.Equal("prod-sms", senderDTO.ID)
-	s.Equal(ncommon.MessageProviderTypeCustom, senderDTO.Provider)
+	s.Equal(ncommon.NotificationProviderTypeCustom, senderDTO.Provider)
 }
 
 func (s *DeclarativeResourceTestSuite) TestParseToConnectionDTOWrapperIDPVendor() {
@@ -362,7 +362,7 @@ func (s *DeclarativeResourceTestSuite) TestGetResourceByIDFallsBackToSender() {
 	s.mockNotif.On("GetSender", mock.Anything, "tw-1").
 		Return(&ncommon.NotificationSenderDTO{
 			ID: "tw-1", Name: "My Twilio", Type: ncommon.NotificationSenderTypeMessage,
-			Provider: ncommon.MessageProviderTypeTwilio,
+			Provider: ncommon.NotificationProviderTypeTwilio,
 			Properties: []cmodels.Property{
 				mustProperty(s.T(), ncommon.TwilioPropKeyAccountSID, "AC00000000000000000000000000000000", false),
 			},
@@ -382,8 +382,8 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDsFiltersUnregisteredV
 		{ID: "2", Type: providers.IDPType("SAML")}, // unregistered -> excluded
 	}, (*tidcommon.ServiceError)(nil))
 	s.mockNotif.On("ListSenders", mock.Anything).Return([]ncommon.NotificationSenderDTO{
-		{ID: "s1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeTwilio},
-		{ID: "s2", Type: ncommon.NotificationSenderTypeEmail, Provider: ncommon.MessageProviderType("mailer")},
+		{ID: "s1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeTwilio},
+		{ID: "s2", Type: ncommon.NotificationSenderTypeEmail, Provider: ncommon.NotificationProviderType("mailer")},
 	}, (*tidcommon.ServiceError)(nil))
 
 	ids, svcErr := s.exporter.GetAllResourceIDs(context.Background())
@@ -418,7 +418,7 @@ func (s *DeclarativeResourceTestSuite) TestConnectionDeclarativeStoreDispatchesB
 	s.Require().NoError(err)
 	s.Equal(idpDTO, got)
 
-	senderDTO := &ncommon.NotificationSenderDTO{ID: "sender-1", Provider: ncommon.MessageProviderTypeTwilio}
+	senderDTO := &ncommon.NotificationSenderDTO{ID: "sender-1", Provider: ncommon.NotificationProviderTypeTwilio}
 	s.Require().NoError(store.Create("sender-1", senderDTO))
 	got, err = store.senderStore.Get("sender-1")
 	s.Require().NoError(err)
@@ -448,7 +448,7 @@ func (s *DeclarativeResourceTestSuite) TestConnectionDeclarativeStoreSkipsIDPWhe
 	_, err := store.idpStore.Get("idp-1")
 	s.Error(err, "IDP declarative resource should not be stored when idp store mode is mutable")
 
-	senderDTO := &ncommon.NotificationSenderDTO{ID: "sender-1", Provider: ncommon.MessageProviderTypeTwilio}
+	senderDTO := &ncommon.NotificationSenderDTO{ID: "sender-1", Provider: ncommon.NotificationProviderTypeTwilio}
 	s.Require().NoError(store.Create("sender-1", senderDTO))
 	got, err := store.senderStore.Get("sender-1")
 	s.Require().NoError(err)

--- a/backend/internal/connection/handler.go
+++ b/backend/internal/connection/handler.go
@@ -275,7 +275,7 @@ func createSMSConnection[Req any, Resp any](h *handler, w http.ResponseWriter, r
 
 // getSMSConnection fetches a message sender of the given provider and writes the encoded response.
 func getSMSConnection[Resp any](h *handler, w http.ResponseWriter, r *http.Request,
-	provider ncommon.MessageProviderType, fromDTO func(ncommon.NotificationSenderDTO) (Resp, error)) {
+	provider ncommon.NotificationProviderType, fromDTO func(ncommon.NotificationSenderDTO) (Resp, error)) {
 	ctx := r.Context()
 	id := r.PathValue("id")
 	if strings.TrimSpace(id) == "" {
@@ -298,7 +298,7 @@ func getSMSConnection[Resp any](h *handler, w http.ResponseWriter, r *http.Reque
 // updateSMSConnection decodes a typed request, maps it, delegates the update (which preserves
 // any secret the request omits), and writes the encoded response.
 func updateSMSConnection[Req any, Resp any](h *handler, w http.ResponseWriter, r *http.Request,
-	provider ncommon.MessageProviderType, toDTO func(Req) (*ncommon.NotificationSenderDTO, error),
+	provider ncommon.NotificationProviderType, toDTO func(Req) (*ncommon.NotificationSenderDTO, error),
 	fromDTO func(ncommon.NotificationSenderDTO) (Resp, error)) {
 	ctx := r.Context()
 	id := r.PathValue("id")
@@ -339,7 +339,7 @@ func createSMSHandler[Req any, Resp any](h *handler,
 }
 
 // getSMSHandler binds a vendor's provider and mapper to getSMSConnection, yielding a handler.
-func getSMSHandler[Resp any](h *handler, provider ncommon.MessageProviderType,
+func getSMSHandler[Resp any](h *handler, provider ncommon.NotificationProviderType,
 	fromDTO func(ncommon.NotificationSenderDTO) (Resp, error)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		getSMSConnection(h, w, r, provider, fromDTO)
@@ -347,7 +347,7 @@ func getSMSHandler[Resp any](h *handler, provider ncommon.MessageProviderType,
 }
 
 // updateSMSHandler binds a vendor's provider and mappers to updateSMSConnection.
-func updateSMSHandler[Req any, Resp any](h *handler, provider ncommon.MessageProviderType,
+func updateSMSHandler[Req any, Resp any](h *handler, provider ncommon.NotificationProviderType,
 	toDTO func(Req) (*ncommon.NotificationSenderDTO, error),
 	fromDTO func(ncommon.NotificationSenderDTO) (Resp, error)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -356,7 +356,7 @@ func updateSMSHandler[Req any, Resp any](h *handler, provider ncommon.MessagePro
 }
 
 // listSMSInstances returns a handler that lists the configured senders of a message provider.
-func (h *handler) listSMSInstances(provider ncommon.MessageProviderType) http.HandlerFunc {
+func (h *handler) listSMSInstances(provider ncommon.NotificationProviderType) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		instances, svcErr := h.svc.listSMSByProvider(ctx, provider)
@@ -377,7 +377,7 @@ func (h *handler) listSMSInstances(provider ncommon.MessageProviderType) http.Ha
 }
 
 // deleteSMSInstance returns a handler that deletes a sender of a message provider.
-func (h *handler) deleteSMSInstance(provider ncommon.MessageProviderType) http.HandlerFunc {
+func (h *handler) deleteSMSInstance(provider ncommon.NotificationProviderType) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		id := r.PathValue("id")
@@ -395,7 +395,7 @@ func (h *handler) deleteSMSInstance(provider ncommon.MessageProviderType) http.H
 
 // usagesSMSInstance returns a handler that lists the resources referencing a sender of a message
 // provider. Drives the pre-delete confirmation dialog.
-func (h *handler) usagesSMSInstance(provider ncommon.MessageProviderType) http.HandlerFunc {
+func (h *handler) usagesSMSInstance(provider ncommon.NotificationProviderType) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		id := r.PathValue("id")

--- a/backend/internal/connection/handler_test.go
+++ b/backend/internal/connection/handler_test.go
@@ -52,9 +52,9 @@ func (s *HandlerTestSuite) mockListFixtures() {
 	s.mockNotif.On("ListSendersByType", mock.Anything, ncommon.NotificationSenderTypeMessage).
 		Return([]ncommon.NotificationSenderDTO{
 			{ID: "s1", Name: "Twilio SMS", Type: ncommon.NotificationSenderTypeMessage,
-				Provider: ncommon.MessageProviderTypeTwilio},
+				Provider: ncommon.NotificationProviderTypeTwilio},
 			{ID: "s2", Name: "Gateway", Type: ncommon.NotificationSenderTypeMessage,
-				Provider: ncommon.MessageProviderTypeCustom},
+				Provider: ncommon.NotificationProviderTypeCustom},
 		}, (*tidcommon.ServiceError)(nil))
 }
 
@@ -204,9 +204,9 @@ func (s *HandlerTestSuite) TestListConnectionsSMSProviderCategory() {
 	s.mockNotif.On("ListSendersByType", mock.Anything, ncommon.NotificationSenderTypeMessage).
 		Return([]ncommon.NotificationSenderDTO{
 			{ID: "s1", Name: "Twilio SMS", Type: ncommon.NotificationSenderTypeMessage,
-				Provider: ncommon.MessageProviderTypeTwilio},
+				Provider: ncommon.NotificationProviderTypeTwilio},
 			{ID: "s2", Name: "Gateway", Type: ncommon.NotificationSenderTypeMessage,
-				Provider: ncommon.MessageProviderTypeCustom},
+				Provider: ncommon.NotificationProviderTypeCustom},
 		}, (*tidcommon.ServiceError)(nil))
 
 	rr, resp := s.listConnections("/connections?category=sms-provider")
@@ -377,7 +377,7 @@ func (s *HandlerTestSuite) TestUsagesSuccess() {
 	s.Equal("restrict", resp.Usages[0].BehaviorOnDelete)
 }
 
-const stubProvider = ncommon.MessageProviderTypeTwilio
+const stubProvider = ncommon.NotificationProviderTypeTwilio
 
 type smsStubReq struct {
 	Name string `json:"name"`
@@ -562,7 +562,7 @@ func (s *SMSHandlerTestSuite) TestListInstancesSuccess() {
 				ID: "tw-1", Name: "A", Description: "d",
 				Type: ncommon.NotificationSenderTypeMessage, Provider: stubProvider,
 			},
-			{ID: "vo-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeVonage},
+			{ID: "vo-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeVonage},
 		}, (*tidcommon.ServiceError)(nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/connections/twilio", nil)

--- a/backend/internal/connection/init.go
+++ b/backend/internal/connection/init.go
@@ -83,20 +83,20 @@ func registerRoutes(mux *http.ServeMux, h *handler) {
 		collectionOpts, itemOpts)
 
 	// SMS-backed vendors.
-	registerSMSVendorRoutes(mux, h, "/connections/twilio", ncommon.MessageProviderTypeTwilio,
+	registerSMSVendorRoutes(mux, h, "/connections/twilio", ncommon.NotificationProviderTypeTwilio,
 		createSMSHandler(h, twilioToSenderDTO, twilioFromSenderDTO),
-		getSMSHandler(h, ncommon.MessageProviderTypeTwilio, twilioFromSenderDTO),
-		updateSMSHandler(h, ncommon.MessageProviderTypeTwilio, twilioToSenderDTO, twilioFromSenderDTO),
+		getSMSHandler(h, ncommon.NotificationProviderTypeTwilio, twilioFromSenderDTO),
+		updateSMSHandler(h, ncommon.NotificationProviderTypeTwilio, twilioToSenderDTO, twilioFromSenderDTO),
 		collectionOpts, itemOpts)
-	registerSMSVendorRoutes(mux, h, "/connections/vonage", ncommon.MessageProviderTypeVonage,
+	registerSMSVendorRoutes(mux, h, "/connections/vonage", ncommon.NotificationProviderTypeVonage,
 		createSMSHandler(h, vonageToSenderDTO, vonageFromSenderDTO),
-		getSMSHandler(h, ncommon.MessageProviderTypeVonage, vonageFromSenderDTO),
-		updateSMSHandler(h, ncommon.MessageProviderTypeVonage, vonageToSenderDTO, vonageFromSenderDTO),
+		getSMSHandler(h, ncommon.NotificationProviderTypeVonage, vonageFromSenderDTO),
+		updateSMSHandler(h, ncommon.NotificationProviderTypeVonage, vonageToSenderDTO, vonageFromSenderDTO),
 		collectionOpts, itemOpts)
-	registerSMSVendorRoutes(mux, h, "/connections/"+smsGatewayVendorName, ncommon.MessageProviderTypeCustom,
+	registerSMSVendorRoutes(mux, h, "/connections/"+smsGatewayVendorName, ncommon.NotificationProviderTypeCustom,
 		createSMSHandler(h, smsGatewayToSenderDTO, smsGatewayFromSenderDTO),
-		getSMSHandler(h, ncommon.MessageProviderTypeCustom, smsGatewayFromSenderDTO),
-		updateSMSHandler(h, ncommon.MessageProviderTypeCustom, smsGatewayToSenderDTO, smsGatewayFromSenderDTO),
+		getSMSHandler(h, ncommon.NotificationProviderTypeCustom, smsGatewayFromSenderDTO),
+		updateSMSHandler(h, ncommon.NotificationProviderTypeCustom, smsGatewayToSenderDTO, smsGatewayFromSenderDTO),
 		collectionOpts, itemOpts)
 }
 
@@ -129,7 +129,7 @@ func registerVendorRoutes(mux *http.ServeMux, h *handler, base string, idpType p
 // routes for a single SMS-backed vendor, plus their OPTIONS handlers.
 //
 //nolint:dupl // mirrors registerVendorRoutes but scopes deletion by message provider, not IdP type
-func registerSMSVendorRoutes(mux *http.ServeMux, h *handler, base string, provider ncommon.MessageProviderType,
+func registerSMSVendorRoutes(mux *http.ServeMux, h *handler, base string, provider ncommon.NotificationProviderType,
 	create, get, update http.HandlerFunc, collectionOpts, itemOpts middleware.CORSOptions) {
 	mux.HandleFunc(middleware.WithCORS("GET "+base, h.listSMSInstances(provider), collectionOpts))
 	mux.HandleFunc(middleware.WithCORS("POST "+base, create, collectionOpts))

--- a/backend/internal/connection/init_test.go
+++ b/backend/internal/connection/init_test.go
@@ -110,12 +110,12 @@ func (s *InitTestSuite) TestRouteTable() {
 
 	twilioDTO := &ncommon.NotificationSenderDTO{
 		ID: "tw-1", Name: "TW", Type: ncommon.NotificationSenderTypeMessage,
-		Provider: ncommon.MessageProviderTypeTwilio,
+		Provider: ncommon.NotificationProviderTypeTwilio,
 	}
 	s.mockNotif.On("ListSendersByType", mock.Anything, ncommon.NotificationSenderTypeMessage).
 		Return([]ncommon.NotificationSenderDTO{*twilioDTO}, (*tidcommon.ServiceError)(nil))
 	s.mockNotif.On("CreateSender", mock.Anything, mock.MatchedBy(func(dto ncommon.NotificationSenderDTO) bool {
-		return dto.Provider == ncommon.MessageProviderTypeTwilio
+		return dto.Provider == ncommon.NotificationProviderTypeTwilio
 	})).Return(twilioDTO, (*tidcommon.ServiceError)(nil))
 	s.mockNotif.On("GetSender", mock.Anything, "tw-1").
 		Return(twilioDTO, (*tidcommon.ServiceError)(nil))
@@ -126,10 +126,10 @@ func (s *InitTestSuite) TestRouteTable() {
 
 	smsGatewayDTO := &ncommon.NotificationSenderDTO{
 		ID: "sg-1", Name: "SG", Type: ncommon.NotificationSenderTypeMessage,
-		Provider: ncommon.MessageProviderTypeCustom,
+		Provider: ncommon.NotificationProviderTypeCustom,
 	}
 	s.mockNotif.On("CreateSender", mock.Anything, mock.MatchedBy(func(dto ncommon.NotificationSenderDTO) bool {
-		return dto.Provider == ncommon.MessageProviderTypeCustom
+		return dto.Provider == ncommon.NotificationProviderTypeCustom
 	})).Return(smsGatewayDTO, (*tidcommon.ServiceError)(nil))
 	s.mockNotif.On("GetSender", mock.Anything, "sg-1").
 		Return(smsGatewayDTO, (*tidcommon.ServiceError)(nil))

--- a/backend/internal/connection/models.go
+++ b/backend/internal/connection/models.go
@@ -31,21 +31,21 @@ var idpBackedVendors = []idpBackedVendor{
 }
 
 // smsGatewayVendorName is the connection vendor name for the generic HTTP SMS gateway. The
-// stored message provider stays MessageProviderTypeCustom; this name is presentation-only,
+// stored message provider stays NotificationProviderTypeCustom; this name is presentation-only,
 // surfaced in the /connections/{vendor} path and the flat-list type.
 const smsGatewayVendorName = "sms-gateway"
 
 // smsBackedVendor maps a connection path segment to an underlying message provider.
 type smsBackedVendor struct {
 	name     string
-	provider ncommon.MessageProviderType
+	provider ncommon.NotificationProviderType
 }
 
 // smsBackedVendors is the set of connection types backed by the notification-sender service.
 var smsBackedVendors = []smsBackedVendor{
-	{name: "twilio", provider: ncommon.MessageProviderTypeTwilio},
-	{name: "vonage", provider: ncommon.MessageProviderTypeVonage},
-	{name: smsGatewayVendorName, provider: ncommon.MessageProviderTypeCustom},
+	{name: "twilio", provider: ncommon.NotificationProviderTypeTwilio},
+	{name: "vonage", provider: ncommon.NotificationProviderTypeVonage},
+	{name: smsGatewayVendorName, provider: ncommon.NotificationProviderTypeCustom},
 }
 
 // connectionCategory is the functional category of a connection instance, used as the

--- a/backend/internal/connection/service.go
+++ b/backend/internal/connection/service.go
@@ -51,7 +51,7 @@ func (s *service) listByType(ctx context.Context, idpType providers.IDPType) ([]
 
 // smsVendorName returns the connection vendor name for a message provider, or false when the
 // provider has no registered vendor (such instances are not exposed by /connections).
-func smsVendorName(provider ncommon.MessageProviderType) (string, bool) {
+func smsVendorName(provider ncommon.NotificationProviderType) (string, bool) {
 	for _, vendor := range smsBackedVendors {
 		if vendor.provider == provider {
 			return vendor.name, true
@@ -214,7 +214,7 @@ func (s *service) deleteByType(ctx context.Context, idpType providers.IDPType, i
 }
 
 // listSMSByProvider returns the configured message senders of the given provider.
-func (s *service) listSMSByProvider(ctx context.Context, provider ncommon.MessageProviderType) (
+func (s *service) listSMSByProvider(ctx context.Context, provider ncommon.NotificationProviderType) (
 	[]ncommon.NotificationSenderDTO, *tidcommon.ServiceError) {
 	all, svcErr := s.notificationService.ListSendersByType(ctx, ncommon.NotificationSenderTypeMessage)
 	if svcErr != nil {
@@ -231,7 +231,7 @@ func (s *service) listSMSByProvider(ctx context.Context, provider ncommon.Messag
 
 // getSMSByProvider fetches a single message sender and verifies it is of the expected provider,
 // returning a not-found error on a mismatch so a vendor endpoint cannot read another provider.
-func (s *service) getSMSByProvider(ctx context.Context, provider ncommon.MessageProviderType, id string) (
+func (s *service) getSMSByProvider(ctx context.Context, provider ncommon.NotificationProviderType, id string) (
 	*ncommon.NotificationSenderDTO, *tidcommon.ServiceError) {
 	dto, svcErr := s.notificationService.GetSender(ctx, id)
 	if svcErr != nil {
@@ -251,7 +251,7 @@ func (s *service) createSMS(ctx context.Context, dto ncommon.NotificationSenderD
 
 // updateSMS verifies the sender is of the expected provider, preserves any secret the request
 // omits (keeping the stored value), then delegates the update.
-func (s *service) updateSMS(ctx context.Context, provider ncommon.MessageProviderType, id string,
+func (s *service) updateSMS(ctx context.Context, provider ncommon.NotificationProviderType, id string,
 	dto ncommon.NotificationSenderDTO) (*ncommon.NotificationSenderDTO, *tidcommon.ServiceError) {
 	existing, svcErr := s.getSMSByProvider(ctx, provider, id)
 	if svcErr != nil {
@@ -262,7 +262,7 @@ func (s *service) updateSMS(ctx context.Context, provider ncommon.MessageProvide
 }
 
 // deleteSMSByProvider verifies the sender is of the expected provider, then deletes it.
-func (s *service) deleteSMSByProvider(ctx context.Context, provider ncommon.MessageProviderType,
+func (s *service) deleteSMSByProvider(ctx context.Context, provider ncommon.NotificationProviderType,
 	id string) *tidcommon.ServiceError {
 	if _, svcErr := s.getSMSByProvider(ctx, provider, id); svcErr != nil {
 		return svcErr
@@ -282,7 +282,7 @@ func (s *service) usagesByType(ctx context.Context, idpType providers.IDPType, i
 
 // usagesSMSByProvider verifies the sender is of the expected provider, then returns the resources
 // that reference it. Drives the pre-delete confirmation dialog.
-func (s *service) usagesSMSByProvider(ctx context.Context, provider ncommon.MessageProviderType, id string) (
+func (s *service) usagesSMSByProvider(ctx context.Context, provider ncommon.NotificationProviderType, id string) (
 	*resourcedependency.DependenciesResponse, *tidcommon.ServiceError) {
 	if _, svcErr := s.getSMSByProvider(ctx, provider, id); svcErr != nil {
 		return nil, svcErr

--- a/backend/internal/connection/service_test.go
+++ b/backend/internal/connection/service_test.go
@@ -78,7 +78,7 @@ func (s *ServiceTestSuite) TestListInstancesAllCategories() {
 	s.mockNotif.On("ListSendersByType", mock.Anything, ncommon.NotificationSenderTypeMessage).
 		Return([]ncommon.NotificationSenderDTO{
 			{ID: "s1", Name: "SMS", Type: ncommon.NotificationSenderTypeMessage,
-				Provider: ncommon.MessageProviderTypeCustom},
+				Provider: ncommon.NotificationProviderTypeCustom},
 		}, (*tidcommon.ServiceError)(nil))
 
 	got, svcErr := s.svc.listInstances(context.Background(), "", serverconst.DefaultPageSize, 0)
@@ -193,7 +193,7 @@ func (s *ServiceTestSuite) TestListInstancesSMSSkipsIdPs() {
 	s.mockNotif.On("ListSendersByType", mock.Anything, ncommon.NotificationSenderTypeMessage).
 		Return([]ncommon.NotificationSenderDTO{
 			{ID: "s1", Name: "SMS", Type: ncommon.NotificationSenderTypeMessage,
-				Provider: ncommon.MessageProviderTypeTwilio},
+				Provider: ncommon.NotificationProviderTypeTwilio},
 		}, (*tidcommon.ServiceError)(nil))
 
 	got, svcErr := s.svc.listInstances(context.Background(), categorySMSProvider,
@@ -208,9 +208,9 @@ func (s *ServiceTestSuite) TestListInstancesSkipsUnregisteredSenderProvider() {
 	s.mockNotif.On("ListSendersByType", mock.Anything, ncommon.NotificationSenderTypeMessage).
 		Return([]ncommon.NotificationSenderDTO{
 			{ID: "s1", Name: "SMS", Type: ncommon.NotificationSenderTypeMessage,
-				Provider: ncommon.MessageProviderTypeTwilio},
+				Provider: ncommon.NotificationProviderTypeTwilio},
 			{ID: "s2", Name: "Unregistered", Type: ncommon.NotificationSenderTypeMessage,
-				Provider: ncommon.MessageProviderType("unregistered-provider")},
+				Provider: ncommon.NotificationProviderType("unregistered-provider")},
 		}, (*tidcommon.ServiceError)(nil))
 
 	got, svcErr := s.svc.listInstances(context.Background(), categorySMSProvider,
@@ -236,7 +236,7 @@ func (s *ServiceTestSuite) TestListInstancesSortsByIDWhenTypeAndNameTie() {
 }
 
 func (s *ServiceTestSuite) TestSMSVendorNameUnregisteredProviderReturnsFalse() {
-	name, ok := smsVendorName(ncommon.MessageProviderType("unregistered-provider"))
+	name, ok := smsVendorName(ncommon.NotificationProviderType("unregistered-provider"))
 	s.False(ok)
 	s.Empty(name)
 }
@@ -354,12 +354,12 @@ func (s *ServiceTestSuite) authToken(value string) []cmodels.Property {
 func (s *ServiceTestSuite) TestListSMSByProviderFilters() {
 	s.mockNotif.On("ListSendersByType", mock.Anything, ncommon.NotificationSenderTypeMessage).
 		Return([]ncommon.NotificationSenderDTO{
-			{ID: "1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeTwilio},
-			{ID: "2", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeVonage},
-			{ID: "3", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeTwilio},
+			{ID: "1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeTwilio},
+			{ID: "2", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeVonage},
+			{ID: "3", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeTwilio},
 		}, (*tidcommon.ServiceError)(nil))
 
-	got, svcErr := s.svc.listSMSByProvider(context.Background(), ncommon.MessageProviderTypeTwilio)
+	got, svcErr := s.svc.listSMSByProvider(context.Background(), ncommon.NotificationProviderTypeTwilio)
 	s.Nil(svcErr)
 	s.Len(got, 2)
 }
@@ -368,16 +368,16 @@ func (s *ServiceTestSuite) TestListSMSByProviderError() {
 	s.mockNotif.On("ListSendersByType", mock.Anything, ncommon.NotificationSenderTypeMessage).
 		Return(([]ncommon.NotificationSenderDTO)(nil), &tidcommon.InternalServerError)
 
-	_, svcErr := s.svc.listSMSByProvider(context.Background(), ncommon.MessageProviderTypeTwilio)
+	_, svcErr := s.svc.listSMSByProvider(context.Background(), ncommon.NotificationProviderTypeTwilio)
 	s.NotNil(svcErr)
 }
 
 func (s *ServiceTestSuite) TestGetSMSByProviderMismatchReturnsNotFound() {
 	s.mockNotif.On("GetSender", mock.Anything, "x").Return(&ncommon.NotificationSenderDTO{
-		ID: "x", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeVonage,
+		ID: "x", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeVonage,
 	}, (*tidcommon.ServiceError)(nil))
 
-	_, svcErr := s.svc.getSMSByProvider(context.Background(), ncommon.MessageProviderTypeTwilio, "x")
+	_, svcErr := s.svc.getSMSByProvider(context.Background(), ncommon.NotificationProviderTypeTwilio, "x")
 	s.Require().NotNil(svcErr)
 	s.Equal(notification.ErrorSenderNotFound.Code, svcErr.Code)
 }
@@ -386,7 +386,7 @@ func (s *ServiceTestSuite) TestGetSMSByProviderError() {
 	s.mockNotif.On("GetSender", mock.Anything, "missing").
 		Return((*ncommon.NotificationSenderDTO)(nil), &notification.ErrorSenderNotFound)
 
-	_, svcErr := s.svc.getSMSByProvider(context.Background(), ncommon.MessageProviderTypeTwilio, "missing")
+	_, svcErr := s.svc.getSMSByProvider(context.Background(), ncommon.NotificationProviderTypeTwilio, "missing")
 	s.Require().NotNil(svcErr)
 	s.Equal(notification.ErrorSenderNotFound.Code, svcErr.Code)
 }
@@ -395,14 +395,14 @@ func (s *ServiceTestSuite) TestDeleteSMSByProviderGetFails() {
 	s.mockNotif.On("GetSender", mock.Anything, "missing").
 		Return((*ncommon.NotificationSenderDTO)(nil), &notification.ErrorSenderNotFound)
 
-	svcErr := s.svc.deleteSMSByProvider(context.Background(), ncommon.MessageProviderTypeTwilio, "missing")
+	svcErr := s.svc.deleteSMSByProvider(context.Background(), ncommon.NotificationProviderTypeTwilio, "missing")
 	s.Require().NotNil(svcErr)
 	s.mockNotif.AssertNotCalled(s.T(), "DeleteSender", mock.Anything, mock.Anything)
 }
 
 func (s *ServiceTestSuite) TestUpdateSMSOmittedSecretKeepsStored() {
 	s.mockNotif.On("GetSender", mock.Anything, "tw-1").Return(&ncommon.NotificationSenderDTO{
-		ID: "tw-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeTwilio,
+		ID: "tw-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeTwilio,
 		Properties: s.authToken("stored"),
 	}, (*tidcommon.ServiceError)(nil))
 
@@ -413,9 +413,9 @@ func (s *ServiceTestSuite) TestUpdateSMSOmittedSecretKeepsStored() {
 
 	// Update carries no secret property at all → the stored secret is preserved.
 	dto := ncommon.NotificationSenderDTO{
-		Name: "tw", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeTwilio,
+		Name: "tw", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeTwilio,
 	}
-	_, svcErr := s.svc.updateSMS(context.Background(), ncommon.MessageProviderTypeTwilio, "tw-1", dto)
+	_, svcErr := s.svc.updateSMS(context.Background(), ncommon.NotificationProviderTypeTwilio, "tw-1", dto)
 
 	s.Nil(svcErr)
 	s.Require().Len(captured.Properties, 1)
@@ -426,13 +426,13 @@ func (s *ServiceTestSuite) TestUpdateSMSOmittedSecretKeepsStored() {
 
 func (s *ServiceTestSuite) TestUpdateSMSProviderMismatch() {
 	s.mockNotif.On("GetSender", mock.Anything, "x").Return(&ncommon.NotificationSenderDTO{
-		ID: "x", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeVonage,
+		ID: "x", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeVonage,
 	}, (*tidcommon.ServiceError)(nil))
 
 	dto := ncommon.NotificationSenderDTO{
-		Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeTwilio,
+		Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeTwilio,
 	}
-	_, svcErr := s.svc.updateSMS(context.Background(), ncommon.MessageProviderTypeTwilio, "x", dto)
+	_, svcErr := s.svc.updateSMS(context.Background(), ncommon.NotificationProviderTypeTwilio, "x", dto)
 	s.Require().NotNil(svcErr)
 	s.Equal(notification.ErrorSenderNotFound.Code, svcErr.Code)
 	s.mockNotif.AssertNotCalled(s.T(), "UpdateSender", mock.Anything, mock.Anything, mock.Anything)
@@ -440,11 +440,11 @@ func (s *ServiceTestSuite) TestUpdateSMSProviderMismatch() {
 
 func (s *ServiceTestSuite) TestDeleteSMSByProviderDelegates() {
 	s.mockNotif.On("GetSender", mock.Anything, "tw-1").Return(&ncommon.NotificationSenderDTO{
-		ID: "tw-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeTwilio,
+		ID: "tw-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeTwilio,
 	}, (*tidcommon.ServiceError)(nil))
 	s.mockNotif.On("DeleteSender", mock.Anything, "tw-1").Return((*tidcommon.ServiceError)(nil))
 
-	svcErr := s.svc.deleteSMSByProvider(context.Background(), ncommon.MessageProviderTypeTwilio, "tw-1")
+	svcErr := s.svc.deleteSMSByProvider(context.Background(), ncommon.NotificationProviderTypeTwilio, "tw-1")
 	s.Nil(svcErr)
 }
 
@@ -488,11 +488,11 @@ func (s *ServiceTestSuite) TestUsagesSMSByProviderDelegates() {
 		},
 	}
 	s.mockNotif.On("GetSender", mock.Anything, "tw-1").Return(&ncommon.NotificationSenderDTO{
-		ID: "tw-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeTwilio,
+		ID: "tw-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeTwilio,
 	}, (*tidcommon.ServiceError)(nil))
 	s.mockNotif.On("GetSenderUsages", mock.Anything, "tw-1").Return(usages, (*tidcommon.ServiceError)(nil))
 
-	result, svcErr := s.svc.usagesSMSByProvider(context.Background(), ncommon.MessageProviderTypeTwilio, "tw-1")
+	result, svcErr := s.svc.usagesSMSByProvider(context.Background(), ncommon.NotificationProviderTypeTwilio, "tw-1")
 	s.Nil(svcErr)
 	s.Equal(usages, result)
 }
@@ -501,10 +501,10 @@ func (s *ServiceTestSuite) TestUsagesSMSByProviderDelegates() {
 // through a vendor's usages endpoint.
 func (s *ServiceTestSuite) TestUsagesSMSByProviderWrongProvider() {
 	s.mockNotif.On("GetSender", mock.Anything, "vo-1").Return(&ncommon.NotificationSenderDTO{
-		ID: "vo-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeVonage,
+		ID: "vo-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeVonage,
 	}, (*tidcommon.ServiceError)(nil))
 
-	result, svcErr := s.svc.usagesSMSByProvider(context.Background(), ncommon.MessageProviderTypeTwilio, "vo-1")
+	result, svcErr := s.svc.usagesSMSByProvider(context.Background(), ncommon.NotificationProviderTypeTwilio, "vo-1")
 	s.Require().NotNil(svcErr)
 	s.Nil(result)
 	s.mockNotif.AssertNotCalled(s.T(), "GetSenderUsages", mock.Anything, mock.Anything)

--- a/backend/internal/connection/sms_gateway.go
+++ b/backend/internal/connection/sms_gateway.go
@@ -50,7 +50,7 @@ func smsGatewayToSenderDTO(req smsGatewayConnectionRequest) (*ncommon.Notificati
 		Name:        req.Name,
 		Description: req.Description,
 		Type:        ncommon.NotificationSenderTypeMessage,
-		Provider:    ncommon.MessageProviderTypeCustom,
+		Provider:    ncommon.NotificationProviderTypeCustom,
 		Properties:  props,
 	}, nil
 }

--- a/backend/internal/connection/sms_gateway_test.go
+++ b/backend/internal/connection/sms_gateway_test.go
@@ -43,7 +43,7 @@ func (s *SMSGatewayTestSuite) TestToSenderDTOMapsFields() {
 	})
 	s.Require().NoError(err)
 	s.Equal(ncommon.NotificationSenderTypeMessage, dto.Type)
-	s.Equal(ncommon.MessageProviderTypeCustom, dto.Provider)
+	s.Equal(ncommon.NotificationProviderTypeCustom, dto.Provider)
 	s.Equal("Custom webhook sender", dto.Description)
 
 	values, err := propertyValues(dto.Properties)
@@ -74,7 +74,7 @@ func (s *SMSGatewayTestSuite) TestCreateReturnsPlaintextNonSecretFields() {
 			ID:       "sg-1",
 			Name:     "Prod SMS",
 			Type:     ncommon.NotificationSenderTypeMessage,
-			Provider: ncommon.MessageProviderTypeCustom,
+			Provider: ncommon.NotificationProviderTypeCustom,
 			Properties: []cmodels.Property{
 				mustProperty(s.T(), ncommon.CustomPropKeyURL, "https://sms.example.com/send", false),
 				mustProperty(s.T(), ncommon.CustomPropKeyHTTPMethod, "POST", false),
@@ -108,7 +108,7 @@ func (s *SMSGatewayTestSuite) TestGetRoundTrip() {
 			ID:       "sg-1",
 			Name:     "Prod SMS",
 			Type:     ncommon.NotificationSenderTypeMessage,
-			Provider: ncommon.MessageProviderTypeCustom,
+			Provider: ncommon.NotificationProviderTypeCustom,
 			Properties: []cmodels.Property{
 				mustProperty(s.T(), ncommon.CustomPropKeyURL, "https://sms.example.com/send", false),
 			},
@@ -117,7 +117,7 @@ func (s *SMSGatewayTestSuite) TestGetRoundTrip() {
 	req := httptest.NewRequest(http.MethodGet, "/connections/sms-gateway/sg-1", nil)
 	req.SetPathValue("id", "sg-1")
 	rr := httptest.NewRecorder()
-	getSMSHandler(s.handler, ncommon.MessageProviderTypeCustom, smsGatewayFromSenderDTO)(rr, req)
+	getSMSHandler(s.handler, ncommon.NotificationProviderTypeCustom, smsGatewayFromSenderDTO)(rr, req)
 
 	s.Equal(http.StatusOK, rr.Code)
 	var resp smsGatewayConnectionResponse
@@ -129,13 +129,13 @@ func (s *SMSGatewayTestSuite) TestGetRoundTrip() {
 func (s *SMSGatewayTestSuite) TestGetProviderMismatchReturnsNotFound() {
 	s.mockNotif.On("GetSender", mock.Anything, "tw-1").
 		Return(&ncommon.NotificationSenderDTO{
-			ID: "tw-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeTwilio,
+			ID: "tw-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeTwilio,
 		}, (*tidcommon.ServiceError)(nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/connections/sms-gateway/tw-1", nil)
 	req.SetPathValue("id", "tw-1")
 	rr := httptest.NewRecorder()
-	getSMSHandler(s.handler, ncommon.MessageProviderTypeCustom, smsGatewayFromSenderDTO)(rr, req)
+	getSMSHandler(s.handler, ncommon.NotificationProviderTypeCustom, smsGatewayFromSenderDTO)(rr, req)
 
 	s.Equal(http.StatusNotFound, rr.Code)
 }

--- a/backend/internal/connection/twilio.go
+++ b/backend/internal/connection/twilio.go
@@ -44,7 +44,7 @@ func twilioToSenderDTO(req twilioConnectionRequest) (*ncommon.NotificationSender
 		Name:        req.Name,
 		Description: req.Description,
 		Type:        ncommon.NotificationSenderTypeMessage,
-		Provider:    ncommon.MessageProviderTypeTwilio,
+		Provider:    ncommon.NotificationProviderTypeTwilio,
 		Properties:  props,
 	}, nil
 }
@@ -58,7 +58,7 @@ func twilioFromSenderDTO(dto ncommon.NotificationSenderDTO) (twilioConnectionRes
 		ID:          dto.ID,
 		Name:        dto.Name,
 		Description: dto.Description,
-		Type:        string(ncommon.MessageProviderTypeTwilio),
+		Type:        string(ncommon.NotificationProviderTypeTwilio),
 		AccountSID:  values[ncommon.TwilioPropKeyAccountSID],
 		AuthToken:   values[ncommon.TwilioPropKeyAuthToken],
 		SenderID:    values[ncommon.TwilioPropKeySenderID],

--- a/backend/internal/connection/twilio_test.go
+++ b/backend/internal/connection/twilio_test.go
@@ -42,7 +42,7 @@ func (s *TwilioTestSuite) TestToSenderDTOMapsFields() {
 	})
 	s.Require().NoError(err)
 	s.Equal(ncommon.NotificationSenderTypeMessage, dto.Type)
-	s.Equal(ncommon.MessageProviderTypeTwilio, dto.Provider)
+	s.Equal(ncommon.NotificationProviderTypeTwilio, dto.Provider)
 	s.Equal("OTP over SMS", dto.Description)
 
 	values, err := propertyValues(dto.Properties)
@@ -59,7 +59,7 @@ func (s *TwilioTestSuite) TestCreateMasksSecret() {
 			ID:       "tw-1",
 			Name:     "My Twilio",
 			Type:     ncommon.NotificationSenderTypeMessage,
-			Provider: ncommon.MessageProviderTypeTwilio,
+			Provider: ncommon.NotificationProviderTypeTwilio,
 			Properties: []cmodels.Property{
 				mustProperty(s.T(), ncommon.TwilioPropKeyAccountSID, "AC00000000000000000000000000000000", false),
 				mustProperty(s.T(), ncommon.TwilioPropKeyAuthToken, "s3cret", true),
@@ -91,7 +91,7 @@ func (s *TwilioTestSuite) TestGetRoundTrip() {
 			ID:       "tw-1",
 			Name:     "My Twilio",
 			Type:     ncommon.NotificationSenderTypeMessage,
-			Provider: ncommon.MessageProviderTypeTwilio,
+			Provider: ncommon.NotificationProviderTypeTwilio,
 			Properties: []cmodels.Property{
 				mustProperty(s.T(), ncommon.TwilioPropKeyAccountSID, "AC00000000000000000000000000000000", false),
 				mustProperty(s.T(), ncommon.TwilioPropKeyAuthToken, "s3cret", true),
@@ -102,7 +102,7 @@ func (s *TwilioTestSuite) TestGetRoundTrip() {
 	req := httptest.NewRequest(http.MethodGet, "/connections/twilio/tw-1", nil)
 	req.SetPathValue("id", "tw-1")
 	rr := httptest.NewRecorder()
-	getSMSHandler(s.handler, ncommon.MessageProviderTypeTwilio, twilioFromSenderDTO)(rr, req)
+	getSMSHandler(s.handler, ncommon.NotificationProviderTypeTwilio, twilioFromSenderDTO)(rr, req)
 
 	s.Equal(http.StatusOK, rr.Code)
 	var resp twilioConnectionResponse
@@ -116,13 +116,13 @@ func (s *TwilioTestSuite) TestGetRoundTrip() {
 func (s *TwilioTestSuite) TestGetProviderMismatchReturnsNotFound() {
 	s.mockNotif.On("GetSender", mock.Anything, "vo-1").
 		Return(&ncommon.NotificationSenderDTO{
-			ID: "vo-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.MessageProviderTypeVonage,
+			ID: "vo-1", Type: ncommon.NotificationSenderTypeMessage, Provider: ncommon.NotificationProviderTypeVonage,
 		}, (*tidcommon.ServiceError)(nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/connections/twilio/vo-1", nil)
 	req.SetPathValue("id", "vo-1")
 	rr := httptest.NewRecorder()
-	getSMSHandler(s.handler, ncommon.MessageProviderTypeTwilio, twilioFromSenderDTO)(rr, req)
+	getSMSHandler(s.handler, ncommon.NotificationProviderTypeTwilio, twilioFromSenderDTO)(rr, req)
 
 	s.Equal(http.StatusNotFound, rr.Code)
 }

--- a/backend/internal/connection/vonage.go
+++ b/backend/internal/connection/vonage.go
@@ -44,7 +44,7 @@ func vonageToSenderDTO(req vonageConnectionRequest) (*ncommon.NotificationSender
 		Name:        req.Name,
 		Description: req.Description,
 		Type:        ncommon.NotificationSenderTypeMessage,
-		Provider:    ncommon.MessageProviderTypeVonage,
+		Provider:    ncommon.NotificationProviderTypeVonage,
 		Properties:  props,
 	}, nil
 }
@@ -58,7 +58,7 @@ func vonageFromSenderDTO(dto ncommon.NotificationSenderDTO) (vonageConnectionRes
 		ID:          dto.ID,
 		Name:        dto.Name,
 		Description: dto.Description,
-		Type:        string(ncommon.MessageProviderTypeVonage),
+		Type:        string(ncommon.NotificationProviderTypeVonage),
 		APIKey:      values[ncommon.VonagePropKeyAPIKey],
 		APISecret:   values[ncommon.VonagePropKeyAPISecret],
 		SenderID:    values[ncommon.VonagePropKeySenderID],

--- a/backend/internal/connection/vonage_test.go
+++ b/backend/internal/connection/vonage_test.go
@@ -42,7 +42,7 @@ func (s *VonageTestSuite) TestToSenderDTOMapsFields() {
 	})
 	s.Require().NoError(err)
 	s.Equal(ncommon.NotificationSenderTypeMessage, dto.Type)
-	s.Equal(ncommon.MessageProviderTypeVonage, dto.Provider)
+	s.Equal(ncommon.NotificationProviderTypeVonage, dto.Provider)
 	s.Equal("OTP over SMS", dto.Description)
 
 	values, err := propertyValues(dto.Properties)
@@ -59,7 +59,7 @@ func (s *VonageTestSuite) TestCreateMasksSecret() {
 			ID:       "vo-1",
 			Name:     "My Vonage",
 			Type:     ncommon.NotificationSenderTypeMessage,
-			Provider: ncommon.MessageProviderTypeVonage,
+			Provider: ncommon.NotificationProviderTypeVonage,
 			Properties: []cmodels.Property{
 				mustProperty(s.T(), ncommon.VonagePropKeyAPIKey, "a1b2c3d4", false),
 				mustProperty(s.T(), ncommon.VonagePropKeyAPISecret, "sec", true),
@@ -90,7 +90,7 @@ func (s *VonageTestSuite) TestGetRoundTrip() {
 			ID:       "vo-1",
 			Name:     "My Vonage",
 			Type:     ncommon.NotificationSenderTypeMessage,
-			Provider: ncommon.MessageProviderTypeVonage,
+			Provider: ncommon.NotificationProviderTypeVonage,
 			Properties: []cmodels.Property{
 				mustProperty(s.T(), ncommon.VonagePropKeyAPIKey, "a1b2c3d4", false),
 				mustProperty(s.T(), ncommon.VonagePropKeyAPISecret, "sec", true),
@@ -101,7 +101,7 @@ func (s *VonageTestSuite) TestGetRoundTrip() {
 	req := httptest.NewRequest(http.MethodGet, "/connections/vonage/vo-1", nil)
 	req.SetPathValue("id", "vo-1")
 	rr := httptest.NewRecorder()
-	getSMSHandler(s.handler, ncommon.MessageProviderTypeVonage, vonageFromSenderDTO)(rr, req)
+	getSMSHandler(s.handler, ncommon.NotificationProviderTypeVonage, vonageFromSenderDTO)(rr, req)
 
 	s.Equal(http.StatusOK, rr.Code)
 	var resp vonageConnectionResponse

--- a/backend/internal/notification/client/custom_client_test.go
+++ b/backend/internal/notification/client/custom_client_test.go
@@ -43,7 +43,7 @@ func (suite *CustomClientTestSuite) SetupSuite() {
 func (suite *CustomClientTestSuite) getValidCustomSenderJSON() common.NotificationSenderDTO {
 	return common.NotificationSenderDTO{
 		Name:     "Test Custom",
-		Provider: common.MessageProviderTypeCustom,
+		Provider: common.NotificationProviderTypeCustom,
 		Properties: []cmodels.Property{
 			createProperty("url", "https://api.example.com/sms", false),
 			createProperty("http_method", "POST", false),
@@ -56,7 +56,7 @@ func (suite *CustomClientTestSuite) getValidCustomSenderJSON() common.Notificati
 func (suite *CustomClientTestSuite) getValidCustomSenderFORM() common.NotificationSenderDTO {
 	return common.NotificationSenderDTO{
 		Name:     "Test Custom Form",
-		Provider: common.MessageProviderTypeCustom,
+		Provider: common.NotificationProviderTypeCustom,
 		Properties: []cmodels.Property{
 			createProperty("url", "https://api.example.com/sms", false),
 			createProperty("http_method", "POST", false),
@@ -195,7 +195,7 @@ func (suite *CustomClientTestSuite) TestSendSMS_NetworkError() {
 func (suite *CustomClientTestSuite) TestSendSMS_UnsupportedContentType() {
 	sender := common.NotificationSenderDTO{
 		Name:     "Test Custom",
-		Provider: common.MessageProviderTypeCustom,
+		Provider: common.NotificationProviderTypeCustom,
 		Properties: []cmodels.Property{
 			createProperty("url", "https://api.example.com/sms", false),
 			createProperty("http_method", "POST", false),
@@ -254,7 +254,7 @@ func (suite *CustomClientTestSuite) TestNewCustomClient_WithUnknownProperty() {
 func (suite *CustomClientTestSuite) TestNewCustomClient_InvalidHeaders() {
 	sender := common.NotificationSenderDTO{
 		Name:     "Test Custom",
-		Provider: common.MessageProviderTypeCustom,
+		Provider: common.NotificationProviderTypeCustom,
 		Properties: []cmodels.Property{
 			createProperty("url", "https://api.example.com/sms", false),
 			createProperty("http_method", "POST", false),

--- a/backend/internal/notification/client/factory.go
+++ b/backend/internal/notification/client/factory.go
@@ -31,11 +31,11 @@ func (p *clientFactory) GetClient(ctx context.Context, sender common.Notificatio
 	var _client NotificationClientInterface
 	var err error
 	switch sender.Provider {
-	case common.MessageProviderTypeVonage:
+	case common.NotificationProviderTypeVonage:
 		_client, err = newVonageClient(ctx, sender)
-	case common.MessageProviderTypeTwilio:
+	case common.NotificationProviderTypeTwilio:
 		_client, err = newTwilioClient(ctx, sender)
-	case common.MessageProviderTypeCustom:
+	case common.NotificationProviderTypeCustom:
 		_client, err = newCustomClient(ctx, sender)
 	default:
 		return nil, &ErrorInvalidProvider

--- a/backend/internal/notification/client/factory_test.go
+++ b/backend/internal/notification/client/factory_test.go
@@ -62,7 +62,7 @@ func (suite *ClientFactoryTestSuite) TestGetClient() {
 			name: "twilio",
 			sender: common.NotificationSenderDTO{
 				Name:     "Test Twilio",
-				Provider: common.MessageProviderTypeTwilio,
+				Provider: common.NotificationProviderTypeTwilio,
 				Properties: []cmodels.Property{
 					createTestProperty("account_sid", "AC00112233445566778899aabbccddeeff", true),
 					createTestProperty("auth_token", "test-token", true),
@@ -75,7 +75,7 @@ func (suite *ClientFactoryTestSuite) TestGetClient() {
 			name: "vonage",
 			sender: common.NotificationSenderDTO{
 				Name:     "Test Vonage",
-				Provider: common.MessageProviderTypeVonage,
+				Provider: common.NotificationProviderTypeVonage,
 				Properties: []cmodels.Property{
 					createTestProperty("api_key", "test-key", true),
 					createTestProperty("api_secret", "test-secret", true),
@@ -88,7 +88,7 @@ func (suite *ClientFactoryTestSuite) TestGetClient() {
 			name: "custom",
 			sender: common.NotificationSenderDTO{
 				Name:     "Test Custom",
-				Provider: common.MessageProviderTypeCustom,
+				Provider: common.NotificationProviderTypeCustom,
 				Properties: []cmodels.Property{
 					createTestProperty("url", "https://api.example.com/sms", false),
 					createTestProperty("http_method", "POST", false),
@@ -127,7 +127,7 @@ func (suite *ClientFactoryTestSuite) TestGetClientWithError() {
 			name: "twilio_decryption_error",
 			sender: common.NotificationSenderDTO{
 				Name:     "Bad Twilio",
-				Provider: common.MessageProviderTypeTwilio,
+				Provider: common.NotificationProviderTypeTwilio,
 				// account_sid is required and marked secret but value will fail decryption
 				Properties: append(makeInvalidSecretProps("account_sid"),
 					createTestProperty("auth_token", "test-token", true)),
@@ -137,7 +137,7 @@ func (suite *ClientFactoryTestSuite) TestGetClientWithError() {
 			name: "vonage_decryption_error",
 			sender: common.NotificationSenderDTO{
 				Name:     "Bad Vonage",
-				Provider: common.MessageProviderTypeVonage,
+				Provider: common.NotificationProviderTypeVonage,
 				Properties: append(makeInvalidSecretProps("api_key"),
 					createTestProperty("api_secret", "test-secret", true)),
 			},
@@ -146,7 +146,7 @@ func (suite *ClientFactoryTestSuite) TestGetClientWithError() {
 			name: "custom_decryption_error",
 			sender: common.NotificationSenderDTO{
 				Name:     "Bad Custom",
-				Provider: common.MessageProviderTypeCustom,
+				Provider: common.NotificationProviderTypeCustom,
 				// url is secret here and invalid ciphertext
 				Properties: makeInvalidSecretProps("url"),
 			},

--- a/backend/internal/notification/client/twilio_client_test.go
+++ b/backend/internal/notification/client/twilio_client_test.go
@@ -70,7 +70,7 @@ func (suite *TwilioClientTestSuite) SetupSuite() {
 func (suite *TwilioClientTestSuite) getValidTwilioSender() common.NotificationSenderDTO {
 	return common.NotificationSenderDTO{
 		Name:     "Test Twilio",
-		Provider: common.MessageProviderTypeTwilio,
+		Provider: common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{
 			createProperty("account_sid", "AC00112233445566778899aabbccddeeff", true),
 			createProperty("auth_token", "test-auth-token", true),

--- a/backend/internal/notification/client/vonage_client_test.go
+++ b/backend/internal/notification/client/vonage_client_test.go
@@ -44,7 +44,7 @@ func (suite *VonageClientTestSuite) SetupSuite() {
 func (suite *VonageClientTestSuite) getValidVonageSender() common.NotificationSenderDTO {
 	return common.NotificationSenderDTO{
 		Name:     "Test Vonage",
-		Provider: common.MessageProviderTypeVonage,
+		Provider: common.NotificationProviderTypeVonage,
 		Properties: []cmodels.Property{
 			createProperty("api_key", "test-api-key", true),
 			createProperty("api_secret", "test-api-secret", true),

--- a/backend/internal/notification/common/constants.go
+++ b/backend/internal/notification/common/constants.go
@@ -13,16 +13,16 @@ const (
 	NotificationSenderTypeEmail NotificationSenderType = "EMAIL"
 )
 
-// MessageProviderType defines the type of messaging provider.
-type MessageProviderType string
+// NotificationProviderType defines the type of messaging provider.
+type NotificationProviderType string
 
 const (
-	// MessageProviderTypeVonage represents the Vonage messaging provider.
-	MessageProviderTypeVonage MessageProviderType = "vonage"
-	// MessageProviderTypeTwilio represents the Twilio messaging provider.
-	MessageProviderTypeTwilio MessageProviderType = "twilio"
-	// MessageProviderTypeCustom represents a custom messaging provider.
-	MessageProviderTypeCustom MessageProviderType = "custom"
+	// NotificationProviderTypeVonage represents the Vonage messaging provider.
+	NotificationProviderTypeVonage NotificationProviderType = "vonage"
+	// NotificationProviderTypeTwilio represents the Twilio messaging provider.
+	NotificationProviderTypeTwilio NotificationProviderType = "twilio"
+	// NotificationProviderTypeCustom represents a custom messaging provider.
+	NotificationProviderTypeCustom NotificationProviderType = "custom"
 )
 
 // ChannelType defines the type of communication channel.

--- a/backend/internal/notification/common/model.go
+++ b/backend/internal/notification/common/model.go
@@ -20,12 +20,12 @@ type NotificationData struct {
 
 // NotificationSenderDTO represents the data transfer object for a notification sender.
 type NotificationSenderDTO struct {
-	ID          string                 `yaml:"id,omitempty"`
-	Name        string                 `yaml:"name"`
-	Description string                 `yaml:"description,omitempty"`
-	Type        NotificationSenderType `yaml:"-"`
-	Provider    MessageProviderType    `yaml:"provider"`
-	Properties  []cmodels.Property     `yaml:"properties,omitempty"`
+	ID          string                   `yaml:"id,omitempty"`
+	Name        string                   `yaml:"name"`
+	Description string                   `yaml:"description,omitempty"`
+	Type        NotificationSenderType   `yaml:"-"`
+	Provider    NotificationProviderType `yaml:"provider"`
+	Properties  []cmodels.Property       `yaml:"properties,omitempty"`
 }
 
 // VerifyOTPDTO represents the service layer data structure for verifying an OTP.

--- a/backend/internal/notification/file_based_store_test.go
+++ b/backend/internal/notification/file_based_store_test.go
@@ -74,7 +74,7 @@ func (suite *FileBasedStoreTestSuite) createTestSender(id, name string) *common.
 		Name:        name,
 		Description: "Test notification sender",
 		Type:        common.NotificationSenderTypeMessage,
-		Provider:    common.MessageProviderTypeTwilio,
+		Provider:    common.NotificationProviderTypeTwilio,
 		Properties:  properties,
 	}
 }
@@ -95,13 +95,13 @@ func (suite *FileBasedStoreTestSuite) TestCreateSender_Success() {
 	suite.NotNil(actualSender)
 	suite.Equal("sender-001", actualSender.ID)
 	suite.Equal("Twilio Test Sender", actualSender.Name)
-	suite.Equal(common.MessageProviderTypeTwilio, actualSender.Provider)
+	suite.Equal(common.NotificationProviderTypeTwilio, actualSender.Provider)
 }
 
 func (suite *FileBasedStoreTestSuite) TestGetSenderByID_Success() {
 	// Arrange
 	sender := suite.createTestSender("sender-002", "Vonage Test Sender")
-	sender.Provider = common.MessageProviderTypeVonage
+	sender.Provider = common.NotificationProviderTypeVonage
 	_ = suite.store.createSender(context.Background(), *sender)
 
 	// Act
@@ -112,7 +112,7 @@ func (suite *FileBasedStoreTestSuite) TestGetSenderByID_Success() {
 	suite.NotNil(retrieved)
 	suite.Equal("sender-002", retrieved.ID)
 	suite.Equal("Vonage Test Sender", retrieved.Name)
-	suite.Equal(common.MessageProviderTypeVonage, retrieved.Provider)
+	suite.Equal(common.NotificationProviderTypeVonage, retrieved.Provider)
 }
 
 func (suite *FileBasedStoreTestSuite) TestGetSenderByID_NotFound() {
@@ -127,7 +127,7 @@ func (suite *FileBasedStoreTestSuite) TestGetSenderByID_NotFound() {
 func (suite *FileBasedStoreTestSuite) TestGetSenderByName_Success() {
 	// Arrange
 	sender := suite.createTestSender("sender-003", "Custom SMS Sender")
-	sender.Provider = common.MessageProviderTypeCustom
+	sender.Provider = common.NotificationProviderTypeCustom
 	_ = suite.store.createSender(context.Background(), *sender)
 
 	// Act
@@ -138,7 +138,7 @@ func (suite *FileBasedStoreTestSuite) TestGetSenderByName_Success() {
 	suite.NotNil(retrieved)
 	suite.Equal("sender-003", retrieved.ID)
 	suite.Equal("Custom SMS Sender", retrieved.Name)
-	suite.Equal(common.MessageProviderTypeCustom, retrieved.Provider)
+	suite.Equal(common.NotificationProviderTypeCustom, retrieved.Provider)
 }
 
 func (suite *FileBasedStoreTestSuite) TestGetSenderByName_NotFound() {
@@ -253,7 +253,7 @@ func (suite *FileBasedStoreTestSuite) TestCreateMultipleSenders_WithProperties()
 		Name:        "Vonage Production",
 		Description: "Vonage notification sender",
 		Type:        common.NotificationSenderTypeMessage,
-		Provider:    common.MessageProviderTypeVonage,
+		Provider:    common.NotificationProviderTypeVonage,
 		Properties:  vonageProps,
 	}
 

--- a/backend/internal/notification/mgt_service_test.go
+++ b/backend/internal/notification/mgt_service_test.go
@@ -847,7 +847,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) getValidTwilioSender() commo
 		Name:        "Test Twilio Sender",
 		Description: "Test Description",
 		Type:        common.NotificationSenderTypeMessage,
-		Provider:    common.MessageProviderTypeTwilio,
+		Provider:    common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{
 			createTestProperty("account_sid", "AC00112233445566778899aabbccddeeff", true),
 			createTestProperty("auth_token", "test-auth-token", true),
@@ -862,7 +862,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) getValidVonageSender() commo
 		Name:        "Test Vonage Sender",
 		Description: "Test Vonage Description",
 		Type:        common.NotificationSenderTypeMessage,
-		Provider:    common.MessageProviderTypeVonage,
+		Provider:    common.NotificationProviderTypeVonage,
 		Properties: []cmodels.Property{
 			createTestProperty("api_key", "test-api-key", true),
 			createTestProperty("api_secret", "test-api-secret", true),

--- a/backend/internal/notification/notification_sender_service_test.go
+++ b/backend/internal/notification/notification_sender_service_test.go
@@ -61,7 +61,7 @@ func (suite *NotificationSenderServiceTestSuite) getValidSender() *common.Notifi
 		ID:       "sender-001",
 		Name:     "Test SMS Sender",
 		Type:     common.NotificationSenderTypeMessage,
-		Provider: common.MessageProviderTypeTwilio,
+		Provider: common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{
 			createTestProperty("account_sid", "AC00112233445566778899aabbccddeeff", true),
 			createTestProperty("auth_token", "test-token", true),

--- a/backend/internal/notification/store.go
+++ b/backend/internal/notification/store.go
@@ -281,7 +281,7 @@ func (s *notificationStore) buildSenderFromResultRow(
 		Name:        name,
 		Description: description,
 		Type:        common.NotificationSenderType(_type),
-		Provider:    common.MessageProviderType(provider),
+		Provider:    common.NotificationProviderType(provider),
 		Properties:  []cmodels.Property{},
 	}
 

--- a/backend/internal/notification/store_test.go
+++ b/backend/internal/notification/store_test.go
@@ -86,7 +86,7 @@ func (suite *StoreTestSuite) TestCreateSender() {
 		Name:        "Test Sender",
 		Description: "Test Description",
 		Type:        common.NotificationSenderTypeMessage,
-		Provider:    common.MessageProviderTypeTwilio,
+		Provider:    common.NotificationProviderTypeTwilio,
 		Properties:  []cmodels.Property{*p},
 	}
 
@@ -426,7 +426,7 @@ func (suite *StoreTestSuite) TestGetSender_WithProperties() {
 }
 
 func (suite *StoreTestSuite) TestUpdateSender() {
-	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1", Provider: common.MessageProviderTypeTwilio}
+	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1", Provider: common.NotificationProviderTypeTwilio}
 
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().ExecuteContext(context.Background(), queryUpdateNotificationSender,
@@ -441,7 +441,7 @@ func (suite *StoreTestSuite) TestUpdateSender_WithProperties() {
 	p, err := cmodels.NewProperty("k", "v", false)
 	suite.NoError(err)
 	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1",
-		Provider: common.MessageProviderTypeTwilio, Properties: []cmodels.Property{*p}}
+		Provider: common.NotificationProviderTypeTwilio, Properties: []cmodels.Property{*p}}
 
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	propsJSON, err := cmodels.SerializePropertiesToJSONArray([]cmodels.Property{*p})
@@ -476,7 +476,7 @@ func (suite *StoreTestSuite) TestUpdateSender_WithError() {
 		{
 			name: "execute error",
 			setup: func(t *testing.T) {
-				sender := common.NotificationSenderDTO{Name: "n1", Provider: common.MessageProviderTypeTwilio}
+				sender := common.NotificationSenderDTO{Name: "n1", Provider: common.NotificationProviderTypeTwilio}
 				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 				suite.mockDBClient.EXPECT().ExecuteContext(context.Background(), queryUpdateNotificationSender,
 					sender.Name,
@@ -492,7 +492,7 @@ func (suite *StoreTestSuite) TestUpdateSender_WithError() {
 			tc.setup(t)
 			// use a sender without properties for these failure-case checks
 			sender := common.NotificationSenderDTO{ID: "s1", Name: "n1",
-				Provider: common.MessageProviderTypeTwilio}
+				Provider: common.NotificationProviderTypeTwilio}
 			err := suite.store.updateSender(context.Background(), "s1", sender)
 			suite.Error(err)
 			suite.Contains(err.Error(), tc.wantErr)
@@ -501,7 +501,7 @@ func (suite *StoreTestSuite) TestUpdateSender_WithError() {
 }
 
 func (suite *StoreTestSuite) TestUpdateSender_ExecuteError() {
-	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1", Provider: common.MessageProviderTypeTwilio}
+	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1", Provider: common.NotificationProviderTypeTwilio}
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().ExecuteContext(context.Background(), queryUpdateNotificationSender,
 		sender.Name, sender.Description,
@@ -523,7 +523,7 @@ func (suite *StoreTestSuite) TestUpdateSender_SerializeError() {
 	p, err := cmodels.NewProperty("k", "v", false)
 	suite.NoError(err)
 	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1",
-		Provider: common.MessageProviderTypeTwilio, Properties: []cmodels.Property{*p}}
+		Provider: common.NotificationProviderTypeTwilio, Properties: []cmodels.Property{*p}}
 
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 

--- a/backend/internal/notification/utils.go
+++ b/backend/internal/notification/utils.go
@@ -38,9 +38,9 @@ func validateMessageNotificationSender(sender common.NotificationSenderDTO) *tid
 	if sender.Provider == "" {
 		return &ErrorInvalidProvider
 	}
-	if sender.Provider != common.MessageProviderTypeTwilio &&
-		sender.Provider != common.MessageProviderTypeVonage &&
-		sender.Provider != common.MessageProviderTypeCustom {
+	if sender.Provider != common.NotificationProviderTypeTwilio &&
+		sender.Provider != common.NotificationProviderTypeVonage &&
+		sender.Provider != common.NotificationProviderTypeCustom {
 		return &ErrorInvalidProvider
 	}
 
@@ -77,11 +77,11 @@ func validateMessageNotificationSenderProperties(sender common.NotificationSende
 	}
 
 	switch sender.Provider {
-	case common.MessageProviderTypeTwilio:
+	case common.NotificationProviderTypeTwilio:
 		return validateTwilioProperties(sender.Properties)
-	case common.MessageProviderTypeVonage:
+	case common.NotificationProviderTypeVonage:
 		return validateVonageProperties(sender.Properties)
-	case common.MessageProviderTypeCustom:
+	case common.NotificationProviderTypeCustom:
 		return validateCustomProperties(sender.Properties)
 	default:
 		return errors.New("unsupported message notification sender")

--- a/backend/internal/notification/utils_test.go
+++ b/backend/internal/notification/utils_test.go
@@ -42,7 +42,7 @@ func (suite *UtilsTestSuite) TestValidateNotificationSender_EmptyName() {
 	sender := common.NotificationSenderDTO{
 		Name:     "",
 		Type:     common.NotificationSenderTypeMessage,
-		Provider: common.MessageProviderTypeTwilio,
+		Provider: common.NotificationProviderTypeTwilio,
 	}
 
 	err := validateNotificationSender(sender)
@@ -55,7 +55,7 @@ func (suite *UtilsTestSuite) TestValidateNotificationSender_InvalidType() {
 	sender := common.NotificationSenderDTO{
 		Name:     "Test Sender",
 		Type:     "INVALID_TYPE",
-		Provider: common.MessageProviderTypeTwilio,
+		Provider: common.NotificationProviderTypeTwilio,
 	}
 
 	err := validateNotificationSender(sender)
@@ -94,7 +94,7 @@ func (suite *UtilsTestSuite) TestValidateMessageNotificationSender_Twilio() {
 	sender := common.NotificationSenderDTO{
 		Name:     "Test Twilio",
 		Type:     common.NotificationSenderTypeMessage,
-		Provider: common.MessageProviderTypeTwilio,
+		Provider: common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{
 			createTestProperty("account_sid", "AC00112233445566778899aabbccddeeff", true),
 			createTestProperty("auth_token", "test-token", true),
@@ -111,7 +111,7 @@ func (suite *UtilsTestSuite) TestValidateMessageNotificationSender_Vonage() {
 	sender := common.NotificationSenderDTO{
 		Name:     "Test Vonage",
 		Type:     common.NotificationSenderTypeMessage,
-		Provider: common.MessageProviderTypeVonage,
+		Provider: common.NotificationProviderTypeVonage,
 		Properties: []cmodels.Property{
 			createTestProperty("api_key", "test-key", true),
 			createTestProperty("api_secret", "test-secret", true),
@@ -128,7 +128,7 @@ func (suite *UtilsTestSuite) TestValidateMessageNotificationSender_Custom() {
 	sender := common.NotificationSenderDTO{
 		Name:     "Test Custom",
 		Type:     common.NotificationSenderTypeMessage,
-		Provider: common.MessageProviderTypeCustom,
+		Provider: common.NotificationProviderTypeCustom,
 		Properties: []cmodels.Property{
 			createTestProperty("url", "https://api.example.com/sms", false),
 			createTestProperty("http_method", "POST", false),
@@ -357,7 +357,7 @@ func (suite *UtilsTestSuite) TestValidateMessageNotificationSender_EmptyProperti
 	sender := common.NotificationSenderDTO{
 		Name:       "Test Twilio Empty Props",
 		Type:       common.NotificationSenderTypeMessage,
-		Provider:   common.MessageProviderTypeTwilio,
+		Provider:   common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{},
 	}
 
@@ -372,7 +372,7 @@ func (suite *UtilsTestSuite) TestValidateNotificationSender() {
 	sender := common.NotificationSenderDTO{
 		Name:     "Test Sender",
 		Type:     common.NotificationSenderTypeMessage,
-		Provider: common.MessageProviderTypeTwilio,
+		Provider: common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{
 			createTestProperty("account_sid", "AC00112233445566778899aabbccddeeff", true),
 			createTestProperty("auth_token", "test-token", true),
@@ -418,7 +418,7 @@ func (suite *UtilsTestSuite) TestValidateMessageNotificationSender_InvalidSuppor
 	sender := common.NotificationSenderDTO{
 		Name:     "Test Sender Invalid Channel",
 		Type:     common.NotificationSenderTypeMessage,
-		Provider: common.MessageProviderTypeTwilio,
+		Provider: common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{
 			createTestProperty("account_sid", "AC00112233445566778899aabbccddeeff", true),
 			createTestProperty("auth_token", "test-token", true),
@@ -446,7 +446,7 @@ func (suite *UtilsTestSuite) TestValidateMessageNotificationSender_SupportedChan
 	sender := common.NotificationSenderDTO{
 		Name:       "Test Sender Read Error",
 		Type:       common.NotificationSenderTypeMessage,
-		Provider:   common.MessageProviderTypeTwilio,
+		Provider:   common.NotificationProviderTypeTwilio,
 		Properties: properties,
 	}
 

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -1392,7 +1392,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_Success() {
 		ID:          "sender1",
 		Name:        "Test Sender",
 		Description: "Test notification sender",
-		Provider:    common.MessageProviderTypeTwilio,
+		Provider:    common.NotificationProviderTypeTwilio,
 		Properties:  []cmodels.Property{*mockProperty},
 	}
 
@@ -1419,7 +1419,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_Multiple() {
 	mockSender1 := &common.NotificationSenderDTO{
 		ID:         "sender1",
 		Name:       "Twilio Sender",
-		Provider:   common.MessageProviderTypeTwilio,
+		Provider:   common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{*mockProperty1},
 	}
 
@@ -1427,7 +1427,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_Multiple() {
 	mockSender2 := &common.NotificationSenderDTO{
 		ID:         "sender2",
 		Name:       "Vonage Sender",
-		Provider:   common.MessageProviderTypeVonage,
+		Provider:   common.NotificationProviderTypeVonage,
 		Properties: []cmodels.Property{*mockProperty2},
 	}
 
@@ -1459,7 +1459,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_Wildcard() {
 		ID:         "sender1",
 		Name:       "Twilio Sender",
 		Type:       common.NotificationSenderTypeMessage,
-		Provider:   common.MessageProviderTypeTwilio,
+		Provider:   common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{*mockProperty1},
 	}
 
@@ -1468,7 +1468,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_Wildcard() {
 		ID:         "sender2",
 		Name:       "Vonage Sender",
 		Type:       common.NotificationSenderTypeMessage,
-		Provider:   common.MessageProviderTypeVonage,
+		Provider:   common.NotificationProviderTypeVonage,
 		Properties: []cmodels.Property{*mockProperty2},
 	}
 
@@ -1528,7 +1528,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_EmptyName() {
 	mockSender := &common.NotificationSenderDTO{
 		ID:         "sender-no-name",
 		Name:       "", // Empty name
-		Provider:   common.MessageProviderTypeTwilio,
+		Provider:   common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{*mockProperty},
 	}
 
@@ -1555,7 +1555,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_NoProperties(
 	mockSender := &common.NotificationSenderDTO{
 		ID:         "sender-no-props",
 		Name:       "Empty Sender",
-		Provider:   common.MessageProviderTypeTwilio,
+		Provider:   common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{}, // Empty properties
 	}
 
@@ -1588,7 +1588,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_WildcardParti
 		ID:         "sender1",
 		Name:       "Twilio Sender",
 		Type:       common.NotificationSenderTypeMessage,
-		Provider:   common.MessageProviderTypeTwilio,
+		Provider:   common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{*mockProperty1},
 	}
 
@@ -1596,7 +1596,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_WildcardParti
 		ID:       "sender2",
 		Name:     "Failing Sender",
 		Type:     common.NotificationSenderTypeMessage,
-		Provider: common.MessageProviderTypeVonage,
+		Provider: common.NotificationProviderTypeVonage,
 	}
 
 	mockProperty3, _ := cmodels.NewProperty("api_key", "key3", true)
@@ -1604,7 +1604,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_WildcardParti
 		ID:         "sender3",
 		Name:       "Vonage Sender",
 		Type:       common.NotificationSenderTypeMessage,
-		Provider:   common.MessageProviderTypeVonage,
+		Provider:   common.NotificationProviderTypeVonage,
 		Properties: []cmodels.Property{*mockProperty3},
 	}
 
@@ -2247,7 +2247,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Notificatio
 	mockSender := &common.NotificationSenderDTO{
 		ID:         senderID,
 		Name:       "Test Sender",
-		Provider:   common.MessageProviderTypeTwilio,
+		Provider:   common.NotificationProviderTypeTwilio,
 		Properties: []cmodels.Property{*mockProperty},
 	}
 


### PR DESCRIPTION
### Purpose

This pull request updates the codebase to use `NotificationProviderType` instead of the deprecated `MessageProviderType` for identifying notification providers (such as Twilio, Vonage, and Custom) throughout the backend connection logic and tests. This change improves consistency and reflects updated naming conventions in the `ncommon` package.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

The most important changes are:

**Provider Type Refactor:**

* All references to `MessageProviderType` have been replaced with `NotificationProviderType` in function signatures, struct fields, and switch statements across the backend connection implementation (`declarative_resource.go`, `handler.go`, `init.go`) and related test files. [[1]](diffhunk://#diff-f66dd82504868b93cd2863dc713727bdf8efc0a3782d9ca356f637aed55b4f49L265-R273) [[2]](diffhunk://#diff-e012a959bc09beee448170ff25c34a743a5ee2432136e54a193979aa3eb4f83cL278-R278) [[3]](diffhunk://#diff-e012a959bc09beee448170ff25c34a743a5ee2432136e54a193979aa3eb4f83cL301-R301) [[4]](diffhunk://#diff-e012a959bc09beee448170ff25c34a743a5ee2432136e54a193979aa3eb4f83cL342-R350) [[5]](diffhunk://#diff-e012a959bc09beee448170ff25c34a743a5ee2432136e54a193979aa3eb4f83cL359-R359) [[6]](diffhunk://#diff-e012a959bc09beee448170ff25c34a743a5ee2432136e54a193979aa3eb4f83cL380-R380) [[7]](diffhunk://#diff-e012a959bc09beee448170ff25c34a743a5ee2432136e54a193979aa3eb4f83cL398-R398) [[8]](diffhunk://#diff-6b698812c6722210ba38e21ae5433ffe88263223468c422cc6f6525e9c80f356L86-R99) [[9]](diffhunk://#diff-6b698812c6722210ba38e21ae5433ffe88263223468c422cc6f6525e9c80f356L132-R132)

**Test Updates:**

* All tests referencing provider types now use `NotificationProviderType` constants and values instead of the old `MessageProviderType`. This includes updates in test DTOs, assertions, and mock expectations. [[1]](diffhunk://#diff-2c7cc5a8a0daf5969fac3a522f8c5e12f04cdfc6224b8e578c501471011911f5L78-R78) [[2]](diffhunk://#diff-2c7cc5a8a0daf5969fac3a522f8c5e12f04cdfc6224b8e578c501471011911f5L94-R94) [[3]](diffhunk://#diff-2c7cc5a8a0daf5969fac3a522f8c5e12f04cdfc6224b8e578c501471011911f5L157-R177) [[4]](diffhunk://#diff-2c7cc5a8a0daf5969fac3a522f8c5e12f04cdfc6224b8e578c501471011911f5L255-R255) [[5]](diffhunk://#diff-2c7cc5a8a0daf5969fac3a522f8c5e12f04cdfc6224b8e578c501471011911f5L365-R365) [[6]](diffhunk://#diff-2c7cc5a8a0daf5969fac3a522f8c5e12f04cdfc6224b8e578c501471011911f5L385-R386) [[7]](diffhunk://#diff-2c7cc5a8a0daf5969fac3a522f8c5e12f04cdfc6224b8e578c501471011911f5L421-R421) [[8]](diffhunk://#diff-2c7cc5a8a0daf5969fac3a522f8c5e12f04cdfc6224b8e578c501471011911f5L451-R451) [[9]](diffhunk://#diff-1337c1f08cffc166840adbd58594560e1945d90f9e64737abb32edc78f6becd3L55-R57) [[10]](diffhunk://#diff-1337c1f08cffc166840adbd58594560e1945d90f9e64737abb32edc78f6becd3L207-R209) [[11]](diffhunk://#diff-1337c1f08cffc166840adbd58594560e1945d90f9e64737abb32edc78f6becd3L380-R380) [[12]](diffhunk://#diff-1337c1f08cffc166840adbd58594560e1945d90f9e64737abb32edc78f6becd3L565-R565) [[13]](diffhunk://#diff-ce990d4ef087b82120e6a0bb90560f6771a8edd554cb3aafce4ec54ff676fbb1L113-R118) [[14]](diffhunk://#diff-ce990d4ef087b82120e6a0bb90560f6771a8edd554cb3aafce4ec54ff676fbb1L129-R132)

**Route and Handler Refactor:**

* All route registration and handler functions for SMS-backed vendors are updated to use `NotificationProviderType` for clarity and consistency. [[1]](diffhunk://#diff-6b698812c6722210ba38e21ae5433ffe88263223468c422cc6f6525e9c80f356L86-R99) [[2]](diffhunk://#diff-6b698812c6722210ba38e21ae5433ffe88263223468c422cc6f6525e9c80f356L132-R132)

These changes are primarily a mechanical refactor to align with updated type naming and ensure future maintainability.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3276

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3516

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed notification provider type terminology across SMS connections and notification services.
  - Updated provider references for Twilio, Vonage, and custom SMS gateways.
  - Existing provider values and behavior remain unchanged.
- **Tests**
  - Updated related test fixtures and coverage to use the revised notification provider terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->