### PR TITLE
Require an auth assertion to enroll a passkey through the Direct API

### DIFF
--- a/api/registration.yaml
+++ b/api/registration.yaml
@@ -47,11 +47,19 @@ paths:
           description: >
             Bad Request: The request body is malformed or contains invalid data. Client-side
             failures (invalid input, user not found, etc.) surface as a single enrollment failure
-            code (AUTHN-PSK-1002).
+            code (AUTHN-PSK-1002). A request that does not prove the target user is rejected
+            before any challenge is issued: an `assertion` that cannot be verified returns
+            AUTHN-1009, and one whose subject is not `userId` returns AUTHN-1010. A missing,
+            empty or blank `assertion` (or `userId`) is a required-field violation and is
+            rejected by request validation before the handler runs, which returns the
+            `INVALID_INPUT_METADATA` shape with a per-field `errors` map instead of the codes
+            above.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/Error'
+                  - $ref: '#/components/schemas/ValidationError'
               examples:
                 enrollmentFailed:
                   value:
@@ -62,6 +70,31 @@ paths:
                     description:
                       key: "error.authnservice.passkey_enrollment_failed_description"
                       defaultValue: "The passkey enrollment attempt failed"
+                missingAssertion:
+                  value:
+                    code: "INVALID_INPUT_METADATA"
+                    message: "Validation Failed"
+                    description: "One or more inbound fields failed structural edge-boundary rules."
+                    errors:
+                      assertion: "The field 'assertion' is missing but is strictly required."
+                invalidAssertion:
+                  value:
+                    code: "AUTHN-1009"
+                    message:
+                      key: "error.authnservice.invalid_assertion"
+                      defaultValue: "Invalid assertion"
+                    description:
+                      key: "error.authnservice.invalid_assertion_description"
+                      defaultValue: "The provided assertion token is invalid"
+                assertionSubjectMismatch:
+                  value:
+                    code: "AUTHN-1010"
+                    message:
+                      key: "error.authnservice.assertion_subject_mismatch"
+                      defaultValue: "Assertion subject mismatch"
+                    description:
+                      key: "error.authnservice.assertion_subject_mismatch_description"
+                      defaultValue: "The subject in the assertion does not match the authenticated user"
         "500":
           description: 'Internal Server Error: An unexpected error occurred while processing the request'
           content:
@@ -177,9 +210,18 @@ components:
           description: Attestation conveyance preference
           enum: ["none", "indirect", "direct", "enterprise"]
           example: "none"
+        assertion:
+          type: string
+          description: >
+            Auth assertion obtained from a prior authentication, proving the caller holds the
+            account named by `userId`. The credential is enrolled only for the assertion subject,
+            so the assertion `sub` and `userId` must be the same user. Holding the Direct Auth
+            Secret is not sufficient on its own.
+          example: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1NTBlODQwMC1lMjliIn0.signature"
       required:
         - userId
         - relyingPartyId
+        - assertion
 
     PasskeyRegistrationStartResponse:
       type: object
@@ -432,6 +474,36 @@ components:
           $ref: '#/components/schemas/I18nMessage'
         description:
           $ref: '#/components/schemas/I18nMessage'
+
+    ValidationError:
+      type: object
+      description: >
+        Returned when a request fails required-field or bounds validation, which happens before the
+        handler runs. Unlike `Error`, its `message` and `description` are plain strings rather than
+        internationalized objects, and it carries an `errors` map naming each field that failed.
+      required:
+        - code
+        - message
+        - description
+        - errors
+      properties:
+        code:
+          type: string
+          description: Always `INVALID_INPUT_METADATA` for a validation failure.
+          example: "INVALID_INPUT_METADATA"
+        message:
+          type: string
+          example: "Validation Failed"
+        description:
+          type: string
+          example: "One or more inbound fields failed structural edge-boundary rules."
+        errors:
+          type: object
+          description: One entry per field that failed validation, keyed by the field's JSON name.
+          additionalProperties:
+            type: string
+          example:
+            assertion: "The field 'assertion' is missing but is strictly required."
 
     I18nMessage:
       type: object

--- a/backend/internal/authn/AuthenticationServiceInterface_mock_test.go
+++ b/backend/internal/authn/AuthenticationServiceInterface_mock_test.go
@@ -644,8 +644,8 @@ func (_c *AuthenticationServiceInterfaceMock_StartPasskeyAuthentication_Call) Ru
 }
 
 // StartPasskeyRegistration provides a mock function for the type AuthenticationServiceInterfaceMock
-func (_mock *AuthenticationServiceInterfaceMock) StartPasskeyRegistration(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *PasskeyAuthenticatorSelectionDTO, attestation string) (interface{}, *common0.ServiceError) {
-	ret := _mock.Called(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation)
+func (_mock *AuthenticationServiceInterfaceMock) StartPasskeyRegistration(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *PasskeyAuthenticatorSelectionDTO, attestation string, assertion string) (interface{}, *common0.ServiceError) {
+	ret := _mock.Called(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation, assertion)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StartPasskeyRegistration")
@@ -653,18 +653,18 @@ func (_mock *AuthenticationServiceInterfaceMock) StartPasskeyRegistration(ctx co
 
 	var r0 interface{}
 	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *PasskeyAuthenticatorSelectionDTO, string) (interface{}, *common0.ServiceError)); ok {
-		return returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *PasskeyAuthenticatorSelectionDTO, string, string) (interface{}, *common0.ServiceError)); ok {
+		return returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation, assertion)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *PasskeyAuthenticatorSelectionDTO, string) interface{}); ok {
-		r0 = returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *PasskeyAuthenticatorSelectionDTO, string, string) interface{}); ok {
+		r0 = returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation, assertion)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(interface{})
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, *PasskeyAuthenticatorSelectionDTO, string) *common0.ServiceError); ok {
-		r1 = returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, *PasskeyAuthenticatorSelectionDTO, string, string) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation, assertion)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common0.ServiceError)
@@ -685,11 +685,12 @@ type AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call struct {
 //   - relyingPartyName string
 //   - authSelection *PasskeyAuthenticatorSelectionDTO
 //   - attestation string
-func (_e *AuthenticationServiceInterfaceMock_Expecter) StartPasskeyRegistration(ctx interface{}, userID interface{}, relyingPartyID interface{}, relyingPartyName interface{}, authSelection interface{}, attestation interface{}) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
-	return &AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call{Call: _e.mock.On("StartPasskeyRegistration", ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation)}
+//   - assertion string
+func (_e *AuthenticationServiceInterfaceMock_Expecter) StartPasskeyRegistration(ctx interface{}, userID interface{}, relyingPartyID interface{}, relyingPartyName interface{}, authSelection interface{}, attestation interface{}, assertion interface{}) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
+	return &AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call{Call: _e.mock.On("StartPasskeyRegistration", ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation, assertion)}
 }
 
-func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) Run(run func(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *PasskeyAuthenticatorSelectionDTO, attestation string)) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
+func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) Run(run func(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *PasskeyAuthenticatorSelectionDTO, attestation string, assertion string)) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -715,6 +716,10 @@ func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) Run(
 		if args[5] != nil {
 			arg5 = args[5].(string)
 		}
+		var arg6 string
+		if args[6] != nil {
+			arg6 = args[6].(string)
+		}
 		run(
 			arg0,
 			arg1,
@@ -722,6 +727,7 @@ func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) Run(
 			arg3,
 			arg4,
 			arg5,
+			arg6,
 		)
 	})
 	return _c
@@ -732,7 +738,7 @@ func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) Retu
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) RunAndReturn(run func(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *PasskeyAuthenticatorSelectionDTO, attestation string) (interface{}, *common0.ServiceError)) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
+func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) RunAndReturn(run func(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *PasskeyAuthenticatorSelectionDTO, attestation string, assertion string) (interface{}, *common0.ServiceError)) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/authn/handler.go
+++ b/backend/internal/authn/handler.go
@@ -300,6 +300,7 @@ func (ah *authenticationHandler) HandlePasskeyRegisterStartRequest(w http.Respon
 		regRequest.RelyingPartyName,
 		regRequest.AuthenticatorSelection,
 		regRequest.Attestation,
+		regRequest.Assertion,
 	)
 	if svcErr != nil {
 		ah.handleServiceError(ctx, w, svcErr)

--- a/backend/internal/authn/handler_test.go
+++ b/backend/internal/authn/handler_test.go
@@ -766,6 +766,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandlePasskeyRegisterStartReque
 		RelyingPartyID:   "example.com",
 		RelyingPartyName: "Example Corp",
 		Attestation:      "direct",
+		Assertion:        testJWTToken,
 	}
 	regResponse := map[string]interface{}{
 		"publicKeyCredentialCreationOptions": map[string]interface{}{
@@ -789,7 +790,8 @@ func (suite *AuthenticationHandlerTestSuite) TestHandlePasskeyRegisterStartReque
 		regRequest.RelyingPartyID,
 		regRequest.RelyingPartyName,
 		regRequest.AuthenticatorSelection,
-		regRequest.Attestation).Return(regResponse, nil)
+		regRequest.Attestation,
+		regRequest.Assertion).Return(regResponse, nil)
 
 	body, _ := json.Marshal(regRequest)
 	req := httptest.NewRequest(http.MethodPost, "/authenticate/passkey/register/start", bytes.NewReader(body))
@@ -819,15 +821,53 @@ func (suite *AuthenticationHandlerTestSuite) TestHandlePasskeyRegisterStartReque
 	suite.Equal(common.APIErrorInvalidRequestFormat.Code, errResp.Code)
 }
 
-func (suite *AuthenticationHandlerTestSuite) TestHandlePasskeyRegisterStartRequestServiceError() {
+// TestHandlePasskeyRegisterStartRequestMissingAssertion asserts the assertion is rejected as a
+// missing required field, so the request never reaches the service.
+func (suite *AuthenticationHandlerTestSuite) TestHandlePasskeyRegisterStartRequestMissingAssertion() {
 	regRequest := PasskeyRegisterStartRequestDTO{
 		UserID:         "user123",
 		RelyingPartyID: "example.com",
 	}
+
+	body, _ := json.Marshal(regRequest)
+	req := httptest.NewRequest(http.MethodPost, "/register/passkey/start", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	suite.handler.HandlePasskeyRegisterStartRequest(w, req)
+
+	suite.Equal(http.StatusBadRequest, w.Code)
+	suite.mockService.AssertNotCalled(suite.T(), "StartPasskeyRegistration")
+}
+
+// TestHandlePasskeyRegisterStartRequestMissingUserID asserts userId stays required alongside the
+// assertion, so a caller cannot fall back to an assertion-only request.
+func (suite *AuthenticationHandlerTestSuite) TestHandlePasskeyRegisterStartRequestMissingUserID() {
+	regRequest := PasskeyRegisterStartRequestDTO{
+		RelyingPartyID: "example.com",
+		Assertion:      testJWTToken,
+	}
+
+	body, _ := json.Marshal(regRequest)
+	req := httptest.NewRequest(http.MethodPost, "/register/passkey/start", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	suite.handler.HandlePasskeyRegisterStartRequest(w, req)
+
+	suite.Equal(http.StatusBadRequest, w.Code)
+	suite.mockService.AssertNotCalled(suite.T(), "StartPasskeyRegistration")
+}
+
+func (suite *AuthenticationHandlerTestSuite) TestHandlePasskeyRegisterStartRequestServiceError() {
+	regRequest := PasskeyRegisterStartRequestDTO{
+		UserID:         "user123",
+		RelyingPartyID: "example.com",
+		Assertion:      testJWTToken,
+	}
 	serviceError := &common.ErrorUserNotFound
 
 	suite.mockService.On("StartPasskeyRegistration",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything).
 		Return(nil, serviceError)
 
 	body, _ := json.Marshal(regRequest)

--- a/backend/internal/authn/model.go
+++ b/backend/internal/authn/model.go
@@ -73,13 +73,15 @@ type PasskeyAuthenticatorSelectionDTO struct {
 	UserVerification        string `json:"userVerification,omitempty"`
 }
 
-// PasskeyRegisterStartRequestDTO is the request to start passkey registration.
+// PasskeyRegisterStartRequestDTO is the request to start passkey registration. Assertion carries
+// the proof that the caller holds UserID; both are required, and the two must agree.
 type PasskeyRegisterStartRequestDTO struct {
-	UserID                 string                            `json:"userId"`
-	RelyingPartyID         string                            `json:"relyingPartyId"`
+	UserID                 string                            `json:"userId"         native:"required"`
+	RelyingPartyID         string                            `json:"relyingPartyId" native:"required"`
 	RelyingPartyName       string                            `json:"relyingPartyName"`
 	AuthenticatorSelection *PasskeyAuthenticatorSelectionDTO `json:"authenticatorSelection,omitempty"`
 	Attestation            string                            `json:"attestation,omitempty"`
+	Assertion              string                            `json:"assertion"      native:"required"`
 }
 
 // PasskeyPublicKeyCredentialDTO represents a WebAuthn public key credential.

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -61,7 +61,7 @@ type AuthenticationServiceInterface interface {
 	) (*common.AuthenticationResponse, *tidcommon.ServiceError)
 	// Passkey methods
 	StartPasskeyRegistration(ctx context.Context, userID, relyingPartyID, relyingPartyName string,
-		authSelection *PasskeyAuthenticatorSelectionDTO, attestation string,
+		authSelection *PasskeyAuthenticatorSelectionDTO, attestation, assertion string,
 	) (interface{}, *tidcommon.ServiceError)
 	FinishPasskeyRegistration(ctx context.Context, credential PasskeyPublicKeyCredentialDTO,
 		sessionToken string, skipAssertion bool, existingAssertion string,
@@ -571,6 +571,32 @@ func (as *authenticationService) extractClaimsFromAssertion(ctx context.Context,
 	return &assuranceCtx, sub, nil
 }
 
+// verifyAssertionSubject rejects the request unless assertion is a valid auth assertion whose
+// subject is userID. Callers use it to gate operations that act on an account rather than merely
+// reporting on one, where a caller supplied user ID is not trustworthy on its own.
+func (as *authenticationService) verifyAssertionSubject(ctx context.Context, assertion, userID string,
+	logger *log.Logger) *tidcommon.ServiceError {
+	// Callers arriving over HTTP are already stopped by the required-field validation on the DTO,
+	// which treats a blank string as absent. This guards the service contract for any other caller.
+	if strings.TrimSpace(assertion) == "" {
+		logger.Debug(ctx, "Assertion missing on a request that requires proof of the target user")
+		return &common.ErrorInvalidAssertion
+	}
+
+	_, assertionSub, svcErr := as.extractClaimsFromAssertion(ctx, assertion, logger)
+	if svcErr != nil {
+		return svcErr
+	}
+
+	if assertionSub != userID {
+		logger.Debug(ctx, "Assertion subject does not match the target user",
+			log.MaskedString("assertionSub", assertionSub), log.MaskedString(log.LoggerKeyUserID, userID))
+		return &common.ErrorAssertionSubjectMismatch
+	}
+
+	return nil
+}
+
 // mapFederatedAuthnError maps provider manager errors to federated-authentication-specific service errors.
 func (as *authenticationService) mapFederatedAuthnError(ctx context.Context, svcErr *tidcommon.ServiceError,
 	logger *log.Logger) *tidcommon.ServiceError {
@@ -724,10 +750,17 @@ func (as *authenticationService) verifyAndDecodeSessionToken(ctx context.Context
 // StartPasskeyRegistration starts the passkey registration process.
 func (as *authenticationService) StartPasskeyRegistration(
 	ctx context.Context, userID, relyingPartyID, relyingPartyName string,
-	authSelection *PasskeyAuthenticatorSelectionDTO, attestation string,
+	authSelection *PasskeyAuthenticatorSelectionDTO, attestation, assertion string,
 ) (interface{}, *tidcommon.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
 	logger.Debug(ctx, "Starting Passkey registration")
+
+	// Enrollment binds a new credential to an account, so it is gated on proof that the caller
+	// holds that account. The challenge is bound to userID here, which makes this the only point
+	// where the check is effective.
+	if svcErr := as.verifyAssertionSubject(ctx, assertion, userID, logger); svcErr != nil {
+		return nil, svcErr
+	}
 
 	var passkeyAuthSel *passkey.AuthenticatorSelection
 	if authSelection != nil {

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -1729,11 +1729,14 @@ func (suite *AuthenticationServiceTestSuite) TestStartPasskeyRegistration_Succes
 		SessionToken: testSessionTkn,
 	}
 
+	assertion := suite.createTestAssertion(testUserID)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, assertion, "", mock.Anything).Return(nil).Once()
 	suite.mockAuthnProvider.On("InitiateEnrollment", mock.Anything, passkey.CredentialType, mock.Anything,
 		mock.Anything).Return(expectedResponse, nil).Once()
 
 	result, err := suite.service.StartPasskeyRegistration(
-		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, authSelection, attestation)
+		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, authSelection, attestation,
+		assertion)
 
 	suite.Nil(err)
 	suite.NotNil(result)
@@ -1748,11 +1751,13 @@ func (suite *AuthenticationServiceTestSuite) TestStartPasskeyRegistration_Withou
 		SessionToken: testSessionTkn,
 	}
 
+	assertion := suite.createTestAssertion(testUserID)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, assertion, "", mock.Anything).Return(nil).Once()
 	suite.mockAuthnProvider.On("InitiateEnrollment", mock.Anything, passkey.CredentialType, mock.Anything,
 		mock.Anything).Return(expectedResponse, nil).Once()
 
 	result, err := suite.service.StartPasskeyRegistration(
-		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, nil, attestation)
+		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, nil, attestation, assertion)
 
 	suite.Nil(err)
 	suite.NotNil(result)
@@ -1769,11 +1774,13 @@ func (suite *AuthenticationServiceTestSuite) TestStartPasskeyRegistration_Servic
 		},
 	}
 
+	assertion := suite.createTestAssertion(testUserID)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, assertion, "", mock.Anything).Return(nil).Once()
 	suite.mockAuthnProvider.On("InitiateEnrollment", mock.Anything, passkey.CredentialType, mock.Anything,
 		mock.Anything).Return(nil, serviceError).Once()
 
 	result, err := suite.service.StartPasskeyRegistration(
-		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, nil, "")
+		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, nil, "", assertion)
 
 	suite.NotNil(err)
 	suite.Nil(result)
@@ -1783,16 +1790,90 @@ func (suite *AuthenticationServiceTestSuite) TestStartPasskeyRegistration_Servic
 }
 
 func (suite *AuthenticationServiceTestSuite) TestStartPasskeyRegistration_ServerError() {
+	assertion := suite.createTestAssertion(testUserID)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, assertion, "", mock.Anything).Return(nil).Once()
 	suite.mockAuthnProvider.On("InitiateEnrollment", mock.Anything, passkey.CredentialType, mock.Anything,
 		mock.Anything).Return(nil, &tidcommon.InternalServerError).Once()
 
 	result, err := suite.service.StartPasskeyRegistration(
-		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, nil, "")
+		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, nil, "", assertion)
 
 	suite.NotNil(err)
 	suite.Nil(result)
 	suite.Equal(tidcommon.InternalServerError.Code, err.Code)
 	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
+// TestStartPasskeyRegistration_MissingAssertion asserts enrollment is refused outright when the
+// caller supplies no proof of the target user, before any challenge is minted. Over HTTP this case
+// is caught earlier by the required-field validation on the DTO; this covers the service contract.
+func (suite *AuthenticationServiceTestSuite) TestStartPasskeyRegistration_MissingAssertion() {
+	result, err := suite.service.StartPasskeyRegistration(
+		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, nil, "", "")
+
+	suite.NotNil(err)
+	suite.Nil(result)
+	suite.Equal(common.ErrorInvalidAssertion.Code, err.Code)
+	suite.mockAuthnProvider.AssertNotCalled(suite.T(), "InitiateEnrollment")
+}
+
+// TestStartPasskeyRegistration_BlankAssertion asserts whitespace is not accepted as proof.
+func (suite *AuthenticationServiceTestSuite) TestStartPasskeyRegistration_BlankAssertion() {
+	result, err := suite.service.StartPasskeyRegistration(
+		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, nil, "", "   ")
+
+	suite.NotNil(err)
+	suite.Nil(result)
+	suite.Equal(common.ErrorInvalidAssertion.Code, err.Code)
+	suite.mockAuthnProvider.AssertNotCalled(suite.T(), "InitiateEnrollment")
+}
+
+// TestStartPasskeyRegistration_AssertionSubjectMismatch is the account takeover case: a valid
+// assertion for one user must not enroll a credential onto another user.
+func (suite *AuthenticationServiceTestSuite) TestStartPasskeyRegistration_AssertionSubjectMismatch() {
+	assertion := suite.createTestAssertion("attacker_user_id")
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, assertion, "", mock.Anything).Return(nil).Once()
+
+	result, err := suite.service.StartPasskeyRegistration(
+		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, nil, "", assertion)
+
+	suite.NotNil(err)
+	suite.Nil(result)
+	suite.Equal(common.ErrorAssertionSubjectMismatch.Code, err.Code)
+	suite.mockAuthnProvider.AssertNotCalled(suite.T(), "InitiateEnrollment")
+}
+
+// TestStartPasskeyRegistration_UnverifiableAssertion asserts a forged assertion is rejected.
+func (suite *AuthenticationServiceTestSuite) TestStartPasskeyRegistration_UnverifiableAssertion() {
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, invalidAssertion, "", mock.Anything).
+		Return(&tidcommon.ServiceError{
+			Type:  tidcommon.ClientErrorType,
+			Code:  "JWT-1001",
+			Error: tidcommon.I18nMessage{Key: "error.test.invalid_jwt", DefaultValue: "Invalid JWT"},
+		}).Once()
+
+	result, err := suite.service.StartPasskeyRegistration(
+		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, nil, "", invalidAssertion)
+
+	suite.NotNil(err)
+	suite.Nil(result)
+	suite.Equal(common.ErrorInvalidAssertion.Code, err.Code)
+	suite.mockAuthnProvider.AssertNotCalled(suite.T(), "InitiateEnrollment")
+}
+
+// TestStartPasskeyRegistration_AssertionWithoutAssurance asserts a JWT that is not an auth
+// assertion (no assurance claim) cannot stand in for one.
+func (suite *AuthenticationServiceTestSuite) TestStartPasskeyRegistration_AssertionWithoutAssurance() {
+	assertion := suite.createTestAssertionWithoutAssurance(testUserID)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, assertion, "", mock.Anything).Return(nil).Once()
+
+	result, err := suite.service.StartPasskeyRegistration(
+		context.Background(), testUserID, testRelyingPartyID, testRelyingPartyName, nil, "", assertion)
+
+	suite.NotNil(err)
+	suite.Nil(result)
+	suite.Equal(common.ErrorInvalidAssertion.Code, err.Code)
+	suite.mockAuthnProvider.AssertNotCalled(suite.T(), "InitiateEnrollment")
 }
 
 func (suite *AuthenticationServiceTestSuite) TestFinishPasskeyRegistration_Success() {

--- a/backend/tests/mocks/authn/authnmock/AuthenticationServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/authnmock/AuthenticationServiceInterface_mock.go
@@ -645,8 +645,8 @@ func (_c *AuthenticationServiceInterfaceMock_StartPasskeyAuthentication_Call) Ru
 }
 
 // StartPasskeyRegistration provides a mock function for the type AuthenticationServiceInterfaceMock
-func (_mock *AuthenticationServiceInterfaceMock) StartPasskeyRegistration(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *authn.PasskeyAuthenticatorSelectionDTO, attestation string) (interface{}, *common0.ServiceError) {
-	ret := _mock.Called(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation)
+func (_mock *AuthenticationServiceInterfaceMock) StartPasskeyRegistration(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *authn.PasskeyAuthenticatorSelectionDTO, attestation string, assertion string) (interface{}, *common0.ServiceError) {
+	ret := _mock.Called(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation, assertion)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StartPasskeyRegistration")
@@ -654,18 +654,18 @@ func (_mock *AuthenticationServiceInterfaceMock) StartPasskeyRegistration(ctx co
 
 	var r0 interface{}
 	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *authn.PasskeyAuthenticatorSelectionDTO, string) (interface{}, *common0.ServiceError)); ok {
-		return returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *authn.PasskeyAuthenticatorSelectionDTO, string, string) (interface{}, *common0.ServiceError)); ok {
+		return returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation, assertion)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *authn.PasskeyAuthenticatorSelectionDTO, string) interface{}); ok {
-		r0 = returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *authn.PasskeyAuthenticatorSelectionDTO, string, string) interface{}); ok {
+		r0 = returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation, assertion)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(interface{})
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, *authn.PasskeyAuthenticatorSelectionDTO, string) *common0.ServiceError); ok {
-		r1 = returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, *authn.PasskeyAuthenticatorSelectionDTO, string, string) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation, assertion)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common0.ServiceError)
@@ -686,11 +686,12 @@ type AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call struct {
 //   - relyingPartyName string
 //   - authSelection *authn.PasskeyAuthenticatorSelectionDTO
 //   - attestation string
-func (_e *AuthenticationServiceInterfaceMock_Expecter) StartPasskeyRegistration(ctx interface{}, userID interface{}, relyingPartyID interface{}, relyingPartyName interface{}, authSelection interface{}, attestation interface{}) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
-	return &AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call{Call: _e.mock.On("StartPasskeyRegistration", ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation)}
+//   - assertion string
+func (_e *AuthenticationServiceInterfaceMock_Expecter) StartPasskeyRegistration(ctx interface{}, userID interface{}, relyingPartyID interface{}, relyingPartyName interface{}, authSelection interface{}, attestation interface{}, assertion interface{}) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
+	return &AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call{Call: _e.mock.On("StartPasskeyRegistration", ctx, userID, relyingPartyID, relyingPartyName, authSelection, attestation, assertion)}
 }
 
-func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) Run(run func(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *authn.PasskeyAuthenticatorSelectionDTO, attestation string)) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
+func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) Run(run func(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *authn.PasskeyAuthenticatorSelectionDTO, attestation string, assertion string)) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -716,6 +717,10 @@ func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) Run(
 		if args[5] != nil {
 			arg5 = args[5].(string)
 		}
+		var arg6 string
+		if args[6] != nil {
+			arg6 = args[6].(string)
+		}
 		run(
 			arg0,
 			arg1,
@@ -723,6 +728,7 @@ func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) Run(
 			arg3,
 			arg4,
 			arg5,
+			arg6,
 		)
 	})
 	return _c
@@ -733,7 +739,7 @@ func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) Retu
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) RunAndReturn(run func(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *authn.PasskeyAuthenticatorSelectionDTO, attestation string) (interface{}, *common0.ServiceError)) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
+func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) RunAndReturn(run func(ctx context.Context, userID string, relyingPartyID string, relyingPartyName string, authSelection *authn.PasskeyAuthenticatorSelectionDTO, attestation string, assertion string) (interface{}, *common0.ServiceError)) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/content/key-concepts/authentication/integration-models.mdx
+++ b/docs/content/key-concepts/authentication/integration-models.mdx
@@ -348,6 +348,8 @@ On a fresh setup, the `setup.sh` / `setup.ps1` script generates a secret, writes
 
 This suits the intended Direct API callers, such as CLI tools, automation scripts, and server-to-server integrations, which can hold a configured secret. Browser and mobile applications, which cannot safely store a static secret, should use the [Redirect-Based](#redirect-based) or [App-Native](#app-native) model instead.
 
+The secret identifies the calling integration, not the end user, and every caller shares the same value. So it authorizes use of the Direct API but never stands in for a user's own identity. Endpoints that act on a specific account require separate proof of that user: enrolling a passkey through `/register/passkey/start`, for example, also requires the `assertion` from a prior authentication, and enrolls the credential only for that assertion's subject. See [Passkeys](../passwordless/passkeys#registration-flow).
+
 ```bash
 curl -X POST https://localhost:8090/auth/credentials/authenticate \
   -H 'Content-Type: application/json' \

--- a/docs/content/key-concepts/authentication/passwordless/passkeys.mdx
+++ b/docs/content/key-concepts/authentication/passwordless/passkeys.mdx
@@ -82,13 +82,25 @@ This approach requires **no custom UI development** or direct WebAuthn API calls
 
 ### Registration Flow
 
+Enrolling a passkey adds a credential that can then be used to sign in as the user, so registration
+requires proof that the caller holds the account. Pass the `assertion` returned by a prior
+authentication, such as a password or OTP login. The credential is enrolled only for the subject of
+that assertion, so the assertion and `userId` must refer to the same user. The `Direct-Auth-Secret`
+header is not sufficient on its own: it identifies the calling integration, not the end user.
+
+This means a user needs an existing credential before they can enroll their first passkey through
+the Direct API. To register a passkey as the very first credential on an account, drive a
+registration [flow](../../../../guides/flows/what-are-flows) instead.
+
 1) **Start registration.** Create WebAuthn creation options and a session token.
 
 ```bash
 curl -k -X POST https://localhost:8090/register/passkey/start \
   -H "Content-Type: application/json" \
+  -H "Direct-Auth-Secret: <secret>" \
   -d '{
     "userId": "<user-id>",
+    "assertion": "<assertion-from-a-prior-authentication>",
     "relyingPartyId": "localhost",
     "relyingPartyName": "{{ProductName}}",
     "authenticatorSelection": {
@@ -102,6 +114,11 @@ Response fields:
 - `publicKeyCredentialCreationOptions`: pass directly to `navigator.credentials.create()` (after Base64URL→ArrayBuffer conversion).
 - `sessionToken`: required for the finish call.
 
+A start request whose assertion cannot be verified is rejected with `AUTHN-1009`, and one whose
+assertion belongs to a different user with `AUTHN-1010`. Omitting `assertion` or `userId` entirely,
+or sending either as an empty or blank string, is a required-field violation: those are rejected by
+request validation with the `INVALID_INPUT_METADATA` code and an `errors` map naming the field.
+
 2) **Run the WebAuthn ceremony in the browser.** Call `navigator.credentials.create()` with the returned options. See the sample implementation in `samples/apps/vanilla-sample/src/services/authService.ts`.
 
 3) **Finish registration.** Send the attestation result with the session token.
@@ -109,6 +126,7 @@ Response fields:
 ```bash
 curl -k -X POST https://localhost:8090/register/passkey/finish \
   -H "Content-Type: application/json" \
+  -H "Direct-Auth-Secret: <secret>" \
   -d '{
     "publicKeyCredential": {
       "id": "<credential-id>",
@@ -132,6 +150,7 @@ On success, the API returns passkey registration metadata for the newly created 
 ```bash
 curl -k -X POST https://localhost:8090/auth/passkey/start \
   -H "Content-Type: application/json" \
+  -H "Direct-Auth-Secret: <secret>" \
   -d '{
     "userId": "<user-id-optional>",
     "relyingPartyId": "localhost"
@@ -150,6 +169,7 @@ curl -k -X POST https://localhost:8090/auth/passkey/start \
 ```bash
 curl -k -X POST https://localhost:8090/auth/passkey/finish \
   -H "Content-Type: application/json" \
+  -H "Direct-Auth-Secret: <secret>" \
   -d '{
     "publicKeyCredential": {
       "id": "<credential-id>",

--- a/tests/integration/authn/passkey_auth_test.go
+++ b/tests/integration/authn/passkey_auth_test.go
@@ -12,8 +12,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/thunder-id/thunderid/tests/integration/testutils"
 	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
 )
 
 const (
@@ -23,6 +23,9 @@ const (
 	passkeyAuthFinishEndpoint     = "/auth/passkey/finish"
 	testRelyingPartyID            = "localhost"
 	testRelyingPartyName          = "ThunderID Test"
+	// testPasskeyOrigin must be one of the origins under passkey.allowed_origins in the test
+	// deployment.yaml, since the direct passkey APIs take their allowed origins from server config.
+	testPasskeyOrigin = "https://localhost:8095"
 )
 
 var (
@@ -33,6 +36,8 @@ var (
 		Parent:      nil,
 	}
 
+	// The optional password is used only in setup to obtain an assertion and enroll the shared
+	// passkey through the direct API. Authentication tests use the resulting passkey.
 	passkeyEntityType = testutils.UserType{
 		Name: "passkey_user",
 		Schema: map[string]interface{}{
@@ -45,8 +50,17 @@ var (
 			"displayName": map[string]interface{}{
 				"type": "string",
 			},
+			"password": map[string]interface{}{
+				"type":       "string",
+				"credential": true,
+			},
 		},
 	}
+)
+
+const (
+	credentialUsername = "passkeytest_credential_user"
+	credentialPassword = "PasskeyCredentialPassword123!"
 )
 
 // PasskeyRegisterStartRequest represents the request to start passkey registration
@@ -56,6 +70,7 @@ type PasskeyRegisterStartRequest struct {
 	RelyingPartyName       string                          `json:"relyingPartyName,omitempty"`
 	AuthenticatorSelection *AuthenticatorSelectionCriteria `json:"authenticatorSelection,omitempty"`
 	Attestation            string                          `json:"attestation,omitempty"`
+	Assertion              string                          `json:"assertion,omitempty"`
 }
 
 // AuthenticatorSelectionCriteria represents authenticator selection criteria
@@ -110,11 +125,13 @@ type PublicKeyCredential struct {
 	Transports []string `json:"transports,omitempty"`
 }
 
-// PasskeyRegisterFinishRequest represents the request to finish passkey registration
+// PasskeyRegisterFinishRequest represents the request to finish passkey registration.
+// Mirrors PasskeyRegisterFinishRequestDTO in backend/internal/authn/model.go.
 type PasskeyRegisterFinishRequest struct {
 	PublicKeyCredential PublicKeyCredentialAttestation `json:"publicKeyCredential"`
 	SessionToken        string                         `json:"sessionToken"`
-	CredentialName      string                         `json:"credentialName,omitempty"`
+	SkipAssertion       bool                           `json:"skipAssertion,omitempty"`
+	Assertion           string                         `json:"assertion,omitempty"`
 }
 
 // PublicKeyCredentialAttestation represents the attestation response
@@ -130,12 +147,6 @@ type AuthenticatorAttestationResponse struct {
 	ClientDataJSON    string   `json:"clientDataJSON"`
 	AttestationObject string   `json:"attestationObject"`
 	Transports        []string `json:"transports,omitempty"`
-}
-
-// PasskeyRegisterFinishResponse represents the response from finishing passkey registration
-type PasskeyRegisterFinishResponse struct {
-	CredentialID   string `json:"credentialId"`
-	CredentialName string `json:"credentialName,omitempty"`
 }
 
 // PasskeyAuthStartRequest represents the request to start passkey authentication
@@ -159,14 +170,22 @@ type PublicKeyCredentialRequestOptionsResponse struct {
 	UserVerification string                `json:"userVerification,omitempty"`
 }
 
-// PasskeyAuthFinishRequest represents the request to finish passkey authentication
+// PasskeyAuthFinishRequest represents the request to finish passkey authentication.
+// Mirrors PasskeyFinishRequestDTO in backend/internal/authn/model.go: the credential is nested
+// under publicKeyCredential, exactly as it is for registration.
 type PasskeyAuthFinishRequest struct {
-	CredentialID      string                         `json:"credentialId"`
-	CredentialType    string                         `json:"credentialType"`
-	Response          AuthenticatorAssertionResponse `json:"response"`
-	SessionToken      string                         `json:"sessionToken"`
-	SkipAssertion     bool                           `json:"skipAssertion,omitempty"`
-	ExistingAssertion string                         `json:"existingAssertion,omitempty"`
+	PublicKeyCredential PublicKeyCredentialAssertion `json:"publicKeyCredential"`
+	SessionToken        string                       `json:"sessionToken"`
+	SkipAssertion       bool                         `json:"skipAssertion,omitempty"`
+	Assertion           string                       `json:"assertion,omitempty"`
+}
+
+// PublicKeyCredentialAssertion represents a WebAuthn credential returned from an assertion ceremony
+type PublicKeyCredentialAssertion struct {
+	ID       string                         `json:"id"`
+	Type     string                         `json:"type"`
+	RawID    string                         `json:"rawId,omitempty"`
+	Response AuthenticatorAssertionResponse `json:"response"`
 }
 
 // AuthenticatorAssertionResponse represents the assertion response
@@ -179,10 +198,20 @@ type AuthenticatorAssertionResponse struct {
 
 type PasskeyAuthTestSuite struct {
 	suite.Suite
-	client       *http.Client
 	testUserID   string
 	entityTypeID string
 	ouID         string
+
+	// credentialUserID is a second user that owns a registered passkey. It is kept separate from
+	// testUserID so the tests asserting behaviour for a user with no credentials stay valid.
+	credentialUserID string
+	// authenticator holds a credential registered against credentialUserID during SetupSuite, so
+	// authentication tests do not have to register one and do not depend on test ordering.
+	authenticator      *testutils.VirtualAuthenticator
+	sharedCredentialID string
+	// webAuthnUserHandle is the user.id the server issued for credentialUserID, needed as the
+	// userHandle in usernameless assertions.
+	webAuthnUserHandle string
 }
 
 func TestPasskeyAuthTestSuite(t *testing.T) {
@@ -190,8 +219,6 @@ func TestPasskeyAuthTestSuite(t *testing.T) {
 }
 
 func (suite *PasskeyAuthTestSuite) SetupSuite() {
-	suite.client = testutils.GetHTTPClient()
-
 	// Create test organization unit
 	ouID, err := testutils.CreateOrganizationUnit(passkeyTestOU)
 	if err != nil {
@@ -225,9 +252,51 @@ func (suite *PasskeyAuthTestSuite) SetupSuite() {
 	userID, err := testutils.CreateUser(user)
 	suite.Require().NoError(err, "Failed to create test user")
 	suite.testUserID = userID
+
+	// Create a second user of the same type to own a registered passkey.
+	// testUserID is deliberately left without a passkey and without any other credential, since
+	// several tests assert the behaviour for a user that has none.
+	credentialAttributes, err := json.Marshal(map[string]interface{}{
+		"username":    credentialUsername,
+		"email":       "passkeytest_credential@example.com",
+		"displayName": "Passkey Credential User",
+		"password":    credentialPassword,
+	})
+	suite.Require().NoError(err, "Failed to marshal credential user attributes")
+
+	credentialUserID, err := testutils.CreateUser(testutils.User{
+		Type:       passkeyEntityType.Name,
+		OUID:       suite.ouID,
+		Attributes: json.RawMessage(credentialAttributes),
+	})
+	suite.Require().NoError(err, "Failed to create credential test user")
+	suite.credentialUserID = credentialUserID
+
+	// Register a credential the authentication tests can reuse. Doing it here rather than in a test
+	// keeps the authentication tests independent of execution order. Enrollment is gated on an
+	// assertion proving the target user, so authenticate with the bootstrap password first; the
+	// enrollment ceremony itself is exercised by PasskeyEnrollmentTestSuite.
+	credentialUserAssertion, err := testutils.ObtainAuthAssertion(credentialUsername, credentialPassword)
+	suite.Require().NoError(err, "Failed to obtain an auth assertion for the credential user")
+
+	authenticator, userHandle, err := testutils.RegisterPasskeyCredential(
+		suite.credentialUserID, testRelyingPartyID, testRelyingPartyName, testPasskeyOrigin,
+		credentialUserAssertion)
+	suite.Require().NoError(err, "Failed to register a passkey for the credential user")
+
+	suite.authenticator = authenticator
+	suite.webAuthnUserHandle = userHandle
+	suite.sharedCredentialID = authenticator.CredentialID()
 }
 
 func (suite *PasskeyAuthTestSuite) TearDownSuite() {
+	// Delete the user that owns the registered passkey
+	if suite.credentialUserID != "" {
+		if err := testutils.DeleteUser(suite.credentialUserID); err != nil {
+			suite.T().Errorf("Failed to delete credential test user during teardown: %v", err)
+		}
+	}
+
 	// Delete test user
 	if suite.testUserID != "" {
 		err := testutils.DeleteUser(suite.testUserID)
@@ -236,7 +305,7 @@ func (suite *PasskeyAuthTestSuite) TearDownSuite() {
 		}
 	}
 
-	// Delete user type
+	// Delete the shared user type after both users.
 	if suite.entityTypeID != "" {
 		err := testutils.DeleteUserType(suite.entityTypeID)
 		if err != nil {
@@ -252,94 +321,6 @@ func (suite *PasskeyAuthTestSuite) TearDownSuite() {
 	}
 }
 
-// TestPasskeyRegistrationStart tests the start of passkey registration
-func (suite *PasskeyAuthTestSuite) TestPasskeyRegistrationStart() {
-	registerRequest := PasskeyRegisterStartRequest{
-		UserID:           suite.testUserID,
-		RelyingPartyID:   testRelyingPartyID,
-		RelyingPartyName: testRelyingPartyName,
-	}
-
-	response, statusCode, err := suite.sendPasskeyRegisterStartRequest(registerRequest)
-	suite.Require().NoError(err, "Failed to send passkey register start request")
-	suite.Equal(http.StatusOK, statusCode, "Expected status 200 for successful registration start")
-
-	// Verify response structure
-	suite.NotEmpty(response.SessionToken, "Response should contain session token")
-	suite.NotEmpty(response.PublicKeyCredentialCreationOptions.Challenge, "Response should contain challenge")
-	suite.Equal(testRelyingPartyID, response.PublicKeyCredentialCreationOptions.RelyingParty.ID,
-		"Response should contain correct RP ID")
-	suite.Equal(testRelyingPartyName, response.PublicKeyCredentialCreationOptions.RelyingParty.Name,
-		"Response should contain correct RP name")
-	suite.NotEmpty(response.PublicKeyCredentialCreationOptions.User.ID, "Response should contain user ID")
-	suite.NotEmpty(response.PublicKeyCredentialCreationOptions.PubKeyCredParams,
-		"Response should contain credential parameters")
-
-	// Verify challenge is valid base64
-	_, err = base64.RawURLEncoding.DecodeString(response.PublicKeyCredentialCreationOptions.Challenge)
-	suite.NoError(err, "Challenge should be valid base64")
-}
-
-// TestPasskeyRegistrationStartWithAuthenticatorSelection tests registration with authenticator selection
-func (suite *PasskeyAuthTestSuite) TestPasskeyRegistrationStartWithAuthenticatorSelection() {
-	registerRequest := PasskeyRegisterStartRequest{
-		UserID:           suite.testUserID,
-		RelyingPartyID:   testRelyingPartyID,
-		RelyingPartyName: testRelyingPartyName,
-		AuthenticatorSelection: &AuthenticatorSelectionCriteria{
-			AuthenticatorAttachment: "platform",
-			RequireResidentKey:      true,
-			ResidentKey:             "required",
-			UserVerification:        "required",
-		},
-		Attestation: "direct",
-	}
-
-	response, statusCode, err := suite.sendPasskeyRegisterStartRequest(registerRequest)
-	suite.Require().NoError(err, "Failed to send passkey register start request")
-	suite.Equal(http.StatusOK, statusCode, "Expected status 200 for successful registration start")
-
-	// Verify response includes authenticator selection
-	suite.NotNil(response.PublicKeyCredentialCreationOptions.AuthenticatorSelection,
-		"Response should contain authenticator selection")
-	suite.Equal("platform",
-		response.PublicKeyCredentialCreationOptions.AuthenticatorSelection.AuthenticatorAttachment)
-	suite.Equal("direct", response.PublicKeyCredentialCreationOptions.Attestation)
-}
-
-// TestPasskeyRegistrationStartInvalidUserID tests registration with invalid user ID
-func (suite *PasskeyAuthTestSuite) TestPasskeyRegistrationStartInvalidUserID() {
-	registerRequest := PasskeyRegisterStartRequest{
-		UserID:         "invalid-user-id",
-		RelyingPartyID: testRelyingPartyID,
-	}
-
-	_, statusCode, _ := suite.sendPasskeyRegisterStartRequest(registerRequest)
-	suite.Equal(http.StatusBadRequest, statusCode, "Expected status 400 for invalid user ID")
-}
-
-// TestPasskeyRegistrationStartEmptyUserID tests registration with empty user ID
-func (suite *PasskeyAuthTestSuite) TestPasskeyRegistrationStartEmptyUserID() {
-	registerRequest := PasskeyRegisterStartRequest{
-		UserID:         "",
-		RelyingPartyID: testRelyingPartyID,
-	}
-
-	_, statusCode, _ := suite.sendPasskeyRegisterStartRequest(registerRequest)
-	suite.Equal(http.StatusBadRequest, statusCode, "Expected status 400 for empty user ID")
-}
-
-// TestPasskeyRegistrationStartEmptyRelyingPartyID tests registration with empty relying party ID
-func (suite *PasskeyAuthTestSuite) TestPasskeyRegistrationStartEmptyRelyingPartyID() {
-	registerRequest := PasskeyRegisterStartRequest{
-		UserID:         suite.testUserID,
-		RelyingPartyID: "",
-	}
-
-	_, statusCode, _ := suite.sendPasskeyRegisterStartRequest(registerRequest)
-	suite.Equal(http.StatusBadRequest, statusCode, "Expected status 400 for empty relying party ID")
-}
-
 // TestPasskeyAuthenticationStartNoCredentials tests authentication start when user has no credentials
 func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationStartNoCredentials() {
 	authRequest := PasskeyAuthStartRequest{
@@ -347,7 +328,7 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationStartNoCredentials()
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	_, statusCode, _ := suite.sendPasskeyAuthStartRequest(authRequest)
+	_, statusCode, _ := sendPasskeyAuthStartRequest(authRequest)
 	// Should return 404 or specific error when no credentials exist
 	suite.True(statusCode == http.StatusNotFound || statusCode == http.StatusBadRequest,
 		"Expected status 404 or 400 when user has no registered credentials")
@@ -360,7 +341,7 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationStartInvalidUserID()
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	_, statusCode, _ := suite.sendPasskeyAuthStartRequest(authRequest)
+	_, statusCode, _ := sendPasskeyAuthStartRequest(authRequest)
 	suite.Equal(http.StatusBadRequest, statusCode, "Expected status 400 for invalid user ID")
 }
 
@@ -371,7 +352,7 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationStartEmptyUserID() {
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	response, statusCode, err := suite.sendPasskeyAuthStartRequest(authRequest)
+	response, statusCode, err := sendPasskeyAuthStartRequest(authRequest)
 	// Usernameless authentication should succeed
 	suite.NoError(err, "Failed to send passkey auth start request")
 	suite.Equal(http.StatusOK, statusCode, "Expected status 200 for usernameless authentication")
@@ -380,42 +361,22 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationStartEmptyUserID() {
 	suite.NotEmpty(response.PublicKeyCredentialRequestOptions.Challenge, "Response should contain challenge")
 }
 
-// TestPasskeyRegistrationFinishInvalidSessionToken tests finish registration with invalid session
-func (suite *PasskeyAuthTestSuite) TestPasskeyRegistrationFinishInvalidSessionToken() {
-	// Create mock credential response
-	finishRequest := PasskeyRegisterFinishRequest{
-		PublicKeyCredential: PublicKeyCredentialAttestation{
-			ID:    "mock-credential-id",
-			Type:  "public-key",
-			RawID: base64.RawURLEncoding.EncodeToString([]byte("mock-credential-id")),
-			Response: AuthenticatorAttestationResponse{
-				ClientDataJSON:    base64.RawURLEncoding.EncodeToString([]byte(`{"type":"webauthn.create"}`)),
-				AttestationObject: base64.RawURLEncoding.EncodeToString([]byte("mock-attestation")),
-			},
-		},
-		SessionToken:   "invalid-session-token",
-		CredentialName: "Test Credential",
-	}
-
-	_, statusCode, _ := suite.sendPasskeyRegisterFinishRequest(finishRequest)
-	suite.True(statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest,
-		"Expected status 401 or 400 for invalid session token")
-}
-
 // TestPasskeyAuthenticationFinishInvalidSessionToken tests finish authentication with invalid session
 func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationFinishInvalidSessionToken() {
 	finishRequest := PasskeyAuthFinishRequest{
-		CredentialID:   "mock-credential-id",
-		CredentialType: "public-key",
-		Response: AuthenticatorAssertionResponse{
-			ClientDataJSON:    base64.RawURLEncoding.EncodeToString([]byte(`{"type":"webauthn.get"}`)),
-			AuthenticatorData: base64.RawURLEncoding.EncodeToString([]byte("mock-auth-data")),
-			Signature:         base64.RawURLEncoding.EncodeToString([]byte("mock-signature")),
+		PublicKeyCredential: PublicKeyCredentialAssertion{
+			ID:   "mock-credential-id",
+			Type: "public-key",
+			Response: AuthenticatorAssertionResponse{
+				ClientDataJSON:    base64.RawURLEncoding.EncodeToString([]byte(`{"type":"webauthn.get"}`)),
+				AuthenticatorData: base64.RawURLEncoding.EncodeToString([]byte("mock-auth-data")),
+				Signature:         base64.RawURLEncoding.EncodeToString([]byte("mock-signature")),
+			},
 		},
 		SessionToken: "invalid-session-token",
 	}
 
-	_, statusCode, _ := suite.sendPasskeyAuthFinishRequest(finishRequest)
+	_, statusCode, _ := sendPasskeyAuthFinishRequest(finishRequest)
 	suite.True(statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest,
 		"Expected status 401 or 400 for invalid session token")
 }
@@ -427,7 +388,7 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationUsernamelessFlow() {
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	startResponse, statusCode, err := suite.sendPasskeyAuthStartRequest(authStartRequest)
+	startResponse, statusCode, err := sendPasskeyAuthStartRequest(authStartRequest)
 	suite.Require().NoError(err, "Failed to send usernameless passkey auth start request")
 	suite.Equal(http.StatusOK, statusCode, "Expected status 200 for usernameless authentication start")
 	suite.NotNil(startResponse, "Start response should not be nil")
@@ -458,7 +419,7 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationUsernamelessFlowWith
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	startResponse, statusCode, err := suite.sendPasskeyAuthStartRequest(authStartRequest)
+	startResponse, statusCode, err := sendPasskeyAuthStartRequest(authStartRequest)
 	suite.Require().NoError(err, "Failed to send usernameless passkey auth start request")
 	suite.Equal(http.StatusOK, statusCode, "Expected status 200 for usernameless authentication start")
 	suite.NotNil(startResponse, "Start response should not be nil")
@@ -474,67 +435,9 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationUsernamelessFlowEmpt
 		RelyingPartyID: "", // Missing RP ID
 	}
 
-	_, statusCode, _ := suite.sendPasskeyAuthStartRequest(authStartRequest)
+	_, statusCode, _ := sendPasskeyAuthStartRequest(authStartRequest)
 	suite.Equal(http.StatusBadRequest, statusCode,
 		"Expected status 400 for usernameless flow with missing RP ID")
-}
-
-// TestPasskeyAuthenticationFinishUsernamelessWithValidCredential tests finish authentication for usernameless flow
-// This test covers the ValidatePasskeyLogin path including the type assertion of user interface
-func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationFinishUsernamelessWithValidCredential() {
-	registerStartRequest := PasskeyRegisterStartRequest{
-		UserID:           suite.testUserID,
-		RelyingPartyID:   testRelyingPartyID,
-		RelyingPartyName: testRelyingPartyName,
-		AuthenticatorSelection: &AuthenticatorSelectionCriteria{
-			ResidentKey:      "required",
-			UserVerification: "required",
-		},
-	}
-
-	registerStartResponse, statusCode, err := suite.sendPasskeyRegisterStartRequest(registerStartRequest)
-	suite.Require().NoError(err, "Failed to send passkey register start request")
-	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for registration start")
-	suite.Require().NotEmpty(registerStartResponse.SessionToken, "Session token should not be empty")
-
-	authStartRequest := PasskeyAuthStartRequest{
-		UserID:         "", // Empty userID for usernameless flow
-		RelyingPartyID: testRelyingPartyID,
-	}
-
-	authStartResponse, statusCode, err := suite.sendPasskeyAuthStartRequest(authStartRequest)
-	suite.Require().NoError(err, "Failed to send usernameless passkey auth start request")
-	suite.Equal(http.StatusOK, statusCode, "Expected status 200 for usernameless authentication start")
-	suite.NotNil(authStartResponse, "Auth start response should not be nil")
-	suite.NotEmpty(authStartResponse.SessionToken, "Session token should not be empty")
-
-	// Verify the response structure for usernameless flow
-	suite.Empty(authStartResponse.PublicKeyCredentialRequestOptions.AllowCredentials,
-		"AllowCredentials should be empty for usernameless flow")
-	suite.NotEmpty(authStartResponse.PublicKeyCredentialRequestOptions.Challenge,
-		"Challenge should be present")
-	suite.Equal(testRelyingPartyID, authStartResponse.PublicKeyCredentialRequestOptions.RelyingPartyID,
-		"RelyingPartyID should match")
-
-	finishRequest := PasskeyAuthFinishRequest{
-		CredentialID:   "mock-credential-id",
-		CredentialType: "public-key",
-		Response: AuthenticatorAssertionResponse{
-			ClientDataJSON: base64.RawURLEncoding.EncodeToString([]byte(
-				`{"type":"webauthn.get","challenge":"` +
-					authStartResponse.PublicKeyCredentialRequestOptions.Challenge + `","origin":"http://localhost"}`)),
-			AuthenticatorData: base64.RawURLEncoding.EncodeToString([]byte(
-				"mock-auth-data-with-sufficient-length-for-parsing")),
-			Signature:  base64.RawURLEncoding.EncodeToString([]byte("mock-signature")),
-			UserHandle: base64.StdEncoding.EncodeToString([]byte(suite.testUserID)),
-		},
-		SessionToken: authStartResponse.SessionToken,
-	}
-
-	_, statusCode, _ = suite.sendPasskeyAuthFinishRequest(finishRequest)
-	// Should fail validation but the code path including type assertion should be exercised
-	suite.True(statusCode == http.StatusBadRequest || statusCode == http.StatusUnauthorized,
-		"Expected validation error status for mock credential")
 }
 
 // TestPasskeyAuthenticationFinishUsernamelessWithInvalidUserHandle tests usernameless flow with invalid userHandle
@@ -546,26 +449,28 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationFinishUsernamelessWi
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	authStartResponse, statusCode, err := suite.sendPasskeyAuthStartRequest(authStartRequest)
+	authStartResponse, statusCode, err := sendPasskeyAuthStartRequest(authStartRequest)
 	suite.Require().NoError(err, "Failed to send usernameless passkey auth start request")
 	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for usernameless authentication start")
 
 	// Attempt finish with invalid user handle
 	finishRequest := PasskeyAuthFinishRequest{
-		CredentialID:   "mock-credential-id",
-		CredentialType: "public-key",
-		Response: AuthenticatorAssertionResponse{
-			ClientDataJSON: base64.RawURLEncoding.EncodeToString([]byte(
-				`{"type":"webauthn.get","challenge":"` +
-					authStartResponse.PublicKeyCredentialRequestOptions.Challenge + `","origin":"http://localhost"}`)),
-			AuthenticatorData: base64.RawURLEncoding.EncodeToString([]byte("mock-auth-data")),
-			Signature:         base64.RawURLEncoding.EncodeToString([]byte("mock-signature")),
-			UserHandle:        "!!!invalid-base64!!!",
+		PublicKeyCredential: PublicKeyCredentialAssertion{
+			ID:   "mock-credential-id",
+			Type: "public-key",
+			Response: AuthenticatorAssertionResponse{
+				ClientDataJSON: base64.RawURLEncoding.EncodeToString([]byte(
+					`{"type":"webauthn.get","challenge":"` +
+						authStartResponse.PublicKeyCredentialRequestOptions.Challenge + `","origin":"http://localhost"}`)),
+				AuthenticatorData: base64.RawURLEncoding.EncodeToString([]byte("mock-auth-data")),
+				Signature:         base64.RawURLEncoding.EncodeToString([]byte("mock-signature")),
+				UserHandle:        "!!!invalid-base64!!!",
+			},
 		},
 		SessionToken: authStartResponse.SessionToken,
 	}
 
-	_, statusCode, _ = suite.sendPasskeyAuthFinishRequest(finishRequest)
+	_, statusCode, _ = sendPasskeyAuthFinishRequest(finishRequest)
 	suite.True(statusCode == http.StatusBadRequest || statusCode == http.StatusUnauthorized,
 		"Expected error status for invalid user handle")
 }
@@ -578,25 +483,27 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationFinishUsernamelessWi
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	authStartResponse, statusCode, err := suite.sendPasskeyAuthStartRequest(authStartRequest)
+	authStartResponse, statusCode, err := sendPasskeyAuthStartRequest(authStartRequest)
 	suite.Require().NoError(err, "Failed to send usernameless passkey auth start request")
 	suite.Require().Equal(
 		http.StatusOK, statusCode, "Expected status 200 for usernameless authentication start")
 
 	// Attempt finish without user handle
 	finishRequest := PasskeyAuthFinishRequest{
-		CredentialID:   "mock-credential-id",
-		CredentialType: "public-key",
-		Response: AuthenticatorAssertionResponse{
-			ClientDataJSON:    base64.RawURLEncoding.EncodeToString([]byte(`{"type":"webauthn.get"}`)),
-			AuthenticatorData: base64.RawURLEncoding.EncodeToString([]byte("mock-auth-data")),
-			Signature:         base64.RawURLEncoding.EncodeToString([]byte("mock-signature")),
-			UserHandle:        "", // Empty userHandle
+		PublicKeyCredential: PublicKeyCredentialAssertion{
+			ID:   "mock-credential-id",
+			Type: "public-key",
+			Response: AuthenticatorAssertionResponse{
+				ClientDataJSON:    base64.RawURLEncoding.EncodeToString([]byte(`{"type":"webauthn.get"}`)),
+				AuthenticatorData: base64.RawURLEncoding.EncodeToString([]byte("mock-auth-data")),
+				Signature:         base64.RawURLEncoding.EncodeToString([]byte("mock-signature")),
+				UserHandle:        "", // Empty userHandle
+			},
 		},
 		SessionToken: authStartResponse.SessionToken,
 	}
 
-	_, statusCode, _ = suite.sendPasskeyAuthFinishRequest(finishRequest)
+	_, statusCode, _ = sendPasskeyAuthFinishRequest(finishRequest)
 	suite.True(statusCode == http.StatusBadRequest || statusCode == http.StatusUnauthorized,
 		"Expected error status when userHandle is missing in usernameless flow")
 }
@@ -610,27 +517,29 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationFinishUsernamelessWi
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	authStartResponse, statusCode, err := suite.sendPasskeyAuthStartRequest(authStartRequest)
+	authStartResponse, statusCode, err := sendPasskeyAuthStartRequest(authStartRequest)
 	suite.Require().NoError(err, "Failed to send usernameless passkey auth start request")
 	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for usernameless authentication start")
 
 	// Attempt finish with userHandle pointing to non-existent user
 	nonExistentUserID := "non-existent-user-id-12345"
 	finishRequest := PasskeyAuthFinishRequest{
-		CredentialID:   "mock-credential-id",
-		CredentialType: "public-key",
-		Response: AuthenticatorAssertionResponse{
-			ClientDataJSON: base64.RawURLEncoding.EncodeToString([]byte(
-				`{"type":"webauthn.get","challenge":"` +
-					authStartResponse.PublicKeyCredentialRequestOptions.Challenge + `","origin":"http://localhost"}`)),
-			AuthenticatorData: base64.RawURLEncoding.EncodeToString([]byte("mock-auth-data")),
-			Signature:         base64.RawURLEncoding.EncodeToString([]byte("mock-signature")),
-			UserHandle:        base64.StdEncoding.EncodeToString([]byte(nonExistentUserID)),
+		PublicKeyCredential: PublicKeyCredentialAssertion{
+			ID:   "mock-credential-id",
+			Type: "public-key",
+			Response: AuthenticatorAssertionResponse{
+				ClientDataJSON: base64.RawURLEncoding.EncodeToString([]byte(
+					`{"type":"webauthn.get","challenge":"` +
+						authStartResponse.PublicKeyCredentialRequestOptions.Challenge + `","origin":"http://localhost"}`)),
+				AuthenticatorData: base64.RawURLEncoding.EncodeToString([]byte("mock-auth-data")),
+				Signature:         base64.RawURLEncoding.EncodeToString([]byte("mock-signature")),
+				UserHandle:        base64.StdEncoding.EncodeToString([]byte(nonExistentUserID)),
+			},
 		},
 		SessionToken: authStartResponse.SessionToken,
 	}
 
-	_, statusCode, _ = suite.sendPasskeyAuthFinishRequest(finishRequest)
+	_, statusCode, _ = sendPasskeyAuthFinishRequest(finishRequest)
 	suite.True(statusCode >= http.StatusBadRequest,
 		"Expected error status for non-existent user in usernameless flow")
 }
@@ -644,27 +553,29 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationUsernamelessValidati
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	authStartResponse, statusCode, err := suite.sendPasskeyAuthStartRequest(authStartRequest)
+	authStartResponse, statusCode, err := sendPasskeyAuthStartRequest(authStartRequest)
 	suite.Require().NoError(err, "Failed to send usernameless passkey auth start request")
 	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for usernameless authentication start")
 	suite.Require().NotEmpty(authStartResponse.SessionToken, "Session token should not be empty")
 
 	finishRequest := PasskeyAuthFinishRequest{
-		CredentialID:   base64.RawURLEncoding.EncodeToString([]byte("test-credential-id")),
-		CredentialType: "public-key",
-		Response: AuthenticatorAssertionResponse{
-			ClientDataJSON: base64.RawURLEncoding.EncodeToString([]byte(
-				`{"type":"webauthn.get","challenge":"` +
-					authStartResponse.PublicKeyCredentialRequestOptions.Challenge +
-					`","origin":"http://` + testRelyingPartyID + `"}`)),
-			AuthenticatorData: base64.RawURLEncoding.EncodeToString(make([]byte, 37)),
-			Signature:         base64.RawURLEncoding.EncodeToString([]byte("invalid-signature")),
-			UserHandle:        base64.StdEncoding.EncodeToString([]byte(suite.testUserID)),
+		PublicKeyCredential: PublicKeyCredentialAssertion{
+			ID:   base64.RawURLEncoding.EncodeToString([]byte("test-credential-id")),
+			Type: "public-key",
+			Response: AuthenticatorAssertionResponse{
+				ClientDataJSON: base64.RawURLEncoding.EncodeToString([]byte(
+					`{"type":"webauthn.get","challenge":"` +
+						authStartResponse.PublicKeyCredentialRequestOptions.Challenge +
+						`","origin":"http://` + testRelyingPartyID + `"}`)),
+				AuthenticatorData: base64.RawURLEncoding.EncodeToString(make([]byte, 37)),
+				Signature:         base64.RawURLEncoding.EncodeToString([]byte("invalid-signature")),
+				UserHandle:        base64.StdEncoding.EncodeToString([]byte(suite.testUserID)),
+			},
 		},
 		SessionToken: authStartResponse.SessionToken,
 	}
 
-	_, statusCode, _ = suite.sendPasskeyAuthFinishRequest(finishRequest)
+	_, statusCode, _ = sendPasskeyAuthFinishRequest(finishRequest)
 	suite.True(statusCode == http.StatusBadRequest || statusCode == http.StatusUnauthorized,
 		"Expected validation error status for usernameless flow with invalid signature")
 }
@@ -678,24 +589,166 @@ func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationUsernameBasedValidat
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	registerStartRequest := PasskeyRegisterStartRequest{
-		UserID:           suite.testUserID,
-		RelyingPartyID:   testRelyingPartyID,
-		RelyingPartyName: testRelyingPartyName,
-	}
-
-	_, regStatus, _ := suite.sendPasskeyRegisterStartRequest(registerStartRequest)
-	suite.Require().Equal(http.StatusOK, regStatus, "Registration start should succeed")
-
-	_, statusCode, _ := suite.sendPasskeyAuthStartRequest(authStartRequest)
+	_, statusCode, _ := sendPasskeyAuthStartRequest(authStartRequest)
 
 	suite.True(statusCode == http.StatusNotFound || statusCode == http.StatusBadRequest,
 		"Expected error when user has no registered credentials for username-based flow")
 }
 
+// TestPasskeyAuthenticationUsernameBasedSuccess authenticates a user that has a registered
+// credential, by supplying the user ID up front.
+func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationUsernameBasedSuccess() {
+	startResponse, statusCode, err := sendPasskeyAuthStartRequest(PasskeyAuthStartRequest{
+		UserID:         suite.credentialUserID,
+		RelyingPartyID: testRelyingPartyID,
+	})
+	suite.Require().NoError(err, "Failed to start passkey authentication")
+	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for authentication start")
+	suite.Require().NotEmpty(startResponse.PublicKeyCredentialRequestOptions.AllowCredentials,
+		"AllowCredentials should list the registered credential for a username-based ceremony")
+
+	credentialID, clientDataJSON, authenticatorData, signature, err :=
+		suite.authenticator.CreateAssertionResponse(
+			startResponse.PublicKeyCredentialRequestOptions.Challenge, true)
+	suite.Require().NoError(err, "Failed to build assertion response")
+
+	response, statusCode, err := sendPasskeyAuthFinishRequest(PasskeyAuthFinishRequest{
+		PublicKeyCredential: PublicKeyCredentialAssertion{
+			ID:    credentialID,
+			Type:  "public-key",
+			RawID: credentialID,
+			Response: AuthenticatorAssertionResponse{
+				ClientDataJSON:    clientDataJSON,
+				AuthenticatorData: authenticatorData,
+				Signature:         signature,
+				UserHandle:        suite.webAuthnUserHandle,
+			},
+		},
+		SessionToken: startResponse.SessionToken,
+	})
+	suite.Require().NoError(err, "Failed to finish passkey authentication")
+	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for authentication finish")
+	suite.Equal(suite.credentialUserID, response.ID, "Response should identify the authenticated user")
+	suite.NotEmpty(response.Assertion, "A JWT assertion should be issued on success")
+}
+
+// TestPasskeyAuthenticationUsernamelessSuccess authenticates without supplying a user ID, so the
+// user is resolved from the credential's user handle through the discoverable credential path.
+func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationUsernamelessSuccess() {
+	startResponse, statusCode, err := sendPasskeyAuthStartRequest(PasskeyAuthStartRequest{
+		UserID:         "",
+		RelyingPartyID: testRelyingPartyID,
+	})
+	suite.Require().NoError(err, "Failed to start usernameless passkey authentication")
+	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for authentication start")
+	suite.Require().Empty(startResponse.PublicKeyCredentialRequestOptions.AllowCredentials,
+		"AllowCredentials should be empty for a usernameless ceremony")
+
+	credentialID, clientDataJSON, authenticatorData, signature, err :=
+		suite.authenticator.CreateAssertionResponse(
+			startResponse.PublicKeyCredentialRequestOptions.Challenge, true)
+	suite.Require().NoError(err, "Failed to build assertion response")
+
+	response, statusCode, err := sendPasskeyAuthFinishRequest(PasskeyAuthFinishRequest{
+		PublicKeyCredential: PublicKeyCredentialAssertion{
+			ID:    credentialID,
+			Type:  "public-key",
+			RawID: credentialID,
+			Response: AuthenticatorAssertionResponse{
+				ClientDataJSON:    clientDataJSON,
+				AuthenticatorData: authenticatorData,
+				Signature:         signature,
+				UserHandle:        suite.webAuthnUserHandle,
+			},
+		},
+		SessionToken: startResponse.SessionToken,
+	})
+	suite.Require().NoError(err, "Failed to finish usernameless passkey authentication")
+	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for authentication finish")
+	suite.Equal(suite.credentialUserID, response.ID,
+		"Usernameless authentication should resolve the user from the user handle")
+	suite.NotEmpty(response.Assertion, "A JWT assertion should be issued on success")
+}
+
+// TestPasskeyAuthenticationReplayedSessionToken confirms a session token cannot be used twice.
+func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationReplayedSessionToken() {
+	startResponse, statusCode, err := sendPasskeyAuthStartRequest(PasskeyAuthStartRequest{
+		UserID:         suite.credentialUserID,
+		RelyingPartyID: testRelyingPartyID,
+	})
+	suite.Require().NoError(err, "Failed to start passkey authentication")
+	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for authentication start")
+
+	finishRequest := func() PasskeyAuthFinishRequest {
+		credentialID, clientDataJSON, authenticatorData, signature, buildErr :=
+			suite.authenticator.CreateAssertionResponse(
+				startResponse.PublicKeyCredentialRequestOptions.Challenge, true)
+		suite.Require().NoError(buildErr, "Failed to build assertion response")
+		return PasskeyAuthFinishRequest{
+			PublicKeyCredential: PublicKeyCredentialAssertion{
+				ID:    credentialID,
+				Type:  "public-key",
+				RawID: credentialID,
+				Response: AuthenticatorAssertionResponse{
+					ClientDataJSON:    clientDataJSON,
+					AuthenticatorData: authenticatorData,
+					Signature:         signature,
+					UserHandle:        suite.webAuthnUserHandle,
+				},
+			},
+			SessionToken: startResponse.SessionToken,
+		}
+	}
+
+	_, statusCode, err = sendPasskeyAuthFinishRequest(finishRequest())
+	suite.Require().NoError(err, "Failed to finish passkey authentication")
+	suite.Require().Equal(http.StatusOK, statusCode, "First use of the session token should succeed")
+
+	_, statusCode, err = sendPasskeyAuthFinishRequest(finishRequest())
+	suite.Require().NoError(err, "Failed to send replayed authentication finish")
+	suite.True(statusCode == http.StatusBadRequest || statusCode == http.StatusUnauthorized,
+		"Replaying a consumed session token should be rejected, got %d", statusCode)
+}
+
+// TestPasskeyAuthenticationSignCountRegression documents that a regressed signature counter is
+// accepted. The library flags it through Authenticator.CloneWarning but returns no error, and that
+// flag is never inspected, so cloned authenticators are not currently detected.
+func (suite *PasskeyAuthTestSuite) TestPasskeyAuthenticationSignCountRegression() {
+	startResponse, statusCode, err := sendPasskeyAuthStartRequest(PasskeyAuthStartRequest{
+		UserID:         suite.credentialUserID,
+		RelyingPartyID: testRelyingPartyID,
+	})
+	suite.Require().NoError(err, "Failed to start passkey authentication")
+	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for authentication start")
+
+	suite.authenticator.SetSignCount(0)
+	credentialID, clientDataJSON, authenticatorData, signature, err :=
+		suite.authenticator.CreateAssertionResponse(
+			startResponse.PublicKeyCredentialRequestOptions.Challenge, true)
+	suite.Require().NoError(err, "Failed to build assertion response")
+
+	_, statusCode, err = sendPasskeyAuthFinishRequest(PasskeyAuthFinishRequest{
+		PublicKeyCredential: PublicKeyCredentialAssertion{
+			ID:    credentialID,
+			Type:  "public-key",
+			RawID: credentialID,
+			Response: AuthenticatorAssertionResponse{
+				ClientDataJSON:    clientDataJSON,
+				AuthenticatorData: authenticatorData,
+				Signature:         signature,
+				UserHandle:        suite.webAuthnUserHandle,
+			},
+		},
+		SessionToken: startResponse.SessionToken,
+	})
+	suite.Require().NoError(err, "Failed to finish passkey authentication")
+	suite.Equal(http.StatusOK, statusCode,
+		"A regressed signature counter is currently accepted; update this test if clone detection is added")
+}
+
 // Helper methods
 
-func (suite *PasskeyAuthTestSuite) sendPasskeyRegisterStartRequest(
+func sendPasskeyRegisterStartRequest(
 	request PasskeyRegisterStartRequest,
 ) (*PasskeyRegisterStartResponse, int, error) {
 	requestBody, err := json.Marshal(request)
@@ -711,7 +764,7 @@ func (suite *PasskeyAuthTestSuite) sendPasskeyRegisterStartRequest(
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := suite.client.Do(req)
+	resp, err := testutils.GetHTTPClient().Do(req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to send request: %w", err)
 	}
@@ -734,9 +787,9 @@ func (suite *PasskeyAuthTestSuite) sendPasskeyRegisterStartRequest(
 	return &response, resp.StatusCode, nil
 }
 
-func (suite *PasskeyAuthTestSuite) sendPasskeyRegisterFinishRequest(
+func sendPasskeyRegisterFinishRequest(
 	request PasskeyRegisterFinishRequest,
-) (*PasskeyRegisterFinishResponse, int, error) {
+) (*testutils.AuthenticationResponse, int, error) {
 	requestBody, err := json.Marshal(request)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to marshal request: %w", err)
@@ -750,7 +803,7 @@ func (suite *PasskeyAuthTestSuite) sendPasskeyRegisterFinishRequest(
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := suite.client.Do(req)
+	resp, err := testutils.GetHTTPClient().Do(req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to send request: %w", err)
 	}
@@ -765,7 +818,7 @@ func (suite *PasskeyAuthTestSuite) sendPasskeyRegisterFinishRequest(
 		return nil, resp.StatusCode, nil
 	}
 
-	var response PasskeyRegisterFinishResponse
+	var response testutils.AuthenticationResponse
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, resp.StatusCode, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
@@ -773,7 +826,7 @@ func (suite *PasskeyAuthTestSuite) sendPasskeyRegisterFinishRequest(
 	return &response, resp.StatusCode, nil
 }
 
-func (suite *PasskeyAuthTestSuite) sendPasskeyAuthStartRequest(
+func sendPasskeyAuthStartRequest(
 	request PasskeyAuthStartRequest,
 ) (*PasskeyAuthStartResponse, int, error) {
 	requestBody, err := json.Marshal(request)
@@ -789,7 +842,7 @@ func (suite *PasskeyAuthTestSuite) sendPasskeyAuthStartRequest(
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := suite.client.Do(req)
+	resp, err := testutils.GetHTTPClient().Do(req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to send request: %w", err)
 	}
@@ -812,7 +865,7 @@ func (suite *PasskeyAuthTestSuite) sendPasskeyAuthStartRequest(
 	return &response, resp.StatusCode, nil
 }
 
-func (suite *PasskeyAuthTestSuite) sendPasskeyAuthFinishRequest(
+func sendPasskeyAuthFinishRequest(
 	request PasskeyAuthFinishRequest,
 ) (*testutils.AuthenticationResponse, int, error) {
 	requestBody, err := json.Marshal(request)
@@ -828,7 +881,7 @@ func (suite *PasskeyAuthTestSuite) sendPasskeyAuthFinishRequest(
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := suite.client.Do(req)
+	resp, err := testutils.GetHTTPClient().Do(req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to send request: %w", err)
 	}

--- a/tests/integration/authn/passkey_enrollment_test.go
+++ b/tests/integration/authn/passkey_enrollment_test.go
@@ -1,0 +1,634 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authn
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// Enrolling a passkey through the direct API requires an assertion proving the target user, so a
+// user needs another credential to authenticate with first. This suite uses a password to obtain
+// that assertion, then exercises credential enrollment onto an existing account.
+var (
+	passkeyEnrollmentTestOU = testutils.OrganizationUnit{
+		Handle:      "passkey-enrollment-test-ou",
+		Name:        "Passkey Enrollment Test Organization Unit",
+		Description: "Organization unit for passkey enrollment testing",
+		Parent:      nil,
+	}
+
+	passkeyEnrollmentEntityType = testutils.UserType{
+		Name: "passkey_enrollment_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"displayName": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type":       "string",
+				"credential": true,
+			},
+		},
+	}
+)
+
+const (
+	enrollmentUsername         = "passkeyenrollmentuser"
+	enrollmentPassword         = "PasskeyEnrollPassword123!"
+	enrollmentAttackerUsername = "passkeyattacker"
+	enrollmentAttackerPassword = "AttackerPassword123!"
+)
+
+// PasskeyEnrollmentTestSuite covers the direct passkey enrollment API: the registration start and
+// finish ceremony, assertion ownership checks, and authentication with an enrolled credential.
+type PasskeyEnrollmentTestSuite struct {
+	suite.Suite
+	ouID         string
+	entityTypeID string
+	userID       string
+	attackerID   string
+	// userAssertion proves userID to the registration API. Registration start enrolls only for the
+	// subject of the assertion it is given, so the tests need one for the user they register for.
+	userAssertion string
+}
+
+func TestPasskeyEnrollmentTestSuite(t *testing.T) {
+	suite.Run(t, new(PasskeyEnrollmentTestSuite))
+}
+
+func (suite *PasskeyEnrollmentTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(passkeyEnrollmentTestOU)
+	suite.Require().NoError(err, "Failed to create test organization unit")
+	suite.ouID = ouID
+
+	passkeyEnrollmentEntityType.OUID = suite.ouID
+	entityTypeID, err := testutils.CreateUserType(passkeyEnrollmentEntityType)
+	suite.Require().NoError(err, "Failed to create test user type")
+	suite.entityTypeID = entityTypeID
+
+	attributes, err := json.Marshal(map[string]interface{}{
+		"username":    enrollmentUsername,
+		"email":       enrollmentUsername + "@example.com",
+		"displayName": "Passkey Enrollment User",
+		"password":    enrollmentPassword,
+	})
+	suite.Require().NoError(err, "Failed to marshal user attributes")
+
+	userID, err := testutils.CreateUser(testutils.User{
+		Type:       passkeyEnrollmentEntityType.Name,
+		OUID:       suite.ouID,
+		Attributes: json.RawMessage(attributes),
+	})
+	suite.Require().NoError(err, "Failed to create test user")
+	suite.userID = userID
+
+	suite.userAssertion = suite.assertionForUser(enrollmentUsername, enrollmentPassword, suite.userID)
+
+	attackerAttributes, err := json.Marshal(map[string]interface{}{
+		"username": enrollmentAttackerUsername,
+		"password": enrollmentAttackerPassword,
+	})
+	suite.Require().NoError(err, "Failed to marshal attacker attributes")
+	attackerID, err := testutils.CreateUser(testutils.User{
+		Type:       passkeyEnrollmentEntityType.Name,
+		OUID:       suite.ouID,
+		Attributes: json.RawMessage(attackerAttributes),
+	})
+	suite.Require().NoError(err, "Failed to create attacker user")
+	suite.attackerID = attackerID
+}
+
+func (suite *PasskeyEnrollmentTestSuite) TearDownSuite() {
+	for _, userID := range []string{suite.userID, suite.attackerID} {
+		if userID == "" {
+			continue
+		}
+		if err := testutils.DeleteUser(userID); err != nil {
+			suite.T().Logf("teardown: failed to delete user: %v", err)
+		}
+	}
+	if suite.entityTypeID != "" {
+		if err := testutils.DeleteUserType(suite.entityTypeID); err != nil {
+			suite.T().Logf("teardown: failed to delete user type: %v", err)
+		}
+	}
+	if suite.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(suite.ouID); err != nil {
+			suite.T().Logf("teardown: failed to delete organization unit: %v", err)
+		}
+	}
+}
+
+// assertionForUser authenticates with a password and verifies the assertion belongs to the expected user.
+func (suite *PasskeyEnrollmentTestSuite) assertionForUser(username, password, expectedID string) string {
+	assertion, err := testutils.ObtainAuthAssertion(username, password)
+	suite.Require().NoError(err, "Failed to obtain an auth assertion for %s", username)
+	claims, err := testutils.DecodeJWT(assertion)
+	suite.Require().NoError(err)
+	suite.Require().Equal(expectedID, claims.Sub, "assertion should belong to the expected user")
+	return assertion
+}
+
+// registerCredential runs a full registration ceremony for the given user using a fresh virtual
+// authenticator, and returns the authenticator along with the WebAuthn user handle the server
+// issued for that user. The assertion must prove userID. Each authenticator owns a single
+// credential ID, so callers that need a distinct credential must call this again rather than
+// reusing an existing authenticator.
+func (suite *PasskeyEnrollmentTestSuite) registerCredential(
+	userID, assertion string,
+) (*testutils.VirtualAuthenticator, string) {
+	authenticator, err := testutils.NewVirtualAuthenticator(testRelyingPartyID, testPasskeyOrigin)
+	suite.Require().NoError(err, "Failed to create virtual authenticator")
+
+	startResponse, statusCode, err := sendPasskeyRegisterStartRequest(PasskeyRegisterStartRequest{
+		UserID:           userID,
+		RelyingPartyID:   testRelyingPartyID,
+		RelyingPartyName: testRelyingPartyName,
+		AuthenticatorSelection: &AuthenticatorSelectionCriteria{
+			ResidentKey:      "required",
+			UserVerification: "required",
+		},
+		Assertion: assertion,
+	})
+	suite.Require().NoError(err, "Failed to start passkey registration")
+	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for registration start")
+
+	credentialID, clientDataJSON, attestationObject, err := authenticator.CreateAttestationResponse(
+		startResponse.PublicKeyCredentialCreationOptions.Challenge, true)
+	suite.Require().NoError(err, "Failed to build attestation response")
+
+	_, statusCode, err = sendPasskeyRegisterFinishRequest(PasskeyRegisterFinishRequest{
+		PublicKeyCredential: PublicKeyCredentialAttestation{
+			ID:    credentialID,
+			Type:  "public-key",
+			RawID: credentialID,
+			Response: AuthenticatorAttestationResponse{
+				ClientDataJSON:    clientDataJSON,
+				AttestationObject: attestationObject,
+			},
+		},
+		SessionToken: startResponse.SessionToken,
+	})
+	suite.Require().NoError(err, "Failed to finish passkey registration")
+	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for registration finish")
+
+	return authenticator, startResponse.PublicKeyCredentialCreationOptions.User.ID
+}
+
+// TestPasskeyRegistrationStart tests the start of passkey registration
+func (suite *PasskeyEnrollmentTestSuite) TestPasskeyRegistrationStart() {
+	registerRequest := PasskeyRegisterStartRequest{
+		UserID:           suite.userID,
+		RelyingPartyID:   testRelyingPartyID,
+		RelyingPartyName: testRelyingPartyName,
+		Assertion:        suite.userAssertion,
+	}
+
+	response, statusCode, err := sendPasskeyRegisterStartRequest(registerRequest)
+	suite.Require().NoError(err, "Failed to send passkey register start request")
+	suite.Equal(http.StatusOK, statusCode, "Expected status 200 for successful registration start")
+
+	// Verify response structure
+	suite.NotEmpty(response.SessionToken, "Response should contain session token")
+	suite.NotEmpty(response.PublicKeyCredentialCreationOptions.Challenge, "Response should contain challenge")
+	suite.Equal(testRelyingPartyID, response.PublicKeyCredentialCreationOptions.RelyingParty.ID,
+		"Response should contain correct RP ID")
+	suite.Equal(testRelyingPartyName, response.PublicKeyCredentialCreationOptions.RelyingParty.Name,
+		"Response should contain correct RP name")
+	suite.NotEmpty(response.PublicKeyCredentialCreationOptions.User.ID, "Response should contain user ID")
+	suite.NotEmpty(response.PublicKeyCredentialCreationOptions.PubKeyCredParams,
+		"Response should contain credential parameters")
+
+	// Verify challenge is valid base64
+	_, err = base64.RawURLEncoding.DecodeString(response.PublicKeyCredentialCreationOptions.Challenge)
+	suite.NoError(err, "Challenge should be valid base64")
+}
+
+// TestPasskeyRegistrationStartWithAuthenticatorSelection tests registration with authenticator selection
+func (suite *PasskeyEnrollmentTestSuite) TestPasskeyRegistrationStartWithAuthenticatorSelection() {
+	registerRequest := PasskeyRegisterStartRequest{
+		UserID:           suite.userID,
+		RelyingPartyID:   testRelyingPartyID,
+		RelyingPartyName: testRelyingPartyName,
+		AuthenticatorSelection: &AuthenticatorSelectionCriteria{
+			AuthenticatorAttachment: "platform",
+			RequireResidentKey:      true,
+			ResidentKey:             "required",
+			UserVerification:        "required",
+		},
+		Attestation: "direct",
+		Assertion:   suite.userAssertion,
+	}
+
+	response, statusCode, err := sendPasskeyRegisterStartRequest(registerRequest)
+	suite.Require().NoError(err, "Failed to send passkey register start request")
+	suite.Equal(http.StatusOK, statusCode, "Expected status 200 for successful registration start")
+
+	// Verify response includes authenticator selection
+	suite.NotNil(response.PublicKeyCredentialCreationOptions.AuthenticatorSelection,
+		"Response should contain authenticator selection")
+	suite.Equal("platform",
+		response.PublicKeyCredentialCreationOptions.AuthenticatorSelection.AuthenticatorAttachment)
+	suite.Equal("direct", response.PublicKeyCredentialCreationOptions.Attestation)
+}
+
+// TestPasskeyRegistrationStartInvalidUserID tests registration with invalid user ID. The assertion
+// proves a different user, so the mismatch is what rejects it.
+func (suite *PasskeyEnrollmentTestSuite) TestPasskeyRegistrationStartInvalidUserID() {
+	registerRequest := PasskeyRegisterStartRequest{
+		UserID:         "invalid-user-id",
+		RelyingPartyID: testRelyingPartyID,
+		Assertion:      suite.userAssertion,
+	}
+
+	_, statusCode, _ := sendPasskeyRegisterStartRequest(registerRequest)
+	suite.Equal(http.StatusBadRequest, statusCode, "Expected status 400 for invalid user ID")
+}
+
+// TestPasskeyRegistrationStartEmptyUserID tests registration with empty user ID
+func (suite *PasskeyEnrollmentTestSuite) TestPasskeyRegistrationStartEmptyUserID() {
+	registerRequest := PasskeyRegisterStartRequest{
+		UserID:         "",
+		RelyingPartyID: testRelyingPartyID,
+		Assertion:      suite.userAssertion,
+	}
+
+	_, statusCode, _ := sendPasskeyRegisterStartRequest(registerRequest)
+	suite.Equal(http.StatusBadRequest, statusCode, "Expected status 400 for empty user ID")
+}
+
+// TestPasskeyRegistrationStartEmptyRelyingPartyID tests registration with empty relying party ID.
+// The relying party ID is a required field, so this is caught by request validation.
+func (suite *PasskeyEnrollmentTestSuite) TestPasskeyRegistrationStartEmptyRelyingPartyID() {
+	registerRequest := PasskeyRegisterStartRequest{
+		UserID:         suite.userID,
+		RelyingPartyID: "",
+		Assertion:      suite.userAssertion,
+	}
+
+	_, statusCode, _ := sendPasskeyRegisterStartRequest(registerRequest)
+	suite.Equal(http.StatusBadRequest, statusCode, "Expected status 400 for empty relying party ID")
+}
+
+// TestPasskeyRegistrationFinishInvalidSessionToken tests finish registration with invalid session
+func (suite *PasskeyEnrollmentTestSuite) TestPasskeyRegistrationFinishInvalidSessionToken() {
+	// Create mock credential response
+	finishRequest := PasskeyRegisterFinishRequest{
+		PublicKeyCredential: PublicKeyCredentialAttestation{
+			ID:    "mock-credential-id",
+			Type:  "public-key",
+			RawID: base64.RawURLEncoding.EncodeToString([]byte("mock-credential-id")),
+			Response: AuthenticatorAttestationResponse{
+				ClientDataJSON:    base64.RawURLEncoding.EncodeToString([]byte(`{"type":"webauthn.create"}`)),
+				AttestationObject: base64.RawURLEncoding.EncodeToString([]byte("mock-attestation")),
+			},
+		},
+		SessionToken: "invalid-session-token",
+	}
+
+	_, statusCode, _ := sendPasskeyRegisterFinishRequest(finishRequest)
+	suite.True(statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest,
+		"Expected status 401 or 400 for invalid session token")
+}
+
+// TestPasskeyAuthenticationFinishUsernamelessWithValidCredential tests finish authentication for usernameless flow
+// This test covers the ValidatePasskeyLogin path including the type assertion of user interface
+func (suite *PasskeyEnrollmentTestSuite) TestPasskeyAuthenticationFinishUsernamelessWithValidCredential() {
+	registerStartRequest := PasskeyRegisterStartRequest{
+		UserID:           suite.userID,
+		RelyingPartyID:   testRelyingPartyID,
+		RelyingPartyName: testRelyingPartyName,
+		AuthenticatorSelection: &AuthenticatorSelectionCriteria{
+			ResidentKey:      "required",
+			UserVerification: "required",
+		},
+		Assertion: suite.userAssertion,
+	}
+
+	registerStartResponse, statusCode, err := sendPasskeyRegisterStartRequest(registerStartRequest)
+	suite.Require().NoError(err, "Failed to send passkey register start request")
+	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for registration start")
+	suite.Require().NotEmpty(registerStartResponse.SessionToken, "Session token should not be empty")
+
+	authStartRequest := PasskeyAuthStartRequest{
+		UserID:         "", // Empty userID for usernameless flow
+		RelyingPartyID: testRelyingPartyID,
+	}
+
+	authStartResponse, statusCode, err := sendPasskeyAuthStartRequest(authStartRequest)
+	suite.Require().NoError(err, "Failed to send usernameless passkey auth start request")
+	suite.Equal(http.StatusOK, statusCode, "Expected status 200 for usernameless authentication start")
+	suite.NotNil(authStartResponse, "Auth start response should not be nil")
+	suite.NotEmpty(authStartResponse.SessionToken, "Session token should not be empty")
+
+	// Verify the response structure for usernameless flow
+	suite.Empty(authStartResponse.PublicKeyCredentialRequestOptions.AllowCredentials,
+		"AllowCredentials should be empty for usernameless flow")
+	suite.NotEmpty(authStartResponse.PublicKeyCredentialRequestOptions.Challenge,
+		"Challenge should be present")
+	suite.Equal(testRelyingPartyID, authStartResponse.PublicKeyCredentialRequestOptions.RelyingPartyID,
+		"RelyingPartyID should match")
+
+	finishRequest := PasskeyAuthFinishRequest{
+		PublicKeyCredential: PublicKeyCredentialAssertion{
+			ID:   "mock-credential-id",
+			Type: "public-key",
+			Response: AuthenticatorAssertionResponse{
+				ClientDataJSON: base64.RawURLEncoding.EncodeToString([]byte(
+					`{"type":"webauthn.get","challenge":"` +
+						authStartResponse.PublicKeyCredentialRequestOptions.Challenge + `","origin":"http://localhost"}`)),
+				AuthenticatorData: base64.RawURLEncoding.EncodeToString([]byte(
+					"mock-auth-data-with-sufficient-length-for-parsing")),
+				Signature:  base64.RawURLEncoding.EncodeToString([]byte("mock-signature")),
+				UserHandle: base64.StdEncoding.EncodeToString([]byte(suite.userID)),
+			},
+		},
+		SessionToken: authStartResponse.SessionToken,
+	}
+
+	_, statusCode, _ = sendPasskeyAuthFinishRequest(finishRequest)
+	// Should fail validation but the code path including type assertion should be exercised
+	suite.True(statusCode == http.StatusBadRequest || statusCode == http.StatusUnauthorized,
+		"Expected validation error status for mock credential")
+}
+
+// TestPasskeyRegisterFinishSuccess completes a registration ceremony with a credential that carries
+// a real signature, and confirms the credential is persisted against the user.
+func (suite *PasskeyEnrollmentTestSuite) TestPasskeyRegisterFinishSuccess() {
+	// Register against a dedicated user so the credential does not affect other tests.
+	attributes, err := json.Marshal(map[string]interface{}{
+		"username":    "passkeytest_register_user",
+		"email":       "passkeytest_register@example.com",
+		"displayName": "Passkey Register User",
+		"password":    "PasskeyRegisterPassword123!",
+	})
+	suite.Require().NoError(err, "Failed to marshal user attributes")
+
+	userID, err := testutils.CreateUser(testutils.User{
+		Type:       passkeyEnrollmentEntityType.Name,
+		OUID:       suite.ouID,
+		Attributes: json.RawMessage(attributes),
+	})
+	suite.Require().NoError(err, "Failed to create user for registration test")
+	defer func() {
+		if err := testutils.DeleteUser(userID); err != nil {
+			suite.T().Logf("Failed to delete registration test user: %v", err)
+		}
+	}()
+
+	registerUserAssertion := suite.assertionForUser("passkeytest_register_user", "PasskeyRegisterPassword123!", userID)
+	authenticator, _ := suite.registerCredential(userID, registerUserAssertion)
+
+	// Stored credentials are not exposed by any API, so persistence is confirmed by starting an
+	// authentication ceremony and checking the credential is offered back.
+	startResponse, statusCode, err := sendPasskeyAuthStartRequest(PasskeyAuthStartRequest{
+		UserID:         userID,
+		RelyingPartyID: testRelyingPartyID,
+	})
+	suite.Require().NoError(err, "Failed to start authentication after registration")
+	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for authentication start")
+
+	credentialIDs := make([]string, 0, len(startResponse.PublicKeyCredentialRequestOptions.AllowCredentials))
+	for _, credential := range startResponse.PublicKeyCredentialRequestOptions.AllowCredentials {
+		credentialIDs = append(credentialIDs, credential.ID)
+	}
+	suite.Contains(credentialIDs, authenticator.CredentialID(),
+		"Registered credential should be offered back in allowCredentials")
+}
+
+// TestPasskeyRegisterFinishWrongOrigin rejects a credential collected from an origin the server
+// does not allow.
+func (suite *PasskeyEnrollmentTestSuite) TestPasskeyRegisterFinishWrongOrigin() {
+	statusCode := suite.attemptRegistrationWithAuthenticator(testRelyingPartyID,
+		"https://evil.example.com")
+	suite.Equal(http.StatusBadRequest, statusCode,
+		"Expected status 400 for a credential collected from a disallowed origin")
+}
+
+// TestPasskeyRegisterFinishWrongRPID rejects a credential whose authenticator data was bound to a
+// different relying party.
+func (suite *PasskeyEnrollmentTestSuite) TestPasskeyRegisterFinishWrongRPID() {
+	statusCode := suite.attemptRegistrationWithAuthenticator("example.com", testPasskeyOrigin)
+	suite.Equal(http.StatusBadRequest, statusCode,
+		"Expected status 400 for a credential bound to a different relying party")
+}
+
+// attemptRegistrationWithAuthenticator runs a registration ceremony where the authenticator is
+// built with the given relying party ID and origin, and returns the status of the finish call. The
+// start call is expected to succeed, since these mismatches are only detectable at finish.
+func (suite *PasskeyEnrollmentTestSuite) attemptRegistrationWithAuthenticator(rpID, origin string) int {
+	authenticator, err := testutils.NewVirtualAuthenticator(rpID, origin)
+	suite.Require().NoError(err, "Failed to create virtual authenticator")
+
+	startResponse, statusCode, err := sendPasskeyRegisterStartRequest(PasskeyRegisterStartRequest{
+		UserID:           suite.userID,
+		RelyingPartyID:   testRelyingPartyID,
+		RelyingPartyName: testRelyingPartyName,
+		Assertion:        suite.userAssertion,
+	})
+	suite.Require().NoError(err, "Failed to start passkey registration")
+	suite.Require().Equal(http.StatusOK, statusCode, "Expected status 200 for registration start")
+
+	credentialID, clientDataJSON, attestationObject, err := authenticator.CreateAttestationResponse(
+		startResponse.PublicKeyCredentialCreationOptions.Challenge, true)
+	suite.Require().NoError(err, "Failed to build attestation response")
+
+	_, statusCode, err = sendPasskeyRegisterFinishRequest(PasskeyRegisterFinishRequest{
+		PublicKeyCredential: PublicKeyCredentialAttestation{
+			ID:    credentialID,
+			Type:  "public-key",
+			RawID: credentialID,
+			Response: AuthenticatorAttestationResponse{
+				ClientDataJSON:    clientDataJSON,
+				AttestationObject: attestationObject,
+			},
+		},
+		SessionToken: startResponse.SessionToken,
+	})
+	suite.Require().NoError(err, "Failed to finish passkey registration")
+
+	return statusCode
+}
+
+// TestStartRejectsRequestWithoutAssertion asserts a registration start that proves nothing about
+// the caller is rejected, rather than handing out a challenge bound to the named user. An absent
+// assertion is the zero value of a required field, so request validation catches it before the
+// service runs, which is why the response carries the structural code rather than a service one.
+func (suite *PasskeyEnrollmentTestSuite) TestStartRejectsRequestWithoutAssertion() {
+	status, body := suite.postRegisterStart(map[string]interface{}{
+		"userId":         suite.userID,
+		"relyingPartyId": testRelyingPartyID,
+	})
+
+	suite.Equal(http.StatusBadRequest, status,
+		"registration start must not issue a challenge for a user the caller has not proven; body: %s", body)
+	suite.Equal("INVALID_INPUT_METADATA", suite.errorCode(body), "body: %s", body)
+}
+
+// TestStartRejectsEmptyAssertion asserts an explicitly empty assertion is rejected the same way an
+// absent one is, since both are the field's zero value.
+func (suite *PasskeyEnrollmentTestSuite) TestStartRejectsEmptyAssertion() {
+	status, body := suite.postRegisterStart(map[string]interface{}{
+		"userId":         suite.userID,
+		"relyingPartyId": testRelyingPartyID,
+		"assertion":      "",
+	})
+
+	suite.Equal(http.StatusBadRequest, status, "body: %s", body)
+	suite.Equal("INVALID_INPUT_METADATA", suite.errorCode(body), "body: %s", body)
+}
+
+// TestStartRejectsBlankAssertion asserts a whitespace only assertion is rejected too. Required
+// field validation treats a blank string as absent, so this lands with the other zero values
+// rather than reaching the service.
+func (suite *PasskeyEnrollmentTestSuite) TestStartRejectsBlankAssertion() {
+	status, body := suite.postRegisterStart(map[string]interface{}{
+		"userId":         suite.userID,
+		"relyingPartyId": testRelyingPartyID,
+		"assertion":      "   ",
+	})
+
+	suite.Equal(http.StatusBadRequest, status, "body: %s", body)
+	suite.Equal("INVALID_INPUT_METADATA", suite.errorCode(body), "body: %s", body)
+}
+
+// TestStartRejectsAssertionForDifferentUser asserts an assertion proving one identity cannot be
+// used to enroll a passkey onto a different account.
+func (suite *PasskeyEnrollmentTestSuite) TestStartRejectsAssertionForDifferentUser() {
+	attackerAssertion := suite.assertionForUser(enrollmentAttackerUsername, enrollmentAttackerPassword, suite.attackerID)
+
+	status, body := suite.postRegisterStart(map[string]interface{}{
+		"userId":         suite.userID,
+		"relyingPartyId": testRelyingPartyID,
+		"assertion":      attackerAssertion,
+	})
+
+	suite.Equal(http.StatusBadRequest, status,
+		"registration start must reject an assertion whose subject is not the target user; body: %s", body)
+	suite.Equal("AUTHN-1010", suite.errorCode(body), "body: %s", body)
+}
+
+// TestStartRejectsMissingRelyingPartyID asserts the relying party ID is enforced as a required
+// field, rather than reaching the passkey service and surfacing as a generic enrollment failure.
+func (suite *PasskeyEnrollmentTestSuite) TestStartRejectsMissingRelyingPartyID() {
+	victimAssertion := suite.assertionForUser(enrollmentUsername, enrollmentPassword, suite.userID)
+
+	status, body := suite.postRegisterStart(map[string]interface{}{
+		"userId":    suite.userID,
+		"assertion": victimAssertion,
+	})
+
+	suite.Equal(http.StatusBadRequest, status, "body: %s", body)
+	suite.Equal("INVALID_INPUT_METADATA", suite.errorCode(body), "body: %s", body)
+}
+
+// TestStartRejectsUnverifiableAssertion asserts a forged assertion is rejected on verification.
+func (suite *PasskeyEnrollmentTestSuite) TestStartRejectsUnverifiableAssertion() {
+	status, body := suite.postRegisterStart(map[string]interface{}{
+		"userId":         suite.userID,
+		"relyingPartyId": testRelyingPartyID,
+		"assertion":      "not.a.valid-jwt",
+	})
+
+	suite.Equal(http.StatusBadRequest, status, "body: %s", body)
+	suite.Equal("AUTHN-1009", suite.errorCode(body), "body: %s", body)
+}
+
+// TestAttackerCannotTakeOverVictimAccount verifies that an assertion for another user is rejected
+// at enrollment start with the expected error and without issuing a session token.
+func (suite *PasskeyEnrollmentTestSuite) TestAttackerCannotTakeOverVictimAccount() {
+	attackerAssertion := suite.assertionForUser(enrollmentAttackerUsername, enrollmentAttackerPassword, suite.attackerID)
+
+	// The ceremony must fail at the first step, and for the right reason: the attacker's assertion
+	// does not name the victim. Asserting the code rather than merely "an error" keeps the test from
+	// passing on an unrelated failure such as a wrong origin or an expired session.
+	status, body := suite.postRegisterStart(map[string]interface{}{
+		"userId":         suite.userID,
+		"relyingPartyId": testRelyingPartyID,
+		"assertion":      attackerAssertion,
+	})
+	suite.Require().Equal(http.StatusBadRequest, status,
+		"ACCOUNT TAKEOVER: registration start issued a challenge for the victim to a caller holding "+
+			"only the Direct Auth Secret, its own account, and the victim's user ID; body: %s", body)
+	suite.Require().Equal("AUTHN-1010", suite.errorCode(body), "body: %s", body)
+
+	// No session token was issued, so the attacker cannot reach finish and no credential can come
+	// into existence from this attempt.
+	suite.NotContains(body, "sessionToken", "a rejected start must not return a session token")
+}
+
+// TestUserCanEnrollWithOwnAssertion is the positive case: a user that proves its own identity
+// enrolls a passkey and can then authenticate with it.
+func (suite *PasskeyEnrollmentTestSuite) TestUserCanEnrollWithOwnAssertion() {
+	victimAssertion := suite.assertionForUser(enrollmentUsername, enrollmentPassword, suite.userID)
+
+	authenticator, userHandle, err := testutils.RegisterPasskeyCredential(
+		suite.userID, testRelyingPartyID, testRelyingPartyName, testPasskeyOrigin, victimAssertion)
+	suite.Require().NoError(err, "a user proving its own identity should be able to enroll a passkey")
+
+	authResponse, err := testutils.AuthenticateWithPasskey(
+		suite.userID, testRelyingPartyID, userHandle, authenticator)
+	suite.Require().NoError(err, "the enrolled passkey should be usable for authentication")
+	suite.Equal(suite.userID, authResponse.ID, "authentication should return the enrolling user")
+	suite.NotEmpty(authResponse.Assertion, "authentication should return an assertion")
+}
+
+// TestStartAcceptsOwnAssertion asserts the happy path at the start endpoint on its own, so a
+// failure here is distinguishable from a failure later in the ceremony.
+func (suite *PasskeyEnrollmentTestSuite) TestStartAcceptsOwnAssertion() {
+	victimAssertion := suite.assertionForUser(enrollmentUsername, enrollmentPassword, suite.userID)
+
+	status, body := suite.postRegisterStart(map[string]interface{}{
+		"userId":         suite.userID,
+		"relyingPartyId": testRelyingPartyID,
+		"assertion":      victimAssertion,
+	})
+
+	suite.Equal(http.StatusOK, status,
+		"registration start should accept an assertion proving the target user; body: %s", body)
+}
+
+// errorCode pulls the top level error code out of a response body, so the tests pin the exact code
+// a rejection carries rather than only its status.
+func (suite *PasskeyEnrollmentTestSuite) errorCode(body string) string {
+	var parsed struct {
+		Code string `json:"code"`
+	}
+	suite.Require().NoError(json.Unmarshal([]byte(body), &parsed), "failed to decode error body: %s", body)
+	return parsed.Code
+}
+
+// postRegisterStart posts a raw registration start payload and returns the status and body. The
+// test client injects the Direct Auth Secret, so this models a caller that holds the secret.
+func (suite *PasskeyEnrollmentTestSuite) postRegisterStart(payload map[string]interface{}) (int, string) {
+	body, err := json.Marshal(payload)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost,
+		testutils.TestServerURL+passkeyRegisterStartEndpoint, bytes.NewReader(body))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+
+	return resp.StatusCode, string(responseBody)
+}

--- a/tests/integration/resources/scripts/setup-test-config.sh
+++ b/tests/integration/resources/scripts/setup-test-config.sh
@@ -128,6 +128,11 @@ flow:
 server_config:
   store: composite
 
+passkey:
+  allowed_origins:
+    - "https://localhost:8095"
+    - "http://localhost:8095"
+
 oauth:
   allow_wildcard_redirect_uri: true
   send_server_errors_to_client: true

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -2005,6 +2005,52 @@ func AuthenticateWithCredential(identifierKey, identifierValue, credentialKey, c
 	return false, fmt.Errorf("unexpected auth status %d: %s", resp.StatusCode, string(body))
 }
 
+// ObtainAuthAssertion authenticates a user with a password and returns the auth assertion from the
+// response. Enrolling a credential requires an assertion proving the target user, so suites that
+// bootstrap a passkey through the direct API need the user to hold another credential first.
+func ObtainAuthAssertion(username, password string) (string, error) {
+	reqBody := map[string]interface{}{
+		"identifiers": map[string]interface{}{"username": username},
+		"credentials": map[string]interface{}{"password": password},
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal auth request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, TestServerURL+"/auth/credentials/authenticate",
+		bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to create auth request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := GetHTTPClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("auth request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read auth response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected auth status %d: %s", resp.StatusCode, responseBody)
+	}
+
+	var authResponse AuthenticationResponse
+	if err := json.Unmarshal(responseBody, &authResponse); err != nil {
+		return "", fmt.Errorf("failed to decode auth response: %w", err)
+	}
+	if authResponse.Assertion == "" {
+		return "", fmt.Errorf("authentication for %s returned no assertion", username)
+	}
+
+	return authResponse.Assertion, nil
+}
+
 // CreateAgent creates an agent via API and returns its ID.
 func CreateAgent(a Agent) (string, error) {
 	payload, err := json.Marshal(a)

--- a/tests/integration/testutils/passkey_utils.go
+++ b/tests/integration/testutils/passkey_utils.go
@@ -1,0 +1,223 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// passkeyRegisterStartRequest mirrors PasskeyRegisterStartRequestDTO in the backend.
+type passkeyRegisterStartRequest struct {
+	UserID                 string                         `json:"userId"`
+	RelyingPartyID         string                         `json:"relyingPartyId"`
+	RelyingPartyName       string                         `json:"relyingPartyName,omitempty"`
+	AuthenticatorSelection *passkeyAuthenticatorSelection `json:"authenticatorSelection,omitempty"`
+	Assertion              string                         `json:"assertion,omitempty"`
+}
+
+type passkeyAuthenticatorSelection struct {
+	ResidentKey      string `json:"residentKey,omitempty"`
+	UserVerification string `json:"userVerification,omitempty"`
+}
+
+// passkeyRegisterStartResponse captures only the fields callers need from the start response.
+type passkeyRegisterStartResponse struct {
+	SessionToken                       string `json:"sessionToken"`
+	PublicKeyCredentialCreationOptions struct {
+		Challenge string `json:"challenge"`
+		User      struct {
+			ID string `json:"id"`
+		} `json:"user"`
+	} `json:"publicKeyCredentialCreationOptions"`
+}
+
+// passkeyRegisterFinishRequest mirrors PasskeyRegisterFinishRequestDTO in the backend, where the
+// credential is nested under publicKeyCredential.
+type passkeyRegisterFinishRequest struct {
+	PublicKeyCredential passkeyAttestationCredential `json:"publicKeyCredential"`
+	SessionToken        string                       `json:"sessionToken"`
+}
+
+type passkeyAttestationCredential struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	RawID    string `json:"rawId"`
+	Response struct {
+		ClientDataJSON    string `json:"clientDataJSON"`
+		AttestationObject string `json:"attestationObject"`
+	} `json:"response"`
+}
+
+// RegisterPasskeyCredential registers a passkey for the given user through the direct passkey API
+// and returns the virtual authenticator holding it, along with the WebAuthn user handle the server
+// issued for that user. Flow based suites use this to obtain a credential without having to drive a
+// registration flow.
+//
+// The assertion must prove userID, since the direct API enrolls a credential only for the subject
+// it names; ObtainAuthAssertion produces one from a password login.
+//
+// The origin must be accepted by the server level passkey.allowed_origins, since the direct API
+// does not take allowed origins from the request or the application.
+func RegisterPasskeyCredential(userID, relyingPartyID, relyingPartyName, origin, assertion string) (
+	*VirtualAuthenticator, string, error) {
+	authenticator, err := NewVirtualAuthenticator(relyingPartyID, origin)
+	if err != nil {
+		return nil, "", err
+	}
+
+	startBody, err := passkeyPost("/register/passkey/start", passkeyRegisterStartRequest{
+		UserID:           userID,
+		RelyingPartyID:   relyingPartyID,
+		RelyingPartyName: relyingPartyName,
+		AuthenticatorSelection: &passkeyAuthenticatorSelection{
+			ResidentKey:      "required",
+			UserVerification: "required",
+		},
+		Assertion: assertion,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("passkey registration start failed: %w", err)
+	}
+
+	var startResponse passkeyRegisterStartResponse
+	if err := json.Unmarshal(startBody, &startResponse); err != nil {
+		return nil, "", fmt.Errorf("failed to decode passkey registration start response: %w", err)
+	}
+
+	credentialID, clientDataJSON, attestationObject, err := authenticator.CreateAttestationResponse(
+		startResponse.PublicKeyCredentialCreationOptions.Challenge, true)
+	if err != nil {
+		return nil, "", err
+	}
+
+	credential := passkeyAttestationCredential{ID: credentialID, Type: "public-key", RawID: credentialID}
+	credential.Response.ClientDataJSON = clientDataJSON
+	credential.Response.AttestationObject = attestationObject
+
+	if _, err := passkeyPost("/register/passkey/finish", passkeyRegisterFinishRequest{
+		PublicKeyCredential: credential,
+		SessionToken:        startResponse.SessionToken,
+	}); err != nil {
+		return nil, "", fmt.Errorf("passkey registration finish failed: %w", err)
+	}
+
+	return authenticator, startResponse.PublicKeyCredentialCreationOptions.User.ID, nil
+}
+
+// passkeyAuthStartRequest mirrors PasskeyStartRequestDTO in the backend.
+type passkeyAuthStartRequest struct {
+	UserID         string `json:"userId"`
+	RelyingPartyID string `json:"relyingPartyId"`
+}
+
+type passkeyAuthStartResponse struct {
+	SessionToken                      string `json:"sessionToken"`
+	PublicKeyCredentialRequestOptions struct {
+		Challenge string `json:"challenge"`
+	} `json:"publicKeyCredentialRequestOptions"`
+}
+
+// passkeyAuthFinishRequest mirrors PasskeyFinishRequestDTO in the backend, where the credential is
+// nested under publicKeyCredential just as it is for registration.
+type passkeyAuthFinishRequest struct {
+	PublicKeyCredential passkeyAssertionCredential `json:"publicKeyCredential"`
+	SessionToken        string                     `json:"sessionToken"`
+}
+
+type passkeyAssertionCredential struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	RawID    string `json:"rawId"`
+	Response struct {
+		ClientDataJSON    string `json:"clientDataJSON"`
+		AuthenticatorData string `json:"authenticatorData"`
+		Signature         string `json:"signature"`
+		UserHandle        string `json:"userHandle,omitempty"`
+	} `json:"response"`
+}
+
+// AuthenticateWithPasskey runs a full authentication ceremony for the given user with the supplied
+// authenticator, and returns the authentication response. Registration suites use it to prove a
+// credential they just enrolled is actually usable, which is the only externally visible evidence
+// that the credential was stored correctly.
+func AuthenticateWithPasskey(
+	userID, relyingPartyID, userHandle string, authenticator *VirtualAuthenticator,
+) (*AuthenticationResponse, error) {
+	startBody, err := passkeyPost("/auth/passkey/start", passkeyAuthStartRequest{
+		UserID:         userID,
+		RelyingPartyID: relyingPartyID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("passkey authentication start failed: %w", err)
+	}
+
+	var startResponse passkeyAuthStartResponse
+	if err := json.Unmarshal(startBody, &startResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode passkey authentication start response: %w", err)
+	}
+
+	credentialID, clientDataJSON, authenticatorData, signature, err :=
+		authenticator.CreateAssertionResponse(
+			startResponse.PublicKeyCredentialRequestOptions.Challenge, true)
+	if err != nil {
+		return nil, err
+	}
+
+	credential := passkeyAssertionCredential{ID: credentialID, Type: "public-key", RawID: credentialID}
+	credential.Response.ClientDataJSON = clientDataJSON
+	credential.Response.AuthenticatorData = authenticatorData
+	credential.Response.Signature = signature
+	credential.Response.UserHandle = userHandle
+
+	finishBody, err := passkeyPost("/auth/passkey/finish", passkeyAuthFinishRequest{
+		PublicKeyCredential: credential,
+		SessionToken:        startResponse.SessionToken,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("passkey authentication finish failed: %w", err)
+	}
+
+	var response AuthenticationResponse
+	if err := json.Unmarshal(finishBody, &response); err != nil {
+		return nil, fmt.Errorf("failed to decode passkey authentication response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// passkeyPost posts a JSON body to a passkey endpoint and returns the response body, treating any
+// non-200 status as an error.
+func passkeyPost(path string, payload interface{}) ([]byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, TestServerURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := GetHTTPClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from %s: %s", resp.StatusCode, path, responseBody)
+	}
+
+	return responseBody, nil
+}

--- a/tests/integration/testutils/webauthn_authenticator.go
+++ b/tests/integration/testutils/webauthn_authenticator.go
@@ -1,0 +1,225 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+)
+
+// VirtualAuthenticator is a software WebAuthn authenticator for integration tests. It holds an
+// ES256 key pair and produces the byte structures a browser would return from a real authenticator,
+// so tests can complete passkey registration and authentication ceremonies end to end.
+//
+// One instance owns exactly one credential ID. A test that needs a second distinct credential must
+// construct a second instance.
+type VirtualAuthenticator struct {
+	key       *ecdsa.PrivateKey
+	aaguid    [16]byte
+	credID    []byte
+	signCount uint32
+	rpID      string
+	origin    string
+}
+
+// WebAuthn authenticator data flags.
+const (
+	flagUserPresent            = 0x01
+	flagUserVerified           = 0x04
+	flagBackupEligible         = 0x08
+	flagBackupState            = 0x10
+	flagAttestedCredentialData = 0x40
+)
+
+// NewVirtualAuthenticator creates an authenticator bound to a relying party ID and origin. The
+// origin must be one the server accepts: for the direct passkey APIs that is an entry under
+// passkey.allowed_origins in deployment.yaml, and for flow-based passkey it is an entry in the
+// application's passkeyAllowedOrigins.
+func NewVirtualAuthenticator(rpID, origin string) (*VirtualAuthenticator, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate authenticator key: %w", err)
+	}
+
+	credID := make([]byte, 32)
+	if _, err := rand.Read(credID); err != nil {
+		return nil, fmt.Errorf("failed to generate credential ID: %w", err)
+	}
+
+	return &VirtualAuthenticator{
+		key:    key,
+		credID: credID,
+		rpID:   rpID,
+		origin: origin,
+	}, nil
+}
+
+// CredentialID returns the base64url encoded credential ID held by this authenticator.
+func (a *VirtualAuthenticator) CredentialID() string {
+	return base64.RawURLEncoding.EncodeToString(a.credID)
+}
+
+// SetSignCount overrides the signature counter, so tests can simulate a counter regression.
+func (a *VirtualAuthenticator) SetSignCount(count uint32) {
+	a.signCount = count
+}
+
+// CreateAttestationResponse produces the credential a browser returns from navigator.credentials
+// .create(), for the registration ceremony. The challenge must be the value from the corresponding
+// start response, passed through unchanged. All returned values are base64url encoded.
+func (a *VirtualAuthenticator) CreateAttestationResponse(challenge string, userVerified bool) (
+	credentialID, clientDataJSON, attestationObject string, err error) {
+	clientData := a.buildClientData("webauthn.create", challenge)
+
+	flags := byte(flagUserPresent | flagBackupEligible | flagBackupState | flagAttestedCredentialData)
+	if userVerified {
+		flags |= flagUserVerified
+	}
+	authData := a.buildAuthenticatorData(flags, true)
+
+	attestation := cborMap3(
+		cborTextString("fmt"), cborTextString("none"),
+		cborTextString("attStmt"), []byte{0xA0},
+		cborTextString("authData"), cborByteString(authData),
+	)
+
+	return a.CredentialID(),
+		base64.RawURLEncoding.EncodeToString(clientData),
+		base64.RawURLEncoding.EncodeToString(attestation),
+		nil
+}
+
+// CreateAssertionResponse produces the credential a browser returns from navigator.credentials.get(),
+// for the authentication ceremony. The challenge must be the value from the corresponding start
+// response, passed through unchanged. All returned values are base64url encoded.
+func (a *VirtualAuthenticator) CreateAssertionResponse(challenge string, userVerified bool) (
+	credentialID, clientDataJSON, authenticatorData, signature string, err error) {
+	clientData := a.buildClientData("webauthn.get", challenge)
+
+	flags := byte(flagUserPresent | flagBackupEligible | flagBackupState)
+	if userVerified {
+		flags |= flagUserVerified
+	}
+	a.signCount++
+	authData := a.buildAuthenticatorData(flags, false)
+
+	// The assertion is signed over the authenticator data concatenated with the hash of the client
+	// data, per the WebAuthn assertion signature format.
+	clientDataHash := sha256.Sum256(clientData)
+	signed := append(append([]byte{}, authData...), clientDataHash[:]...)
+	digest := sha256.Sum256(signed)
+
+	sig, err := ecdsa.SignASN1(rand.Reader, a.key, digest[:])
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("failed to sign assertion: %w", err)
+	}
+
+	return a.CredentialID(),
+		base64.RawURLEncoding.EncodeToString(clientData),
+		base64.RawURLEncoding.EncodeToString(authData),
+		base64.RawURLEncoding.EncodeToString(sig),
+		nil
+}
+
+// buildClientData assembles the collected client data a browser sends. The challenge is echoed
+// exactly as received, since the server compares it against the base64url value it issued.
+func (a *VirtualAuthenticator) buildClientData(ceremonyType, challenge string) []byte {
+	clientData := map[string]interface{}{
+		"type":        ceremonyType,
+		"challenge":   challenge,
+		"origin":      a.origin,
+		"crossOrigin": false,
+	}
+	encoded, err := json.Marshal(clientData)
+	if err != nil {
+		// The map contains only strings and a bool, so marshalling cannot fail.
+		panic(fmt.Sprintf("failed to marshal client data: %v", err))
+	}
+	return encoded
+}
+
+// buildAuthenticatorData assembles the authenticator data structure. When includeCredential is set
+// the attested credential data (AAGUID, credential ID and COSE public key) is appended, which is
+// required for registration and absent for authentication.
+func (a *VirtualAuthenticator) buildAuthenticatorData(flags byte, includeCredential bool) []byte {
+	rpIDHash := sha256.Sum256([]byte(a.rpID))
+
+	authData := make([]byte, 0, 37)
+	authData = append(authData, rpIDHash[:]...)
+	authData = append(authData, flags)
+	authData = binary.BigEndian.AppendUint32(authData, a.signCount)
+
+	if !includeCredential {
+		return authData
+	}
+
+	authData = append(authData, a.aaguid[:]...)
+	authData = binary.BigEndian.AppendUint16(authData, uint16(len(a.credID)))
+	authData = append(authData, a.credID...)
+	authData = append(authData, a.coseKey()...)
+
+	return authData
+}
+
+// coseKey encodes the public key as a COSE_Key structure for an ES256 key on the P-256 curve. The
+// map is written directly rather than through a CBOR library, since its shape is fixed: the test
+// module depends only on testify, and this keeps the encoded bytes inspectable when a verification
+// failure needs debugging.
+func (a *VirtualAuthenticator) coseKey() []byte {
+	x := make([]byte, 32)
+	y := make([]byte, 32)
+	a.key.PublicKey.X.FillBytes(x)
+	a.key.PublicKey.Y.FillBytes(y)
+
+	key := []byte{
+		0xA5,       // map with 5 pairs
+		0x01, 0x02, // kty: EC2
+		0x03, 0x26, // alg: -7 (ES256)
+		0x20, 0x01, // crv: 1 (P-256)
+		0x21, 0x58, 0x20, // x: byte string of 32
+	}
+	key = append(key, x...)
+	key = append(key, 0x22, 0x58, 0x20) // y: byte string of 32
+	key = append(key, y...)
+
+	return key
+}
+
+// cborTextString encodes a short text string. Only lengths below 24 occur here, so the length is
+// packed into the initial byte.
+func cborTextString(s string) []byte {
+	if len(s) >= 24 {
+		panic(fmt.Sprintf("cborTextString only supports strings shorter than 24 bytes, got %d", len(s)))
+	}
+	return append([]byte{0x60 | byte(len(s))}, []byte(s)...)
+}
+
+// cborByteString encodes a byte string with the smallest length header that fits.
+func cborByteString(b []byte) []byte {
+	var header []byte
+	switch {
+	case len(b) < 24:
+		header = []byte{0x40 | byte(len(b))}
+	case len(b) < 256:
+		header = []byte{0x58, byte(len(b))}
+	default:
+		header = binary.BigEndian.AppendUint16([]byte{0x59}, uint16(len(b)))
+	}
+	return append(header, b...)
+}
+
+// cborMap3 assembles a CBOR map of exactly three already encoded key and value pairs.
+func cborMap3(k1, v1, k2, v2, k3, v3 []byte) []byte {
+	out := []byte{0xA3}
+	for _, part := range [][]byte{k1, v1, k2, v2, k3, v3} {
+		out = append(out, part...)
+	}
+	return out
+}


### PR DESCRIPTION
### Purpose
  Fix a privilege escalation vulnerability in Direct API passkey registration. Previously, a caller holding the Direct-Auth-Secret could enroll a passkey for an
  arbitrary user and authenticate as that user.

  ### ⚠️ Breaking Changes
  #### 🔧 Summary of Breaking Changes
  POST /register/passkey/start now requires both userId and an authentication assertion. The assertion’s subject must match userId.

  #### 💥 Impact
  Direct API integrations that register passkeys without an assertion will receive HTTP 400. Users need an existing authentication method before enrolling their
  first passkey through the Direct API.

  Orchestrated registration flows are unaffected.

  #### 🔄 Migration Guide
  Authenticate the user first, then include the returned assertion in the registration-start request:

```text
  {
    "userId": "<authenticated-user-id>",
    "assertion": "<assertion-from-prior-authentication>",
    "relyingPartyId": "localhost",
    "relyingPartyName": "Example"
  }
```
  Use an orchestrated registration flow when a passkey must be the account’s first credential.

  ### Approach
  - Require userId and assertion through request validation.
  - Verify the assertion’s signature, expiration, issuer, and assurance claim, then confirm its subject matches userId before initiating enrollment.
  - Enforce ownership at the Direct API service layer to preserve orchestrated registration flows.
  - Add unit and integration tests for missing, invalid, and mismatched assertions, attempted account takeover, and successful enrollment with the user’s own
    assertion.
  - Update API documentation and integration test setup for the authentication requirement.

  ### Related Issues
  - N/A
  ### Related PRs
  - Backport of #5338 to `1.0.x`.

  ### Checklist
  - [ ] Followed the contribution guidelines.
  - [x] Manual test round performed and verified.
  - [x] Documentation provided.
      - [ ] Ran Vale and fixed all errors and warnings
  - [x] Tests provided.
      - [x] Unit Tests
      - [x] Integration Tests
  - [x] Breaking changes.
      - [x] Breaking changes section filled.
      - [ ] breaking change label added.

  ### Security checks
  - [ ] Followed secure coding standards in WSO2 Secure Coding Guidelines
  - [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
